### PR TITLE
Update reportdb on the fly

### DIFF
--- a/module/Database/Module.php
+++ b/module/Database/Module.php
@@ -1,6 +1,7 @@
 <?php
 namespace Database;
 
+use Report\Listener\DatabaseDeletionListener;
 use Report\Listener\DatabaseUpdateListener;
 
 class Module
@@ -19,6 +20,7 @@ class Module
         $dem = $em->getEventManager();
         $dem->addEventListener([\Doctrine\ORM\Events::postPersist], new DatabaseUpdateListener($sm));
         $dem->addEventListener([\Doctrine\ORM\Events::postUpdate], new DatabaseUpdateListener($sm));
+        $dem->addEventListener([\Doctrine\ORM\Events::preRemove], new DatabaseDeletionListener($sm));
     }
 
     /**

--- a/module/Database/Module.php
+++ b/module/Database/Module.php
@@ -1,6 +1,7 @@
 <?php
 namespace Database;
 
+use Report\Listener\DatabaseUpdateListener;
 
 class Module
 {
@@ -14,6 +15,10 @@ class Module
 
         // register event logging
         $sm->get('database_service_event')->register();
+        $em = $sm->get('database_doctrine_em');
+        $dem = $em->getEventManager();
+        $dem->addEventListener([\Doctrine\ORM\Events::postPersist], new DatabaseUpdateListener($sm));
+        $dem->addEventListener([\Doctrine\ORM\Events::postUpdate], new DatabaseUpdateListener($sm));
     }
 
     /**

--- a/module/Database/src/Database/Model/SubDecision.php
+++ b/module/Database/src/Database/Model/SubDecision.php
@@ -152,7 +152,7 @@ abstract class SubDecision
      */
     public function getDecisionNumber()
     {
-        return $this->number;
+        return $this->decision_number;
     }
 
     /**

--- a/module/Report/config/module.config.php
+++ b/module/Report/config/module.config.php
@@ -64,6 +64,15 @@ return array(
                             'action' => 'generate'
                         )
                     )
+                ),
+                'generate_reportdb_full' => array(
+                    'options' => array(
+                        'route' => 'generate reportdb full',
+                        'defaults' => array(
+                            'controller' => 'Report\Controller\Report',
+                            'action' => 'generateAll'
+                        )
+                    )
                 )
             )
         )

--- a/module/Report/src/Report/Controller/ReportController.php
+++ b/module/Report/src/Report/Controller/ReportController.php
@@ -14,6 +14,15 @@ class ReportController extends AbstractActionController
     {
         $console = $this->getConsole();
 
+        echo "generating board tables\n";
+        $this->getBoardService()->generate();
+
+        echo "generating misc tables\n";
+        $this->getMiscService()->generate();
+    }
+
+    public function generateAllAction()
+    {
         echo "generating members table\n";
         $this->getMemberService()->generate();
 
@@ -22,12 +31,6 @@ class ReportController extends AbstractActionController
 
         echo "generating organ tables\n";
         $this->getOrganService()->generate();
-
-        echo "generating board tables\n";
-        $this->getBoardService()->generate();
-
-        echo "generating misc tables\n";
-        $this->getMiscService()->generate();
     }
 
     /**

--- a/module/Report/src/Report/Listener/DatabaseDeletionListener.php
+++ b/module/Report/src/Report/Listener/DatabaseDeletionListener.php
@@ -1,0 +1,85 @@
+<?php
+namespace Report\Listener;
+
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * Doctrine event listener intended to automatically update reportdb.
+ */
+class DatabaseDeletionListener
+{
+    protected $sm;
+    public function __construct(ServiceManager $sm)
+    {
+        $this->sm = $sm;
+    }
+
+    public function preRemove($eventArgs)
+    {
+        $em = $this->sm->get('doctrine.entitymanager.orm_report');
+        $entity = $eventArgs->getEntity();
+        switch (true) {
+            case $entity instanceof \Database\Model\Address:
+                $this->getMemberService()->deleteAddress($entity);
+                break;
+            case $entity instanceof \Database\Model\Member:
+                try {
+                    $this->getMemberService()->deleteMember($entity);
+                } catch (ForeignKeyConstraintViolationException $e) {
+                    // Member has relations, so we'll just leave it in reportdb
+                }
+                $this->getMemberService()->deleteMember($entity);
+                break;
+
+            case $entity instanceof \Database\Model\Meeting:
+                throw new \Exception('reportdb deletion of meetings not implemented');
+                break;
+
+            case $entity instanceof \Database\Model\Decision:
+                $this->getMeetingService()->deleteDecision($entity);
+                break;
+        }
+        $em->flush();
+    }
+
+    /**
+     * Get the member service.
+     *
+     * @return \Report\Service\Member
+     */
+    public function getMemberService()
+    {
+        return $this->sm->get('report_service_member');
+    }
+
+    /**
+     * Get the meeting service.
+     *
+     * @return \Report\Service\Meeting
+     */
+    public function getMeetingService()
+    {
+        return $this->sm->get('report_service_meeting');
+    }
+
+    /**
+     * Get the organ service.
+     *
+     * @return \Report\Service\Organ
+     */
+    public function getOrganService()
+    {
+        return $this->sm->get('report_service_organ');
+    }
+
+    /**
+     * Get the board service.
+     *
+     * @return \Report\Service\Board
+     */
+    public function getBoardService()
+    {
+        return $this->sm->get('report_service_board');
+    }
+}

--- a/module/Report/src/Report/Listener/DatabaseUpdateListener.php
+++ b/module/Report/src/Report/Listener/DatabaseUpdateListener.php
@@ -21,6 +21,7 @@ class DatabaseUpdateListener
 
     public function postUpdate($eventArgs)
     {
+        $em = $this->sm->get('doctrine.entitymanager.orm_report');
         $entity = $eventArgs->getEntity();
         switch (true) {
             case $entity instanceof \Database\Model\Address:
@@ -42,10 +43,10 @@ class DatabaseUpdateListener
             case $entity instanceof \Database\Model\SubDecision:
                 $subdecision = $this->getMeetingService()->generateSubDecision($entity);
                 $this->processOrganUpdates($subdecision);
+                $em->persist($subdecision);
                 break;
 
         }
-        $em = $this->sm->get('doctrine.entitymanager.orm_report');
         $em->flush();
     }
 
@@ -53,7 +54,6 @@ class DatabaseUpdateListener
     {
         switch (true) {
             case $entity instanceof \Report\Model\SubDecision\Foundation:
-                echo "foundation";
                 $this->getOrganService()->generateFoundation($entity);
                 break;
 
@@ -69,9 +69,6 @@ class DatabaseUpdateListener
                 $this->getOrganService()->generateDischarge($entity);
                 break;
         }
-
-        $em = $this->sm->get('doctrine.entitymanager.orm_report');
-        $em->persist($entity);
     }
 
     /**

--- a/module/Report/src/Report/Listener/DatabaseUpdateListener.php
+++ b/module/Report/src/Report/Listener/DatabaseUpdateListener.php
@@ -1,0 +1,113 @@
+<?php
+namespace Report\Listener;
+
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * Doctrine event listener intended to automatically update reportdb.
+ */
+class DatabaseUpdateListener
+{
+    protected $sm;
+    public function __construct(ServiceManager $sm)
+    {
+        $this->sm = $sm;
+    }
+
+    public function postPersist($eventArgs)
+    {
+        $this->postUpdate($eventArgs);
+    }
+
+    public function postUpdate($eventArgs)
+    {
+        echo '<br>' .get_class($eventArgs) .' call '.get_class($eventArgs->getEntity()) . '<br>';
+        $entity = $eventArgs->getEntity();
+        switch (true) {
+            case $entity instanceof \Database\Model\Address:
+                $this->getMemberService()->generateAddress($entity);
+                break;
+
+            case $entity instanceof \Database\Model\Member:
+                $this->getMemberService()->generateMember($entity);
+                break;
+
+            case $entity instanceof \Database\Model\Meeting:
+                $this->getMeetingService()->generateMeeting($entity);
+                break;
+
+            case $entity instanceof \Database\Model\Decision:
+                $this->getMeetingService()->generateDecision($entity);
+                break;
+
+            case $entity instanceof \Database\Model\SubDecision:
+                $this->getMeetingService()->generateSubDecision($entity);
+                $this->processOrganUpdates($entity);
+                break;
+
+        }
+        $em = $this->sm->get('doctrine.entitymanager.orm_report');
+        $em->flush();
+    }
+
+    public function processOrganUpdates($entity)
+    {
+        switch (true) {
+            case $entity instanceof \Database\Model\SubDecision\Foundation:
+                $this->getOrganService()->generateFoundation($entity);
+                break;
+
+            case $entity instanceof \Database\Model\SubDecision\Abrogation:
+                $this->getOrganService()->generateAbrogation($entity);
+                break;
+
+            case $entity instanceof \Database\Model\SubDecision\Installation:
+                $this->getOrganService()->generateInstallation($entity);
+                break;
+
+            case $entity instanceof \Database\Model\SubDecision\Discharge:
+                $this->getOrganService()->generateDischarge($entity);
+                break;
+        }
+    }
+
+    /**
+     * Get the member service.
+     *
+     * @return \Report\Service\Member
+     */
+    public function getMemberService()
+    {
+        return $this->sm->get('report_service_member');
+    }
+
+    /**
+     * Get the meeting service.
+     *
+     * @return \Report\Service\Meeting
+     */
+    public function getMeetingService()
+    {
+        return $this->sm->get('report_service_meeting');
+    }
+
+    /**
+     * Get the organ service.
+     *
+     * @return \Report\Service\Organ
+     */
+    public function getOrganService()
+    {
+        return $this->getServiceLocator()->get('report_service_organ');
+    }
+
+    /**
+     * Get the board service.
+     *
+     * @return \Report\Service\Board
+     */
+    public function getBoardService()
+    {
+        return $this->getServiceLocator()->get('report_service_board');
+    }
+}

--- a/module/Report/src/Report/Listener/DatabaseUpdateListener.php
+++ b/module/Report/src/Report/Listener/DatabaseUpdateListener.php
@@ -21,7 +21,7 @@ class DatabaseUpdateListener
 
     public function postUpdate($eventArgs)
     {
-        echo '<br>' .get_class($eventArgs) .' call '.get_class($eventArgs->getEntity()) . '<br>';
+       // echo '<br>' .get_class($eventArgs) .' call '.get_class($eventArgs->getEntity()) . '<br>';
         $entity = $eventArgs->getEntity();
         switch (true) {
             case $entity instanceof \Database\Model\Address:
@@ -41,8 +41,8 @@ class DatabaseUpdateListener
                 break;
 
             case $entity instanceof \Database\Model\SubDecision:
-                $this->getMeetingService()->generateSubDecision($entity);
-                $this->processOrganUpdates($entity);
+                $subdecision = $this->getMeetingService()->generateSubDecision($entity);
+                $this->processOrganUpdates($subdecision);
                 break;
 
         }
@@ -52,23 +52,28 @@ class DatabaseUpdateListener
 
     public function processOrganUpdates($entity)
     {
+      //  echo '<br>processOrganUpdates call '.get_class($entity) . '<br>';
         switch (true) {
-            case $entity instanceof \Database\Model\SubDecision\Foundation:
+            case $entity instanceof \Report\Model\SubDecision\Foundation:
+                echo "foundation";
                 $this->getOrganService()->generateFoundation($entity);
                 break;
 
-            case $entity instanceof \Database\Model\SubDecision\Abrogation:
+            case $entity instanceof \Report\Model\SubDecision\Abrogation:
                 $this->getOrganService()->generateAbrogation($entity);
                 break;
 
-            case $entity instanceof \Database\Model\SubDecision\Installation:
+            case $entity instanceof \Report\Model\SubDecision\Installation:
                 $this->getOrganService()->generateInstallation($entity);
                 break;
 
-            case $entity instanceof \Database\Model\SubDecision\Discharge:
+            case $entity instanceof \Report\Model\SubDecision\Discharge:
                 $this->getOrganService()->generateDischarge($entity);
                 break;
         }
+
+        $em = $this->sm->get('doctrine.entitymanager.orm_report');
+        $em->persist($entity);
     }
 
     /**
@@ -98,7 +103,7 @@ class DatabaseUpdateListener
      */
     public function getOrganService()
     {
-        return $this->getServiceLocator()->get('report_service_organ');
+        return $this->sm->get('report_service_organ');
     }
 
     /**
@@ -108,6 +113,6 @@ class DatabaseUpdateListener
      */
     public function getBoardService()
     {
-        return $this->getServiceLocator()->get('report_service_board');
+        return $this->sm->get('report_service_board');
     }
 }

--- a/module/Report/src/Report/Listener/DatabaseUpdateListener.php
+++ b/module/Report/src/Report/Listener/DatabaseUpdateListener.php
@@ -46,6 +46,10 @@ class DatabaseUpdateListener
                 $em->persist($subdecision);
                 break;
 
+            case $entity instanceof \Database\Model\MailingList:
+                $this->getMiscService()->generateList($entity);
+                break;
+
         }
         $em->flush();
     }
@@ -109,5 +113,15 @@ class DatabaseUpdateListener
     public function getBoardService()
     {
         return $this->sm->get('report_service_board');
+    }
+
+    /**
+     * Get the misc service.
+     *
+     * @return \Report\Service\Misc
+     */
+    public function getMiscService()
+    {
+        return $this->sm->get('report_service_misc');
     }
 }

--- a/module/Report/src/Report/Listener/DatabaseUpdateListener.php
+++ b/module/Report/src/Report/Listener/DatabaseUpdateListener.php
@@ -21,7 +21,6 @@ class DatabaseUpdateListener
 
     public function postUpdate($eventArgs)
     {
-       // echo '<br>' .get_class($eventArgs) .' call '.get_class($eventArgs->getEntity()) . '<br>';
         $entity = $eventArgs->getEntity();
         switch (true) {
             case $entity instanceof \Database\Model\Address:
@@ -52,7 +51,6 @@ class DatabaseUpdateListener
 
     public function processOrganUpdates($entity)
     {
-      //  echo '<br>processOrganUpdates call '.get_class($entity) . '<br>';
         switch (true) {
             case $entity instanceof \Report\Model\SubDecision\Foundation:
                 echo "foundation";

--- a/module/Report/src/Report/Model/MailingList.php
+++ b/module/Report/src/Report/Model/MailingList.php
@@ -206,4 +206,14 @@ class MailingList
     {
         $this->members[] = $member;
     }
+
+    /**
+     * Remove a member.
+     *
+     * @param Member $member
+     */
+    public function removeMember(Member $member)
+    {
+        $this->members->removeElement($member);
+    }
 }

--- a/module/Report/src/Report/Model/Member.php
+++ b/module/Report/src/Report/Model/Member.php
@@ -153,7 +153,7 @@ class Member
     /**
      * Addresses of this member.
      *
-     * @ORM\OneToMany(targetEntity="Address", mappedBy="member",cascade={"persist"})
+     * @ORM\OneToMany(targetEntity="Address", mappedBy="member",cascade={"persist", "remove"})
      */
     protected $addresses;
 

--- a/module/Report/src/Report/Model/Member.php
+++ b/module/Report/src/Report/Model/Member.php
@@ -655,6 +655,19 @@ class Member
     }
 
     /**
+     * Remove a mailing list subscription.
+     *
+     * Note that this is the owning side.
+     *
+     * @param MailingList $list
+     */
+    public function removeList(MailingList $list)
+    {
+        $list->removeMember($this);
+        $this->lists->removeElement($list);
+    }
+
+    /**
      * Add multiple mailing lists.
      *
      * @param array $lists

--- a/module/Report/src/Report/Model/Organ.php
+++ b/module/Report/src/Report/Model/Organ.php
@@ -89,13 +89,13 @@ class Organ
      *
      * @ORM\ManyToMany(targetEntity="SubDecision")
      * @ORM\JoinTable(name="organs_subdecisions",
-     *      joinColumns={@ORM\JoinColumn(name="organ_id", referencedColumnName="id")},
+     *      joinColumns={@ORM\JoinColumn(name="organ_id", onDelete="cascade", referencedColumnName="id")},
      *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="meeting_type", referencedColumnName="meeting_type"),
-     *          @ORM\JoinColumn(name="meeting_number", referencedColumnName="meeting_number"),
-     *          @ORM\JoinColumn(name="decision_point", referencedColumnName="decision_point"),
-     *          @ORM\JoinColumn(name="decision_number", referencedColumnName="decision_number"),
-     *          @ORM\JoinColumn(name="subdecision_number", referencedColumnName="number")
+     *          @ORM\JoinColumn(name="meeting_type", referencedColumnName="meeting_type", onDelete="cascade"),
+     *          @ORM\JoinColumn(name="meeting_number", referencedColumnName="meeting_number", onDelete="cascade"),
+     *          @ORM\JoinColumn(name="decision_point", referencedColumnName="decision_point", onDelete="cascade"),
+     *          @ORM\JoinColumn(name="decision_number", referencedColumnName="decision_number", onDelete="cascade"),
+     *          @ORM\JoinColumn(name="subdecision_number", referencedColumnName="number", onDelete="cascade")
      *      })
      */
     protected $subdecisions;

--- a/module/Report/src/Report/Model/SubDecision/Discharge.php
+++ b/module/Report/src/Report/Model/SubDecision/Discharge.php
@@ -20,7 +20,7 @@ class Discharge extends SubDecision
     /**
      * Reference to the installation of a member.
      *
-     * @ORM\OneToOne(targetEntity="Installation",inversedBy="discharge")
+     * @ORM\OneToOne(targetEntity="Installation",inversedBy="discharge", cascade="remove")
      * @ORM\JoinColumns({
      *  @ORM\JoinColumn(name="r_meeting_type", referencedColumnName="meeting_type"),
      *  @ORM\JoinColumn(name="r_meeting_number", referencedColumnName="meeting_number"),

--- a/module/Report/src/Report/Model/SubDecision/Foundation.php
+++ b/module/Report/src/Report/Model/SubDecision/Foundation.php
@@ -44,14 +44,14 @@ class Foundation extends SubDecision
     /**
      * References from other subdecisions to this organ.
      *
-     * @ORM\OneToMany(targetEntity="FoundationReference",mappedBy="foundation")
+     * @ORM\OneToMany(targetEntity="FoundationReference",mappedBy="foundation", cascade="remove")
      */
     protected $references;
 
     /**
      * Organ entry for this organ.
      *
-     * @ORM\OneToOne(targetEntity="Report\Model\Organ",mappedBy="foundation")
+     * @ORM\OneToOne(targetEntity="Report\Model\Organ",mappedBy="foundation", cascade="remove")
      */
     protected $organ;
 

--- a/module/Report/src/Report/Model/SubDecision/FoundationReference.php
+++ b/module/Report/src/Report/Model/SubDecision/FoundationReference.php
@@ -22,11 +22,11 @@ abstract class FoundationReference extends SubDecision
      *
      * @ORM\ManyToOne(targetEntity="Foundation",inversedBy="references",cascade={"persist"})
      * @ORM\JoinColumns({
-     *  @ORM\JoinColumn(name="r_meeting_type", referencedColumnName="meeting_type"),
-     *  @ORM\JoinColumn(name="r_meeting_number", referencedColumnName="meeting_number"),
-     *  @ORM\JoinColumn(name="r_decision_point", referencedColumnName="decision_point"),
-     *  @ORM\JoinColumn(name="r_decision_number", referencedColumnName="decision_number"),
-     *  @ORM\JoinColumn(name="r_number", referencedColumnName="number")
+     *  @ORM\JoinColumn(name="r_meeting_type", referencedColumnName="meeting_type", onDelete="cascade"),
+     *  @ORM\JoinColumn(name="r_meeting_number", referencedColumnName="meeting_number", onDelete="cascade"),
+     *  @ORM\JoinColumn(name="r_decision_point", referencedColumnName="decision_point", onDelete="cascade"),
+     *  @ORM\JoinColumn(name="r_decision_number", referencedColumnName="decision_number", onDelete="cascade"),
+     *  @ORM\JoinColumn(name="r_number", referencedColumnName="number", onDelete="cascade")
      * })
      */
     protected $foundation;

--- a/module/Report/src/Report/Model/SubDecision/Installation.php
+++ b/module/Report/src/Report/Model/SubDecision/Installation.php
@@ -33,14 +33,14 @@ class Installation extends FoundationReference
     /**
      * Discharges.
      *
-     * @ORM\OneToOne(targetEntity="Discharge",mappedBy="installation")
+     * @ORM\OneToOne(targetEntity="Discharge",mappedBy="installation", cascade="remove")
      */
     protected $discharge;
 
     /**
      * The organmember reference.
      *
-     * @ORM\OneToOne(targetEntity="Report\Model\OrganMember",mappedBy="installation")
+     * @ORM\OneToOne(targetEntity="Report\Model\OrganMember",mappedBy="installation", cascade="remove")
      */
     protected $organMember;
 

--- a/module/Report/src/Report/Service/Meeting.php
+++ b/module/Report/src/Report/Service/Meeting.php
@@ -26,172 +26,236 @@ class Meeting extends AbstractService
 
         // simply export every meeting
         $em = $this->getServiceManager()->get('doctrine.entitymanager.orm_report');
-        $repo = $em->getRepository('Report\Model\Meeting');
-        $decRepo = $em->getRepository('Report\Model\Decision');
-        $subdecRepo = $em->getRepository('Report\Model\SubDecision');
-
         foreach ($mapper->findAll(true, true) as $meeting) {
-            $meeting = $meeting[0];
-
-            $reportMeeting = $repo->find(array(
-                'type' => $meeting->getType(),
-                'number' => $meeting->getNumber()
-            ));
-
-            if ($reportMeeting === null) {
-                $reportMeeting = new ReportMeeting();
-            }
-
-            $reportMeeting->setType($meeting->getType());
-            $reportMeeting->setNumber($meeting->getNumber());
-            $reportMeeting->setDate($meeting->getDate());
-
-            foreach ($meeting->getDecisions() as $decision) {
-                try {
-                    // see if decision exists
-                    $reportDecision = $decRepo->find(array(
-                        'meeting_type' => $decision->getMeeting()->getType(),
-                        'meeting_number' => $decision->getMeeting()->getNumber(),
-                        'point' => $decision->getPoint(),
-                        'number' => $decision->getNumber()
-                    ));
-                    if (null === $reportDecision) {
-                        $reportDecision = new ReportDecision();
-                        $reportDecision->setMeeting($reportMeeting);
-                    }
-                    $reportDecision->setPoint($decision->getPoint());
-                    $reportDecision->setNumber($decision->getNumber());
-                    $content = array();
-
-                    foreach ($decision->getSubdecisions() as $subdecision) {
-                        $reportSubDecision = $subdecRepo->find(array(
-                            'meeting_type' => $decision->getMeeting()->getType(),
-                            'meeting_number' => $decision->getMeeting()->getNumber(),
-                            'decision_point' => $decision->getPoint(),
-                            'decision_number' => $decision->getNumber(),
-                            'number' => $subdecision->getNumber()
-                        ));
-                        if (null === $reportSubDecision) {
-                            // determine type and create
-                            $class = get_class($subdecision);
-                            $class = preg_replace('/^Database/', 'Report', $class);
-                            $reportSubDecision = new $class();
-                            $reportSubDecision->setDecision($reportDecision);
-                            $reportSubDecision->setNumber($subdecision->getNumber());
-                        }
-
-                        if ($subdecision instanceof SubDecision\FoundationReference) {
-                            $ref = $subdecision->getFoundation();
-                            $foundation = $subdecRepo->find(array(
-                                'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
-                                'meeting_number' => $ref->getDecision()->getMeeting()->getNumber(),
-                                'decision_point' => $ref->getDecision()->getPoint(),
-                                'decision_number' => $ref->getDecision()->getNumber(),
-                                'number' => $ref->getNumber()
-                            ));
-                            $reportSubDecision->setFoundation($foundation);
-                        }
-
-                        // transfer specific data
-                        if ($subdecision instanceof SubDecision\Installation) {
-                            // installation
-                            $reportSubDecision->setFunction($subdecision->getFunction());
-                            $reportSubDecision->setMember($this->findMember($subdecision->getMember()));
-                        } else if ($subdecision instanceof SubDecision\Discharge) {
-                            // discharge
-                            $ref = $subdecision->getInstallation();
-                            $installation = $subdecRepo->find(array(
-                                'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
-                                'meeting_number' => $ref->getDecision()->getMeeting()->getNumber(),
-                                'decision_point' => $ref->getDecision()->getPoint(),
-                                'decision_number' => $ref->getDecision()->getNumber(),
-                                'number' => $ref->getNumber()
-                            ));
-                            $reportSubDecision->setInstallation($installation);
-                        } else if ($subdecision instanceof SubDecision\Foundation) {
-                            // foundation
-                            $reportSubDecision->setAbbr($subdecision->getAbbr());
-                            $reportSubDecision->setName($subdecision->getName());
-                            $reportSubDecision->setOrganType($subdecision->getOrganType());
-                        } else if ($subdecision instanceof SubDecision\Reckoning || $subdecision instanceof SubDecision\Budget) {
-                            // budget and reckoning
-                            if (null !== $subdecision->getAuthor()) {
-                                $reportSubDecision->setAuthor($this->findMember($subdecision->getAuthor()));
-                            }
-                            $reportSubDecision->setName($subdecision->getName());
-                            $reportSubDecision->setVersion($subdecision->getVersion());
-                            $reportSubDecision->setDate($subdecision->getDate());
-                            $reportSubDecision->setApproval($subdecision->getApproval());
-                            $reportSubDecision->setChanges($subdecision->getChanges());
-                        } else if ($subdecision instanceof SubDecision\Board\Installation) {
-                            // board installation
-                            $reportSubDecision->setFunction($subdecision->getFunction());
-                            $reportSubDecision->setMember($this->findMember($subdecision->getMember()));
-                            $reportSubDecision->setDate($subdecision->getDate());
-                        } else if ($subdecision instanceof SubDecision\Board\Release) {
-                            // board release
-                            $ref = $subdecision->getInstallation();
-                            $installation = $subdecRepo->find(array(
-                                'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
-                                'meeting_number' => $ref->getDecision()->getMeeting()->getNumber(),
-                                'decision_point' => $ref->getDecision()->getPoint(),
-                                'decision_number' => $ref->getDecision()->getNumber(),
-                                'number' => $ref->getNumber()
-                            ));
-                            $reportSubDecision->setInstallation($installation);
-                            $reportSubDecision->setDate($subdecision->getDate());
-                        } else if ($subdecision instanceof SubDecision\Board\Discharge) {
-                            $ref = $subdecision->getInstallation();
-                            $installation = $subdecRepo->find(array(
-                                'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
-                                'meeting_number' => $ref->getDecision()->getMeeting()->getNumber(),
-                                'decision_point' => $ref->getDecision()->getPoint(),
-                                'decision_number' => $ref->getDecision()->getNumber(),
-                                'number' => $ref->getNumber()
-                            ));
-                            $reportSubDecision->setInstallation($installation);
-                        } else if ($subdecision instanceof SubDecision\Destroy) {
-                            $ref = $subdecision->getTarget();
-                            $target = $decRepo->find(array(
-                                'meeting_type' => $ref->getMeeting()->getType(),
-                                'meeting_number' => $ref->getMeeting()->getNumber(),
-                                'point' => $ref->getPoint(),
-                                'number' => $ref->getNumber()
-                            ));
-                            $reportSubDecision->setTarget($target);
-                        }
-                        // Abolish decisions are handled by foundationreference
-                        // Other decisions don't need special handling
-
-                        // for any decision, make sure the content is filled
-                        $cnt = $subdecision->getContent();
-                        if (null === $cnt) {
-                            $cnt = '';
-                        }
-                        $reportSubDecision->setContent($cnt);
-                        $content[] = $subdecision->getContent();
-                        $em->persist($reportSubDecision);
-                    }
-
-                    if (empty($content)) {
-                        $content[] = '';
-                    }
-                    $reportDecision->setContent(implode(' ', $content));
-
-                    $em->persist($reportDecision);
-                } catch (\Exception $e) {
-                    // send email, something went wrong
-                    $this->sendDecisionExceptionMail($e, $decision);
-                    continue;
-                }
-            }
-
-            $em->persist($reportMeeting);
+            $this->generateMeeting($meeting[0]);
             $em->flush();
         }
         $em->flush();
     }
 
+    public function generateMeeting($meeting)
+    {
+        $em = $this->getServiceManager()->get('doctrine.entitymanager.orm_report');
+        $repo = $em->getRepository('Report\Model\Meeting');
+
+        $reportMeeting = $repo->find(array(
+            'type' => $meeting->getType(),
+            'number' => $meeting->getNumber()
+        ));
+
+        if ($reportMeeting === null) {
+            $reportMeeting = new ReportMeeting();
+        }
+
+        $reportMeeting->setType($meeting->getType());
+        $reportMeeting->setNumber($meeting->getNumber());
+        $reportMeeting->setDate($meeting->getDate());
+
+        foreach ($meeting->getDecisions() as $decision) {
+            try {
+                $this->generateDecision($decision, $reportMeeting);
+            } catch (\Exception $e) {
+                // send email, something went wrong
+                $this->sendDecisionExceptionMail($e, $decision);
+                continue;
+            }
+        }
+
+        $em->persist($reportMeeting);
+    }
+
+    public function generateDecision($decision, $reportMeeting = null)
+    {
+        $em = $this->getServiceManager()->get('doctrine.entitymanager.orm_report');
+        $decRepo = $em->getRepository('Report\Model\Decision');
+        if ($reportMeeting === null) {
+            $reportMeeting = $em->getRepository('Report\Model\Meeting')->find([
+                'type' => $decision->getMeeting()->getType(),
+                'number' => $decision->getMeeting()->getNumber()
+            ]);
+            if ($reportMeeting === null) {
+                throw new \LogicException('Decision without meeting');
+            }
+        }
+        // see if decision exists
+        $reportDecision = $decRepo->find(array(
+            'meeting_type' => $decision->getMeeting()->getType(),
+            'meeting_number' => $decision->getMeeting()->getNumber(),
+            'point' => $decision->getPoint(),
+            'number' => $decision->getNumber()
+        ));
+        if (null === $reportDecision) {
+            var_dump(array(
+                'meeting_type' => $decision->getMeeting()->getType(),
+                'meeting_number' => $decision->getMeeting()->getNumber(),
+                'point' => $decision->getPoint(),
+                'number' => $decision->getNumber()
+            ));
+            $reportDecision = new ReportDecision();
+            $reportDecision->setMeeting($reportMeeting);
+        }
+        $reportDecision->setPoint($decision->getPoint());
+        $reportDecision->setNumber($decision->getNumber());
+        $content = array();
+
+        foreach ($decision->getSubdecisions() as $subdecision) {
+            $this->generateSubDecision($subdecision, $reportDecision);
+        }
+
+        if (empty($content)) {
+            $content[] = '';
+        }
+        $reportDecision->setContent(implode(' ', $content));
+
+        $em->persist($reportDecision);
+
+    }
+
+    public function generateSubDecision($subdecision, $reportDecision = null) {
+        $em = $this->getServiceManager()->get('doctrine.entitymanager.orm_report');
+        $decRepo = $em->getRepository('Report\Model\Decision');
+        $subdecRepo = $em->getRepository('Report\Model\SubDecision');
+        if ($reportDecision === null) {
+            $reportDecision = $decRepo->find(array(
+                'meeting_type' => $subdecision->getMeetingType(),
+                'meeting_number' => $subdecision->getMeetingNumber(),
+                'point' => $subdecision->getDecisionPoint(),
+                'number' => $subdecision->getDecisionNumber()
+            ));
+            if ($reportDecision === null) {
+                throw new \LogicException('Decision without meeting');
+            }
+        }
+        $reportSubDecision = $subdecRepo->find(array(
+            'meeting_type' => $subdecision->getMeetingType(),
+            'meeting_number' => $subdecision->getMeetingNumber(),
+            'decision_point' => $subdecision->getDecisionPoint(),
+            'decision_number' => $subdecision->getDecisionNumber(),
+            'number' => $subdecision->getNumber()
+        ));
+        if (null === $reportSubDecision) {
+            var_dump(array(
+                'meeting_type' => $subdecision->getMeetingType(),
+                'meeting_number' => $subdecision->getMeetingnumber(),
+                'decision_point' => $subdecision->getDecisionPoint(),
+                'decision_number' => $subdecision->getDecisionNumber(),
+                'number' => $subdecision->getNumber()
+            ));
+            // determine type and create
+            $class = get_class($subdecision);
+            $class = preg_replace('/^Database/', 'Report', $class);
+            $reportSubDecision = new $class();
+            $reportSubDecision->setDecision($reportDecision);
+            $reportSubDecision->setNumber($subdecision->getNumber());
+        }
+
+        if ($subdecision instanceof SubDecision\FoundationReference) {
+            $ref = $subdecision->getFoundation();
+            $foundation = $subdecRepo->find(array(
+                'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
+                'meeting_number' => $ref->getDecision()->getMeeting()->getNumber(),
+                'decision_point' => $ref->getDecision()->getPoint(),
+                'decision_number' => $ref->getDecision()->getNumber(),
+                'number' => $ref->getNumber()
+            ));
+            $reportSubDecision->setFoundation($foundation);
+        }
+
+        // transfer specific data
+        if ($subdecision instanceof SubDecision\Installation) {
+            // installation
+            $reportSubDecision->setFunction($subdecision->getFunction());
+            $reportSubDecision->setMember($this->findMember($subdecision->getMember()));
+        } else {
+            if ($subdecision instanceof SubDecision\Discharge) {
+                // discharge
+                $ref = $subdecision->getInstallation();
+                $installation = $subdecRepo->find(array(
+                    'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
+                    'meeting_number' => $ref->getDecision()->getMeeting()->getNumber(),
+                    'decision_point' => $ref->getDecision()->getPoint(),
+                    'decision_number' => $ref->getDecision()->getNumber(),
+                    'number' => $ref->getNumber()
+                ));
+                $reportSubDecision->setInstallation($installation);
+            } else {
+                if ($subdecision instanceof SubDecision\Foundation) {
+                    // foundation
+                    $reportSubDecision->setAbbr($subdecision->getAbbr());
+                    $reportSubDecision->setName($subdecision->getName());
+                    $reportSubDecision->setOrganType($subdecision->getOrganType());
+                } else {
+                    if ($subdecision instanceof SubDecision\Reckoning || $subdecision instanceof SubDecision\Budget) {
+                        // budget and reckoning
+                        if (null !== $subdecision->getAuthor()) {
+                            $reportSubDecision->setAuthor($this->findMember($subdecision->getAuthor()));
+                        }
+                        $reportSubDecision->setName($subdecision->getName());
+                        $reportSubDecision->setVersion($subdecision->getVersion());
+                        $reportSubDecision->setDate($subdecision->getDate());
+                        $reportSubDecision->setApproval($subdecision->getApproval());
+                        $reportSubDecision->setChanges($subdecision->getChanges());
+                    } else {
+                        if ($subdecision instanceof SubDecision\Board\Installation) {
+                            // board installation
+                            $reportSubDecision->setFunction($subdecision->getFunction());
+                            $reportSubDecision->setMember($this->findMember($subdecision->getMember()));
+                            $reportSubDecision->setDate($subdecision->getDate());
+                        } else {
+                            if ($subdecision instanceof SubDecision\Board\Release) {
+                                // board release
+                                $ref = $subdecision->getInstallation();
+                                $installation = $subdecRepo->find(array(
+                                    'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
+                                    'meeting_number' => $ref->getDecision()->getMeeting()->getNumber(),
+                                    'decision_point' => $ref->getDecision()->getPoint(),
+                                    'decision_number' => $ref->getDecision()->getNumber(),
+                                    'number' => $ref->getNumber()
+                                ));
+                                $reportSubDecision->setInstallation($installation);
+                                $reportSubDecision->setDate($subdecision->getDate());
+                            } else {
+                                if ($subdecision instanceof SubDecision\Board\Discharge) {
+                                    $ref = $subdecision->getInstallation();
+                                    $installation = $subdecRepo->find(array(
+                                        'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
+                                        'meeting_number' => $ref->getDecision()->getMeeting()->getNumber(),
+                                        'decision_point' => $ref->getDecision()->getPoint(),
+                                        'decision_number' => $ref->getDecision()->getNumber(),
+                                        'number' => $ref->getNumber()
+                                    ));
+                                    $reportSubDecision->setInstallation($installation);
+                                } else {
+                                    if ($subdecision instanceof SubDecision\Destroy) {
+                                        $ref = $subdecision->getTarget();
+                                        $target = $decRepo->find(array(
+                                            'meeting_type' => $ref->getMeeting()->getType(),
+                                            'meeting_number' => $ref->getMeeting()->getNumber(),
+                                            'point' => $ref->getPoint(),
+                                            'number' => $ref->getNumber()
+                                        ));
+                                        $reportSubDecision->setTarget($target);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Abolish decisions are handled by foundationreference
+        // Other decisions don't need special handling
+
+        // for any decision, make sure the content is filled
+        $cnt = $subdecision->getContent();
+        if (null === $cnt) {
+            $cnt = '';
+        }
+        $reportSubDecision->setContent($cnt);
+        $content[] = $subdecision->getContent();
+        $em->persist($reportSubDecision);
+    }
     /**
      * Obtain the correct member, given a database member.
      *
@@ -203,6 +267,7 @@ class Meeting extends AbstractService
     {
         $em = $this->getServiceManager()->get('doctrine.entitymanager.orm_report');
         $repo = $em->getRepository('Report\Model\Member');
+
         return $repo->find($member->getLidnr());
     }
 

--- a/module/Report/src/Report/Service/Meeting.php
+++ b/module/Report/src/Report/Service/Meeting.php
@@ -250,6 +250,18 @@ class Meeting extends AbstractService
         $em->persist($reportSubDecision);
         return $reportSubDecision;
     }
+
+    public function deleteDecision($decision)
+    {
+        $em = $this->getServiceManager()->get('doctrine.entitymanager.orm_report');
+        $reportDecision = $em->getRepository('Report\Model\Decision')->find(array(
+            'meeting_type' => $decision->getMeeting()->getType(),
+            'meeting_number' => $decision->getMeeting()->getNumber(),
+            'point' => $decision->getPoint(),
+            'number' => $decision->getNumber()
+        ));
+        $em->remove($reportDecision);
+    }
     /**
      * Obtain the correct member, given a database member.
      *

--- a/module/Report/src/Report/Service/Meeting.php
+++ b/module/Report/src/Report/Service/Meeting.php
@@ -85,12 +85,6 @@ class Meeting extends AbstractService
             'number' => $decision->getNumber()
         ));
         if (null === $reportDecision) {
-            var_dump(array(
-                'meeting_type' => $decision->getMeeting()->getType(),
-                'meeting_number' => $decision->getMeeting()->getNumber(),
-                'point' => $decision->getPoint(),
-                'number' => $decision->getNumber()
-            ));
             $reportDecision = new ReportDecision();
             $reportDecision->setMeeting($reportMeeting);
         }

--- a/module/Report/src/Report/Service/Meeting.php
+++ b/module/Report/src/Report/Service/Meeting.php
@@ -134,13 +134,6 @@ class Meeting extends AbstractService
             'number' => $subdecision->getNumber()
         ));
         if (null === $reportSubDecision) {
-            var_dump(array(
-                'meeting_type' => $subdecision->getMeetingType(),
-                'meeting_number' => $subdecision->getMeetingnumber(),
-                'decision_point' => $subdecision->getDecisionPoint(),
-                'decision_number' => $subdecision->getDecisionNumber(),
-                'number' => $subdecision->getNumber()
-            ));
             // determine type and create
             $class = get_class($subdecision);
             $class = preg_replace('/^Database/', 'Report', $class);
@@ -255,6 +248,7 @@ class Meeting extends AbstractService
         $reportSubDecision->setContent($cnt);
         $content[] = $subdecision->getContent();
         $em->persist($reportSubDecision);
+        return $reportSubDecision;
     }
     /**
      * Obtain the correct member, given a database member.

--- a/module/Report/src/Report/Service/Member.php
+++ b/module/Report/src/Report/Service/Member.php
@@ -90,6 +90,26 @@ class Member extends AbstractService
         $em->persist($reportAddress);
     }
 
+    public function deleteMember($member)
+    {
+        $em = $this->getServiceManager()->get('doctrine.entitymanager.orm_report');
+        $repo = $em->getRepository('Report\Model\Member');
+        // first try to find an existing member
+        $reportMember = $repo->find($member->getLidnr());
+        $em->remove($reportMember);
+    }
+
+    public function deleteAddress($address)
+    {
+        $em = $this->getServiceManager()->get('doctrine.entitymanager.orm_report');
+        $repo = $em->getRepository('Report\Model\Address');
+        // first try to find an existing member
+        $reportAddress = $repo->find(array(
+            'member' => $address->getMember()->getLidnr(),
+            'type' => $address->getType()
+        ));
+        $em->remove($reportAddress);
+    }
     /**
      * Get the member mapper.
      *

--- a/module/Report/src/Report/Service/Organ.php
+++ b/module/Report/src/Report/Service/Organ.php
@@ -31,15 +31,7 @@ class Organ extends AbstractService
 
         foreach ($foundations as $foundation) {
             // see if there already is an organ
-            $repOrgan = $foundation->getOrgan();
-            if (null === $repOrgan) {
-                $repOrgan = new ReportOrgan();
-                $repOrgan->setFoundation($foundation);
-            }
-            $repOrgan->setAbbr($foundation->getAbbr());
-            $repOrgan->setName($foundation->getName());
-            $repOrgan->setType($foundation->getOrganType());
-            $repOrgan->setFoundationDate($foundation->getDecision()->getMeeting()->getDate());
+            $repOrgan = $this->generateFoundation($foundation);
 
             /**
              * Also find all related subdecisions.
@@ -95,6 +87,37 @@ class Organ extends AbstractService
             $em->persist($repOrgan);
         }
         $em->flush();
+    }
+
+    public function generatFoundation($foundation)
+    {
+        // see if there already is an organ
+        $repOrgan = $foundation->getOrgan();
+        if (null === $repOrgan) {
+            $repOrgan = new ReportOrgan();
+            $repOrgan->setFoundation($foundation);
+        }
+        $repOrgan->setAbbr($foundation->getAbbr());
+        $repOrgan->setName($foundation->getName());
+        $repOrgan->setType($foundation->getOrganType());
+        $repOrgan->setFoundationDate($foundation->getDecision()->getMeeting()->getDate());
+
+        return $repOrgan;
+    }
+
+    public function generateAbrogation($installation)
+    {
+
+    }
+
+    public function generateInstallation($installation)
+    {
+
+    }
+
+    public function generateDischarge($discharge)
+    {
+
     }
 
     /**


### PR DESCRIPTION
This makes reportdb update automatically when there are changes in meetings/decisions/members. This solves the following problems (once the website is switched over to use reportdb directly):

- Members signing up can now directly make use of all GEWIS services.
- It no longer takes 48 hours for organ changes to display correctly on the website.
- If somehow a decision is taken which will mess up reportdb it is immediately detected and prevented. 
- Deletions are handled properly
- #133, #134, #118

The old method of generating reportdb was also left intact in case it still is needed in the future.