### PR TITLE
Correctly implement canvas resizing to prevent crashes

### DIFF
--- a/module/Database/view/database/member/subscribe.phtml
+++ b/module/Database/view/database/member/subscribe.phtml
@@ -361,10 +361,14 @@ inschrijvingen kunnen op een later tijdstip veranderd worden.') ?>
 <p>
 <?= $this->translate('Voor de automatische eenmalige SEPA-machtiging hebben we je handtekening nodig. Deze kan je hieronder in het vakje tekenen.') ?>
 </p>
-<canvas id="signature-canvas"><?= $this->translate('Je internet browser ondersteunt geen digitale handtekeningen. Gebruik een moderne browser, zoals Firefox.') ?></canvas>
-<br>
-<button class="btn" type="button" id="signature-canvas-clear"><?= $this->translate('Verwijder handtekening') ?></button>
-<?= $this->formHidden($form->get('signature')->setAttribute('id', 'signature-canvas-data')); ?>
+<div class="form-group" id="signature-form-group">
+    <div class="col-sm-12">
+        <canvas id="signature-canvas"><?= $this->translate('Je internet browser ondersteunt geen digitale handtekeningen. Gebruik een moderne browser, zoals Firefox.') ?></canvas>
+        <br>
+        <button class="btn" type="button" id="signature-canvas-clear"><?= $this->translate('Verwijder handtekening') ?></button>
+        <?= $this->formHidden($form->get('signature')->setAttribute('id', 'signature-canvas-data')); ?>
+    </div>
+</div>
 
 <?php
 $element = $form->get('signatureLocation');

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -140,6 +140,6 @@ case Address::TYPE_MAIL:
 <?php endforeach ?>
 </ul>
 <h3>Handtekening SEPA incasso</h3>
-<img src="<?= $this->fileUrl($member->getSignature()) ?>" height="100" width="300" />
+<img src="<?= $this->fileUrl($member->getSignature()) ?>" height="150" width="300" />
 </div>
 </div>

--- a/public/js/subscribe.app.js
+++ b/public/js/subscribe.app.js
@@ -4,6 +4,7 @@ var inputSignature = document.getElementById("signature-canvas-data");
 var ibanInput = document.getElementById("iban-input");
 var ibanCheckbox = document.getElementById("iban-agreement");
 var form = document.getElementById("form-subscribe");
+var signatureFormGroup = document.getElementById("signature-form-group");
 var canvas = document.getElementById("signature-canvas");
 var signaturePad = new SignaturePad(canvas, {
     'throttle': 32,
@@ -14,16 +15,16 @@ var signaturePad = new SignaturePad(canvas, {
 });
 
 function resizeCanvas() {
-  var ratio =  Math.max(window.devicePixelRatio || 1, 1);
+    var ratio =  Math.max(window.devicePixelRatio || 1, 1);
 
-  canvas.width = canvas.offsetWidth * ratio;
-  canvas.height = canvas.offsetHeight * ratio;
-  canvas.getContext("2d").scale(ratio, ratio);
+    canvas.width = Math.min(signatureFormGroup.offsetWidth * ratio, 300);
+    canvas.height = Math.min(signatureFormGroup.offsetHeight * ratio, 150);
 
-  signaturePad.clear();
+    inputSignature.value = "";
+    signaturePad.clear();
 }
 
-window.onresize = resizeCanvas;
+window.onorientationchange = resizeCanvas;
 resizeCanvas();
 
 clearButton.addEventListener("click", function (event) {


### PR DESCRIPTION
This change is introduced to stop the subscription webpage from crashing
on mobile devices. This issue was caused by implementing the canvas
resizing using the `window.onresize` EventHandler, however, on mobile
devices this event is also emitted when scrolling (due to the moving
omnibox).

Resizing is now done when the orientation of a mobile device changes (`window.onorientationchange`).

Furthermore, the height of the canvas is increased from 100 to 150 to
aid mobile users entering their signature.