### PR TITLE
Updated membership types and status checks

### DIFF
--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -17,6 +17,12 @@ return [
      */
     'checker' => [
         'report_mail' => 'mail@example.org',
+        'membership_api' => [
+            'endpoint' => 'https://tue-lookup.gewis.nl/user/',
+            'key' => 'c2VjcmV0',
+            'max_total_requests' => 200,
+            'max_manual_requests' => 20
+        ],
     ],
 
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,6 +7,10 @@ services:
 #      - .:/code
     environment:
       CHECKER_REPORT_MAIL: "mail@example.org"
+      CHECKER_MEMBERSHIP_API_ENDPOINT: "https://tue-lookup.gewis.nl/user/"
+      CHECKER_MEMBERSHIP_API_KEY: "c2VjcmV0"
+      CHECKER_MEMBERSHIP_API_MAX_TOTAL_REQUESTS: 200
+      CHECKER_MEMBERSHIP_API_MAX_MANUAL_REQUESTS: 20
       DOCTRINE_DEFAULT_HOST: "postgres"
       DOCTRINE_DEFAULT_PORT: "5432"
       DOCTRINE_DEFAULT_USER: "gewisdb"

--- a/docker/autoload/local.php
+++ b/docker/autoload/local.php
@@ -17,6 +17,12 @@ return [
      */
     'checker' => [
         'report_mail' => getenv('CHECKER_REPORT_MAIL'),
+        'membership_api' => [
+            'endpoint' => getenv('CHECKER_MEMBERSHIP_API_ENDPOINT'),
+            'key' => getenv('CHECKER_MEMBERSHIP_API_KEY'),
+            'max_total_requests' => getenv('CHECKER_MEMBERSHIP_API_MAX_TOTAL_REQUESTS'),
+            'max_manual_requests' => getenv('CHECKER_MEMBERSHIP_API_MAX_MANUAL_REQUESTS')
+        ]
     ],
 
 

--- a/module/Checker/Module.php
+++ b/module/Checker/Module.php
@@ -43,7 +43,8 @@ class Module
                 'checker_service_organ' => 'Checker\Service\Organ',
                 'checker_service_installation' => 'Checker\Service\Installation',
                 'checker_service_budget' => 'Checker\Service\Budget',
-                'checker_service_meeting' => 'Checker\Service\Meeting'
+                'checker_service_meeting' => 'Checker\Service\Meeting',
+                'checker_service_member' => 'Checker\Service\Member'
             ),
             'factories' => array(
                 'checker_mapper_organ' => function ($sm) {
@@ -58,6 +59,11 @@ class Module
                 },
                 'checker_mapper_budget' => function ($sm) {
                     return new \Checker\Mapper\Budget(
+                        $sm->get('database_doctrine_em')
+                    );
+                },
+                'checker_mapper_member' => function ($sm) {
+                    return new \Checker\Mapper\Member(
                         $sm->get('database_doctrine_em')
                     );
                 },

--- a/module/Checker/config/module.config.php
+++ b/module/Checker/config/module.config.php
@@ -17,6 +17,15 @@ return array(
                         )
                     )
                 ),
+                'check_memberships' => array(
+                    'options' => array(
+                        'route' => 'check memberships',
+                        'defaults' => array(
+                            'controller' => 'Checker\Controller\Checker',
+                            'action' => 'checkMemberships'
+                        )
+                    )
+                ),
             )
         )
     )

--- a/module/Checker/src/Checker/Controller/CheckerController.php
+++ b/module/Checker/src/Checker/Controller/CheckerController.php
@@ -20,4 +20,10 @@ class CheckerController extends AbstractActionController
         $service = $this->getServiceLocator()->get('checker_service_checker');
         $service->check();
     }
+
+    public function checkMembershipsAction()
+    {
+        $service = $this->getServiceLocator()->get('checker_service_checker');
+        $service->checkMemberships();
+    }
 }

--- a/module/Checker/src/Checker/Mapper/Member.php
+++ b/module/Checker/src/Checker/Mapper/Member.php
@@ -45,8 +45,11 @@ class Member
             ->andWhere('m.tueUsername IS NOT NULL')
             ->andWhere('m.membershipEndsOn IS NULL')
             ->andWhere('m.lastCheckedOn IS NULL OR m.lastCheckedOn < CURRENT_DATE()')
+            ->andWhere('m.expiration <= :endOfCurrentAssociationYear')
             ->orderBy('m.lastCheckedOn', 'ASC')
             ->setMaxResults($limit);
+
+        $qb->setParameter('endOfCurrentAssociationYear', $this->getEndOfCurrentAssociationYear());
 
         return $qb->getQuery()->getResult();
     }
@@ -63,9 +66,31 @@ class Member
         $qb->select('m')
             ->from('Database\Model\Member', 'm')
             ->where('m.type = \'ordinary\' OR m.type = \'external\'')
-            ->andWhere('m.membershipEndsOn IS NOT NULL');
+            ->andWhere('m.membershipEndsOn IS NOT NULL')
+            ->andWhere('m.expiration <= :endOfCurrentAssociationYear');
+
+        $qb->setParameter('endOfCurrentAssociationYear', $this->getEndOfCurrentAssociationYear());
 
         return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return \DateTime
+     */
+    private function getEndOfCurrentAssociationYear()
+    {
+        $end = new \DateTime();
+        $end->setTime(0, 0);
+
+        if ($end->format('m') >= 7) {
+            $year = (int) $end->format('Y') + 1;
+        } else {
+            $year = (int) $end->format('Y');
+        }
+
+        $end->setDate($year, 7, 1);
+
+        return $end;
     }
 
     /**

--- a/module/Checker/src/Checker/Mapper/Member.php
+++ b/module/Checker/src/Checker/Mapper/Member.php
@@ -42,7 +42,7 @@ class Member
         $qb->select('m')
             ->from('Database\Model\Member', 'm')
             ->where('m.type = \'ordinary\'')
-            ->andWhere('m.tuenumber IS NOT NULL')
+            ->andWhere('m.tueUsername IS NOT NULL')
             ->andWhere('m.membershipEndsOn IS NULL')
             ->andWhere('m.lastCheckedOn IS NULL OR m.lastCheckedOn < CURRENT_DATE()')
             ->orderBy('m.lastCheckedOn', 'ASC')

--- a/module/Checker/src/Checker/Mapper/Member.php
+++ b/module/Checker/src/Checker/Mapper/Member.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Checker\Mapper;
+
+use Database\Model\Member as MemberModel;
+use Doctrine\ORM\EntityManager;
+
+/**
+ * Member mapper
+ */
+class Member
+{
+
+    /**
+     * Doctrine entity manager.
+     *
+     * @var EntityManager
+     */
+    protected $em;
+
+    /**
+     * Constructor
+     *
+     * @param EntityManager $em
+     */
+    public function __construct(EntityManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * Get a list of members whose membership should be checked against the TU/e student administration database.
+     *
+     * @param int $limit
+     *
+     * @return array
+     */
+    public function getMembersToCheck($limit)
+    {
+        $qb = $this->em->createQueryBuilder();
+
+        $qb->select('m')
+            ->from('Database\Model\Member', 'm')
+            ->where('m.type = \'ordinary\'')
+            ->andWhere('m.tuenumber IS NOT NULL')
+            ->andWhere('m.membershipEndsOn IS NULL')
+            ->andWhere('m.lastCheckedOn IS NULL OR m.lastCheckedOn < CURRENT_DATE()')
+            ->orderBy('m.lastCheckedOn', 'ASC')
+            ->setMaxResults($limit);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Get a list of members whose membership has an end date, but who are not yet "graduate".
+     *
+     * @return array
+     */
+    public function getEndingMembershipsWithNormalTypes()
+    {
+        $qb = $this->em->createQueryBuilder();
+
+        $qb->select('m')
+            ->from('Database\Model\Member', 'm')
+            ->where('m.type = \'ordinary\' OR m.type = \'external\'')
+            ->andWhere('m.membershipEndsOn IS NOT NULL');
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Persist a member model.
+     *
+     * @param MemberModel $member Member to persist.
+     */
+    public function persist(MemberModel $member)
+    {
+        $this->em->persist($member);
+        $this->em->flush();
+    }
+}

--- a/module/Checker/src/Checker/Service/Checker.php
+++ b/module/Checker/src/Checker/Service/Checker.php
@@ -272,6 +272,7 @@ class Checker extends AbstractService
             } else if (404 === $response->getStatusCode()) {
                 // The member cannot be found in the TU/e student administration database.
                 $member->setChangedOn(new \DateTime());
+                $member->setIsStudying(false);
                 $member->setMembershipEndsOn($exp);
                 $member->setLastCheckedOn(new \DateTime());
             }
@@ -326,6 +327,10 @@ class Checker extends AbstractService
                     // member is still studying.
                     if ($member->getIsStudying()) {
                         $member->setType(\Database\Model\Member::TYPE_EXTERNAL);
+
+                        // External memberships should run till the end of the next association year (which is actually
+                        // the same date as the expiration).
+                        $member->setMembershipEndsOn($exp);
                     } else {
                         $member->setType(\Database\Model\Member::TYPE_GRADUATE);
                     }

--- a/module/Checker/src/Checker/Service/Checker.php
+++ b/module/Checker/src/Checker/Service/Checker.php
@@ -120,8 +120,10 @@ class Checker extends AbstractService
             // Check if the members are still member of GEWIS
             $member = $installation->getMember();
 
-            if ($member->getExpiration() < $meeting->getDate()) {
-                $errors[] = new Error\MemberExpiredButStillInOrgan($meeting, $installation);
+            if (null !== ($membershipEndsOn = $member->getMembershipEndsOn())) {
+                if ($membershipEndsOn < $meeting->getDate()) {
+                    $errors[] = new Error\MemberExpiredButStillInOrgan($meeting, $installation);
+                }
             }
         }
         return $errors;

--- a/module/Checker/src/Checker/Service/Checker.php
+++ b/module/Checker/src/Checker/Service/Checker.php
@@ -237,7 +237,7 @@ class Checker extends AbstractService
         /** @var \Database\Model\Member $member */
         foreach ($members as $member) {
             $this->getEventManager()->trigger(__FUNCTION__ . '.pre', $this, array('member' => $member));
-            $request->setUri($config['endpoint'] . $member->getTuenumber());
+            $request->setUri($config['endpoint'] . $member->getTueUsername());
             $response = $client->send($request);
 
             // Check if the request was successful. If something else happens than 200 or 404 that may have broken the
@@ -250,7 +250,7 @@ class Checker extends AbstractService
                     // Check that we have a proper response.
                     if (array_key_exists('registrations', $responseContent)) {
                         // Check if the member is still registered for a study in the department of Mathematics and Computer
-                        // Science & Engineering. If not, update membership type to "graduate" and set date of expiration.
+                        // Science & Engineering. If not, set date of expiration.
                         if (!in_array('WIN', array_column($responseContent['registrations'], 'dept'))) {
                             $member->setChangedOn(new \DateTime());
                             $member->setMembershipEndsOn($exp);

--- a/module/Checker/src/Checker/Service/Checker.php
+++ b/module/Checker/src/Checker/Service/Checker.php
@@ -11,6 +11,10 @@ use Application\Service\AbstractService;
 use \Database\Model\SubDecision\Foundation;
 use \Database\Model\Meeting;
 use \Checker\Model\Error;
+use Zend\Http\Client;
+use Zend\Http\Client\Adapter\Curl;
+use Zend\Http\Request;
+use Zend\Json\Json;
 use Zend\Mail\Message;
 
 class Checker extends AbstractService
@@ -32,7 +36,7 @@ class Checker extends AbstractService
                 $this->checkOrganMeetingType($meeting)
             );
 
-            $message .= $this->handleErrors($meeting, $errors);
+            $message .= $this->handleMeetingErrors($meeting, $errors);
         }
 
         $this->sendMail($message);
@@ -44,7 +48,7 @@ class Checker extends AbstractService
      * @param \Database\Model\Meeting $meeting Meeting for which this errors hold
      * @param array $errors
      */
-    private function handleErrors(\Database\Model\Meeting $meeting, array $errors)
+    private function handleMeetingErrors(\Database\Model\Meeting $meeting, array $errors)
     {
         // At this moment only write to output.
         $body =  'Errors after meeting ' . $meeting->getNumber() . ' hold at '
@@ -66,13 +70,11 @@ class Checker extends AbstractService
      */
     private function sendMail($body)
     {
-        $config = $meetingService = $this->getServiceManager()->get('config');
+        $config = $this->getServiceManager()->get('config');
         $message = new Message();
         $message->addTo($config['checker']['report_mail'])
             ->setSubject('Database Checker Report')
             ->setBody($body);
-
-        echo $body;
 
         $transport = $this->getServiceManager()->get('checker_mail_transport');
         $transport->send($message);
@@ -181,5 +183,145 @@ class Checker extends AbstractService
             }
         }
         return $errors;
+    }
+
+    /**
+     * Checks members whose membership status and type may require changes.
+     *
+     * @return void
+     */
+    public function checkMemberships()
+    {
+        $memberService = $this->getServiceManager()->get('checker_service_member');
+
+        $this->checkAtTUe($memberService->getMembersToCheck());
+        $this->checkProperMembershipType();
+    }
+
+    /**
+     * Checks that "ordinary" members are still enrolled at the TU/e. If not, their membership should expire at the end
+     * of the current association year. This does not actually update their membership type, as that is still valid for
+     * the remainder of the current association year.
+     *
+     * @return void
+     */
+    private function checkAtTUe(array $members)
+    {
+        $memberService = $this->getServiceManager()->get('checker_service_member');
+        $config = $this->getServiceManager()->get('config')['checker']['membership_api'];
+
+        $client = new Client();
+        $client->setAdapter(Curl::class)
+            ->setEncType('application/json');
+
+        $request = new Request();
+        $request->setMethod(Request::METHOD_GET)
+            ->getHeaders()->addHeaders([
+                'Authorization' => 'Bearer ' . $config['key'],
+            ]);
+
+        // Determine the date of (potential) expiration of a member's membership outside the foreach to make sure we
+        // only do it once.
+        $exp = new \DateTime();
+        $exp->setTime(0, 0);
+
+        if ($exp->format('m') >= 7) {
+            $year = (int) $exp->format('Y') + 1;
+        } else {
+            $year = $exp->format('Y');
+        }
+
+        $exp->setDate($year, 7, 1);
+
+        // Check each member that needs to be checked.
+        /** @var \Database\Model\Member $member */
+        foreach ($members as $member) {
+            $this->getEventManager()->trigger(__FUNCTION__ . '.pre', $this, array('member' => $member));
+            $request->setUri($config['endpoint'] . $member->getTuenumber());
+            $response = $client->send($request);
+
+            // Check if the request was successful. If something else happens than 200 or 404 that may have broken the
+            // request, assume that the member is still in the TU/e student administration database but do not update
+            // membership status.
+            if (200 === $response->getStatusCode()) {
+                try {
+                    $responseContent = Json::decode($response->getBody(), Json::TYPE_ARRAY);
+
+                    // Check that we have a proper response.
+                    if (array_key_exists('registrations', $responseContent)) {
+                        // Check if the member is still registered for a study in the department of Mathematics and Computer
+                        // Science & Engineering. If not, update membership type to "graduate" and set date of expiration.
+                        if (!in_array('WIN', array_column($responseContent['registrations'], 'dept'))) {
+                            $member->setChangedOn(new \DateTime());
+                            $member->setMembershipEndsOn($exp);
+                        }
+
+                        $member->setLastCheckedOn(new \DateTime());
+                    }
+                } catch (\RuntimeException $e) {
+                    // The request could not be decoded :/
+                }
+            } else if (404 === $response->getStatusCode()) {
+                // The member cannot be found in the TU/e student administration database.
+                $member->setChangedOn(new \DateTime());
+                $member->setMembershipEndsOn($exp);
+                $member->setLastCheckedOn(new \DateTime());
+            }
+
+            $memberService->getMemberMapper()->persist($member);
+            $this->getEventManager()->trigger(__FUNCTION__ . '.post', $this, array('member' => $member));
+        }
+    }
+
+    /**
+     * Makes sure that members whose membership has end date are actually converted to "graduate" when their membership
+     * has ended.
+     *
+     * @return void
+     */
+    private function checkProperMembershipType()
+    {
+        $memberService = $this->getServiceManager()->get('checker_service_member');
+        $members = $memberService->getEndingMembershipsWithNormalTypes();
+
+        $meetingService = $this->getServiceManager()->get('checker_service_meeting');
+        $lastMeeting = $meetingService->getLastMeeting();
+
+        $installationService = $this->getServiceManager()->get('checker_service_installation');
+        $activeMembers = $installationService->getActiveMembers($lastMeeting);
+
+        $now = (new \DateTime())->setTime(0, 0);
+
+        /** @var \Database\Model\Member $member */
+        foreach ($members as $member) {
+            if ($member->getMembershipEndsOn() <= $now) {
+                $this->getEventManager()->trigger(__FUNCTION__ . '.pre', $this, array('member' => $member));
+
+                if (array_key_exists($member->getLidnr(), $activeMembers)) {
+                    $member->setType(\Database\Model\Member::TYPE_EXTERNAL);
+
+                    // External memberships should run till the end of the current association year.
+                    $exp = new \DateTime();
+                    $exp->setTime(0, 0);
+
+                    if ($exp->format('m') >= 7) {
+                        $year = (int) $exp->format('Y') + 1;
+                    } else {
+                        $year = $exp->format('Y');
+                    }
+                    $exp->setDate($year, 7, 1);
+
+                    $member->setMembershipEndsOn($exp);
+                } else {
+                    // We only have to change the membership type for graduates.
+                    $member->setType(\Database\Model\Member::TYPE_GRADUATE);
+                }
+
+                $member->setChangedOn(new \DateTime());
+
+                $memberService->getMemberMapper()->persist($member);
+                $this->getEventManager()->trigger(__FUNCTION__ . '.post', $this, array('member' => $member));
+            }
+        }
     }
 }

--- a/module/Checker/src/Checker/Service/Installation.php
+++ b/module/Checker/src/Checker/Service/Installation.php
@@ -65,6 +65,34 @@ class Installation extends AbstractService
     }
 
     /**
+     * Get all members who are currently installed in an organ.
+     *
+     * @param \Database\Model\Meeting|null $meeting
+     *
+     * @return array
+     */
+    public function getActiveMembers($meeting)
+    {
+        if (null === $meeting) {
+            return [];
+        }
+
+        $installations = $this->getAllInstallations($meeting);
+
+        $members = [];
+        foreach ($installations as $installation) {
+            $member = $installation->getMember()->getLidnr();
+
+            // Doing checks against the keys is a lot faster, and we do not need a lot of information.
+            if (!array_key_exists($member, $members)) {
+                $members[$member] = '';
+            }
+        }
+
+        return $members;
+    }
+
+    /**
      * Returns a unique hash for a subdecision (Needed for matching subdecisions)
      *
      * @param \Database\Model\SubDecision $d Decision to hash for

--- a/module/Checker/src/Checker/Service/Meeting.php
+++ b/module/Checker/src/Checker/Service/Meeting.php
@@ -22,4 +22,15 @@ class Meeting extends AbstractService
             $meetings
         );
     }
+
+    /**
+     * @return \Database\Model\Meeting|null
+     */
+    public function getLastMeeting()
+    {
+        $databaseServiceMeeting = $this->getServiceManager()->get('database_service_meeting');
+        $meetingMapper = $databaseServiceMeeting->getMeetingMapper();
+
+        return $meetingMapper->findLast();
+    }
 }

--- a/module/Checker/src/Checker/Service/Member.php
+++ b/module/Checker/src/Checker/Service/Member.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Checker\Service;
+
+use Application\Service\AbstractService;
+
+class Member extends AbstractService
+{
+
+    /**
+     * Fetch some members whose membership status should be checked.
+     *
+     * @return array Database\Model\Member
+     */
+    public function getMembersToCheck()
+    {
+        $memberMapper = $this->getServiceManager()->get('checker_mapper_member');
+        $config = $this->getServiceManager()->get('config')['checker']['membership_api'];
+
+        return $memberMapper->getMembersToCheck($config['max_total_requests'] - $config['max_manual_requests']);
+    }
+
+    /**
+     * Get members who may require an adjustment to their membership type (based on whether their membership has ended).
+     *
+     * @return array
+     */
+    public function getEndingMembershipsWithNormalTypes()
+    {
+        $memberMapper = $this->getServiceManager()->get('checker_mapper_member');
+
+        return $memberMapper->getEndingMembershipsWithNormalTypes();
+    }
+
+    /**
+     * @return \Checker\Mapper\Member
+     */
+    public function getMemberMapper()
+    {
+        return $this->getServiceManager()->get('checker_mapper_member');
+    }
+}

--- a/module/Database/Module.php
+++ b/module/Database/Module.php
@@ -111,6 +111,9 @@ class Module
                     $form->setHydrator($sm->get('database_hydrator_member'));
                     return $form;
                 },
+                'database_form_memberexpiration' => function ($sm) {
+                    return new \Database\Form\MemberExpiration();
+                },
                 'database_form_membertype' => function ($sm) {
                     $form = new \Database\Form\MemberType();
                     $form->setHydrator($sm->get('database_hydrator_member'));

--- a/module/Database/config/module.config.php
+++ b/module/Database/config/module.config.php
@@ -239,6 +239,15 @@ return array(
                                                 'action' => 'lists'
                                             )
                                         )
+                                    ),
+                                    'expiration' => array(
+                                        'type' => 'Literal',
+                                        'options' => array(
+                                            'route' => '/expiration',
+                                            'defaults' => array(
+                                                'action' => 'expiration'
+                                            )
+                                        )
                                     )
                                 )
                             ),

--- a/module/Database/src/Database/Controller/MemberController.php
+++ b/module/Database/src/Database/Controller/MemberController.php
@@ -204,6 +204,30 @@ class MemberController extends AbstractActionController
     }
 
     /**
+     * Expiration action.
+     *
+     * Extend the duration of the membership.
+     */
+    public function expirationAction()
+    {
+        $lidnr = $this->params()->fromRoute('id');
+        $service = $this->getMemberService();
+
+        if ($this->getRequest()->isPost()) {
+            $member = $service->expiration($this->getRequest()->getPost(), $lidnr);
+
+            if (null !== $member) {
+                return new ViewModel(array(
+                    'success' => true,
+                    'member' => $member
+                ));
+            }
+        }
+
+        return new ViewModel($service->getMemberExpirationForm($lidnr));
+    }
+
+    /**
      * Edit address action.
      *
      * Edit a member's address.

--- a/module/Database/src/Database/Controller/ProspectiveMemberController.php
+++ b/module/Database/src/Database/Controller/ProspectiveMemberController.php
@@ -59,18 +59,20 @@ class ProspectiveMemberController extends AbstractActionController
      */
     public function finalizeAction()
     {
-        $service = $this->getMemberService();
-        $prospectiveMember = $service->getProspectiveMember($this->params()->fromRoute('id'))['member'];
-        $result = $service->finalizeSubscription($prospectiveMember);
-        if (is_null($result)) {
-            // TODO: Fails silently currently
-            return $this->redirect()->toRoute('prospective-member/show', [
-                'id' => $this->params()->fromRoute('id')
-            ]);
+        if ($this->getRequest()->isPost()) {
+            $service = $this->getMemberService();
+            $prospectiveMember = $service->getProspectiveMember($this->params()->fromRoute('id'))['member'];
+            $result = $service->finalizeSubscription($this->getRequest()->getPost()->toArray(), $prospectiveMember);
+
+            if (null !== $result) {
+                return $this->redirect()->toRoute('member/show', [
+                    'id' => $result->getLidnr()
+                ]);
+            }
         }
 
-        return $this->redirect()->toRoute('member/show', [
-            'id' => $result->getLidnr()
+        return $this->redirect()->toRoute('prospective-member/show', [
+            'id' => $this->params()->fromRoute('id')
         ]);
     }
 

--- a/module/Database/src/Database/Form/Member.php
+++ b/module/Database/src/Database/Form/Member.php
@@ -73,10 +73,10 @@ class Member extends Form implements InputFilterProviderInterface
         ));
 
         $this->add(array(
-            'name' => 'tuenumber',
-            'type' => 'number',
+            'name' => 'tueUsername',
+            'type' => 'text',
             'options' => array(
-                'label' => $translator->translate('TU/e nummer')
+                'label' => $translator->translate('TU/e-gebruikersnaam')
             )
         ));
 
@@ -289,10 +289,21 @@ class Member extends Form implements InputFilterProviderInterface
                     )
                 )
             ),
-            'tuenumber' => array(
+            'tueUsername' => array(
                 'required' => false,
                 'validators' => array(
-                    array('name' => 'digits')
+                    array(
+                        'name' => 'regex',
+                        'options' => array(
+                            'pattern' => '/^(s\d{6}|\d{8})$/',
+                            'messages' => array(
+                                'regexNotMatch' => $this->translator->translate('Je TU/e-gebruikersnaam ziet er uit als sXXXXXX of als YYYYXXXX.')
+                            )
+                        )
+                    )
+                ),
+                'filters' => array(
+                    array('name' => 'tonull')
                 )
             )
         );

--- a/module/Database/src/Database/Form/MemberEdit.php
+++ b/module/Database/src/Database/Form/MemberEdit.php
@@ -59,6 +59,14 @@ class MemberEdit extends Form implements InputFilterProviderInterface
         ));
 
         $this->add(array(
+            'name' => 'tuenumber',
+            'type' => 'number',
+            'options' => array(
+                'label' => 'TU/e nummer'
+            )
+        ));
+
+        $this->add(array(
             'name' => 'email',
             'type' => 'email',
             'options' => array(
@@ -147,6 +155,12 @@ class MemberEdit extends Form implements InputFilterProviderInterface
             ),
             'paid' => array(
                 'required' => true,
+                'validators' => array(
+                    array('name' => 'digits')
+                )
+            ),
+            'tuenumber' => array(
+                'required' => false,
                 'validators' => array(
                     array('name' => 'digits')
                 )

--- a/module/Database/src/Database/Form/MemberEdit.php
+++ b/module/Database/src/Database/Form/MemberEdit.php
@@ -59,10 +59,10 @@ class MemberEdit extends Form implements InputFilterProviderInterface
         ));
 
         $this->add(array(
-            'name' => 'tuenumber',
-            'type' => 'number',
+            'name' => 'tueUsername',
+            'type' => 'text',
             'options' => array(
-                'label' => 'TU/e nummer'
+                'label' => 'TU/e-gebruikersnaam'
             )
         ));
 
@@ -159,10 +159,21 @@ class MemberEdit extends Form implements InputFilterProviderInterface
                     array('name' => 'digits')
                 )
             ),
-            'tuenumber' => array(
+            'tueUsername' => array(
                 'required' => false,
                 'validators' => array(
-                    array('name' => 'digits')
+                    array(
+                        'name' => 'regex',
+                        'options' => array(
+                            'pattern' => '/^(s\d{6}|\d{8})$/',
+                            'messages' => array(
+                                'regexNotMatch' => 'Een TU/e-gebruikersnaam ziet er uit als sXXXXXX of als YYYYXXXX.'
+                            )
+                        )
+                    )
+                ),
+                'filters' => array(
+                    array('name' => 'tonull')
                 )
             )
         );

--- a/module/Database/src/Database/Form/MemberExpiration.php
+++ b/module/Database/src/Database/Form/MemberExpiration.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Form;
+
+use Zend\Form\Form;
+use Zend\InputFilter\InputFilterProviderInterface;
+
+class MemberExpiration extends Form implements InputFilterProviderInterface
+{
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->add(array(
+            'name' => 'submit_yes',
+            'type' => 'submit',
+            'attributes' => array(
+                'value' => 'Ja'
+            )
+        ));
+
+        $this->add(array(
+            'name' => 'submit_no',
+            'type' => 'submit',
+            'attributes' => array(
+                'value' => 'Nee'
+            )
+        ));
+    }
+
+    public function getInputFilterSpecification()
+    {
+        return array(
+            'submit_yes' => array(
+                'required' => true
+            )
+        );
+    }
+}

--- a/module/Database/src/Database/Form/MemberType.php
+++ b/module/Database/src/Database/Form/MemberType.php
@@ -21,11 +21,10 @@ class MemberType extends Form implements InputFilterProviderInterface
             'options' => array(
                 'label' => 'Lidmaatschapstype',
                 'value_options' => array(
-                    Member::TYPE_ORDINARY => 'Gewoon - Ingeschreven bij faculteit W&I',
-                    Member::TYPE_PROLONGED => 'Geprolongeerd - Verlengd ingeschreven bij faculteit W&I',
-                    Member::TYPE_EXTERNAL => 'Extern - Was gewoon lid, maar is niet meer ingeschreven bij W&I',
-                    Member::TYPE_EXTRAORDINARY => 'Buitengewoon - Speciaal toegelaten door bestuur',
-                    Member::TYPE_HONORARY => 'Erelid'
+                    Member::TYPE_ORDINARY => 'Gewoon lid - Ingeschreven bij faculteit M&CS',
+                    Member::TYPE_EXTERNAL => 'Extern lid - Speciaal toegelaten door het bestuur',
+                    Member::TYPE_GRADUATE => 'Afgestudeerde - Was lid en is speciaal toegelaten door het bestuur',
+                    Member::TYPE_HONORARY => 'Erelid - Speciaal benoemd door de ALV'
                 )
             )
         ));

--- a/module/Database/src/Database/Form/MemberType.php
+++ b/module/Database/src/Database/Form/MemberType.php
@@ -44,6 +44,9 @@ class MemberType extends Form implements InputFilterProviderInterface
     public function getInputFilterSpecification()
     {
         return array(
+            'type' => array(
+                'required' => true
+            )
         );
     }
 }

--- a/module/Database/src/Database/Mapper/Meeting.php
+++ b/module/Database/src/Database/Mapper/Meeting.php
@@ -69,6 +69,23 @@ class Meeting
     }
 
     /**
+     * Find the last meeting.
+     *
+     * @return MeetingModel|null
+     */
+    public function findLast()
+    {
+        $qb = $this->em->createQueryBuilder();
+        $qb->select('m')
+            ->from('Database\Model\Meeting', 'm')
+            ->leftJoin('m.decisions', 'd')
+            ->orderBy('m.date', 'DESC')
+            ->setMaxResults(1);
+
+        return $qb->getQuery()->getOneOrNullResult();
+    }
+
+    /**
      * Find decisions by given meetings.
      *
      * @param array $meetings

--- a/module/Database/src/Database/Model/Member.php
+++ b/module/Database/src/Database/Model/Member.php
@@ -18,9 +18,8 @@ class Member
     const GENDER_OTHER = 'o';
 
     const TYPE_ORDINARY = 'ordinary';
-    const TYPE_PROLONGED = 'prolonged';
     const TYPE_EXTERNAL = 'external';
-    const TYPE_EXTRAORDINARY = 'extraordinary';
+    const TYPE_GRADUATE = 'graduate';
     const TYPE_HONORARY = 'honorary';
 
     /**
@@ -108,16 +107,13 @@ class Member
      * This can be one of the following, as defined by the GEWIS statuten:
      *
      * - ordinary
-     * - prolonged
      * - external
-     * - extraordinary
+     * - graduate
      * - honorary
      *
-     * You can find the GEWIS Statuten here:
+     * You can find the GEWIS statuten here: https://gewis.nl/vereniging/statuten/statuten.
      *
-     * http://gewis.nl/vereniging/statuten/statuten.php
-     *
-     * Zie artikel 7 lid 1 en 2.
+     * See artikel 7.
      *
      * @ORM\Column(type="string")
      */
@@ -206,9 +202,8 @@ class Member
     {
         return array(
             self::TYPE_ORDINARY,
-            self::TYPE_PROLONGED,
             self::TYPE_EXTERNAL,
-            self::TYPE_EXTRAORDINARY,
+            self::TYPE_GRADUATE,
             self::TYPE_HONORARY
         );
     }
@@ -482,20 +477,16 @@ class Member
     {
         $exp = clone $this->getChangedOn();
         switch ($this->getType()) {
-        case self::TYPE_ORDINARY:
-            // 6 years
-            $exp->add(new \DateInterval('P6Y'));
-            break;
-        case self::TYPE_PROLONGED:
-        case self::TYPE_EXTERNAL:
-        case self::TYPE_EXTRAORDINARY:
-            $exp->add(new \DateInterval('P1Y'));
-            // 1 year
-            break;
-        case self::TYPE_HONORARY:
-            // infinity (1000 is close enough, right?)
-            $exp->add(new \DateInterval('P1000Y'));
-            break;
+            case self::TYPE_ORDINARY:
+            case self::TYPE_EXTERNAL:
+            case self::TYPE_GRADUATE:
+                $exp->add(new \DateInterval('P1Y'));
+                // 1 year
+                break;
+            case self::TYPE_HONORARY:
+                // infinity (1000 is close enough, right?)
+                $exp->add(new \DateInterval('P1000Y'));
+                break;
         }
         return $exp;
     }

--- a/module/Database/src/Database/Model/Member.php
+++ b/module/Database/src/Database/Model/Member.php
@@ -133,7 +133,14 @@ class Member
      *
      * @ORM\Column(type="date", nullable=true)
      */
-    protected $membershipEndsOn;
+    protected $membershipEndsOn = null;
+
+    /**
+     * Last date membership status was checked.
+     *
+     * @ORM\Column(type="date", nullable=true)
+     */
+    protected $lastCheckedOn = null;
 
     /**
      * Member birth date.
@@ -578,6 +585,26 @@ class Member
     public function setMembershipEndsOn($membershipEndsOn)
     {
         $this->membershipEndsOn = $membershipEndsOn;
+    }
+
+    /**
+     * Get the date of when the membership status was last checked.
+     *
+     * @return \DateTime
+     */
+    public function getLastCheckedOn()
+    {
+        return $this->lastCheckedOn;
+    }
+
+    /**
+     * Set the date of when the membership status was last checked.
+     *
+     * @param \DateTime $lastCheckedOn
+     */
+    public function setLastCheckedOn($lastCheckedOn)
+    {
+        $this->lastCheckedOn = $lastCheckedOn;
     }
 
     /**

--- a/module/Database/src/Database/Model/Member.php
+++ b/module/Database/src/Database/Model/Member.php
@@ -88,11 +88,11 @@ class Member
     protected $generation;
 
     /**
-     * TU/e registration number.
+     * TU/e username.
      *
-     * @ORM\Column(type="integer",nullable=true)
+     * @ORM\Column(type="string", nullable=true)
      */
-    protected $tuenumber;
+    protected $tueUsername;
 
     /**
      * Study of the member.
@@ -418,23 +418,23 @@ class Member
     }
 
     /**
-     * Get the TU/e registration number.
+     * Get the TU/e username.
      *
-     * @return int
+     * @return string|null
      */
-    public function getTuenumber()
+    public function getTueUsername()
     {
-        return $this->tuenumber;
+        return $this->tueUsername;
     }
 
     /**
-     * Set the TU/e registration number.
+     * Set the TU/e username.
      *
-     * @param int $tuenumber
+     * @param string|null $tueUsername
      */
-    public function setTuenumber($tuenumber)
+    public function setTueUsername($tueUsername)
     {
-        $this->tuenumber = $tuenumber;
+        $this->tueUsername = $tueUsername;
     }
 
     /**

--- a/module/Database/src/Database/Model/Member.php
+++ b/module/Database/src/Database/Model/Member.php
@@ -127,6 +127,14 @@ class Member
     protected $changedOn;
 
     /**
+     * Keeps track of whether a student is still studying (either at the Department of Mathematics and Computer Science,
+     * the TU/e in general, or another institution).
+     *
+     * @ORM\Column(type="boolean")
+     */
+    protected $isStudying;
+
+    /**
      * Date when the real membership ("ordinary" or "external") of the member will have ended, in other words, from this
      * date onwards they are "graduate". If `null`, the expiration is rolling and will be silently renewed if the member
      * still meets the requirements as set forth in the bylaws and internal regulations.
@@ -550,6 +558,26 @@ class Member
     public function setChangedOn($changedOn)
     {
         $this->changedOn = $changedOn;
+    }
+
+    /**
+     * Get whether the member is still studying.
+     *
+     * @return \bool
+     */
+    public function getIsStudying()
+    {
+        return $this->isStudying;
+    }
+
+    /**
+     * Set whether the member is still studying.
+     *
+     * @param bool $isStudying
+     */
+    public function setIsStudying($isStudying)
+    {
+        $this->isStudying = $isStudying;
     }
 
     /**

--- a/module/Database/src/Database/Model/Member.php
+++ b/module/Database/src/Database/Model/Member.php
@@ -127,6 +127,15 @@ class Member
     protected $changedOn;
 
     /**
+     * Date when the real membership ("ordinary" or "external") of the member will have ended, in other words, from this
+     * date onwards they are "graduate". If `null`, the expiration is rolling and will be the end of the current
+     * association year.
+     *
+     * @ORM\Column(type="date", nullable=true)
+     */
+    protected $membershipEndsOn;
+
+    /**
      * Member birth date.
      *
      * @ORM\Column(type="date")
@@ -467,27 +476,47 @@ class Member
     }
 
     /**
-     * Get the expiration date.
+     * Get the date on which the member's membership will expire and has to be renewed.
      *
      * The information comes from the statuten and HR.
      *
-     * @return \DateTime
+     * @return \DateTime|null
+     * @throws \Exception
      */
     public function getExpiration()
     {
-        $exp = clone $this->getChangedOn();
+        // At the end of the current association year (unless...).
+        $exp = new \DateTime();
+        $exp->setTime(0, 0);
+
+        if ($exp->format('m') >= 7) {
+            $year = (int) $exp->format('Y') + 1;
+        } else {
+            $year = $exp->format('Y');
+        }
+
         switch ($this->getType()) {
             case self::TYPE_ORDINARY:
             case self::TYPE_EXTERNAL:
             case self::TYPE_GRADUATE:
-                $exp->add(new \DateInterval('P1Y'));
-                // 1 year
+                // If the membership ends within this association year, set expiration to an additional year. This
+                // accounts for expiration of their original membership and their new one.
+                if (null !== ($membershipEndsOn = $this->getMembershipEndsOn())) {
+                    if ($membershipEndsOn->format('Y') >= $year) {
+                        $year += 1;
+                    }
+                }
+
                 break;
             case self::TYPE_HONORARY:
                 // infinity (1000 is close enough, right?)
-                $exp->add(new \DateInterval('P1000Y'));
+                $year += 1000;
                 break;
         }
+
+        // At the end of the current association year.
+        $exp->setDate($year, 7, 1);
+
         return $exp;
     }
 
@@ -529,6 +558,26 @@ class Member
     public function setChangedOn($changedOn)
     {
         $this->changedOn = $changedOn;
+    }
+
+    /**
+     * Get the date on which the membership of the member will have ended (i.e., they have become "graduate").
+     *
+     * @return \DateTime|null
+     */
+    public function getMembershipEndsOn()
+    {
+        return $this->membershipEndsOn;
+    }
+
+    /**
+     * Set the date on which the membership of the member will have ended (i.e., they have become "graduate").
+     *
+     * @param \DateTime|null $membershipEndsOn
+     */
+    public function setMembershipEndsOn($membershipEndsOn)
+    {
+        $this->membershipEndsOn = $membershipEndsOn;
     }
 
     /**

--- a/module/Database/src/Database/Model/Member.php
+++ b/module/Database/src/Database/Model/Member.php
@@ -128,12 +128,20 @@ class Member
 
     /**
      * Date when the real membership ("ordinary" or "external") of the member will have ended, in other words, from this
-     * date onwards they are "graduate". If `null`, the expiration is rolling and will be the end of the current
-     * association year.
+     * date onwards they are "graduate". If `null`, the expiration is rolling and will be silently renewed if the member
+     * still meets the requirements as set forth in the bylaws and internal regulations.
      *
      * @ORM\Column(type="date", nullable=true)
      */
     protected $membershipEndsOn = null;
+
+    /**
+     * The date on which the membership of the member is set to expire and will therefore have to be renewed, which
+     * happens either automatically or has to be done manually, as set forth in the bylaws and internal regulations.
+     *
+     * @ORM\Column(type="date")
+     */
+    protected $expiration;
 
     /**
      * Last date membership status was checked.
@@ -483,49 +491,25 @@ class Member
     }
 
     /**
-     * Get the date on which the membership of the member is set to expire and will therefore have to be renewed, which
-     * happens either automatically or has to be done manually.
+     * Get the expiration date.
      *
-     * The information comes from the statuten and HR.
-     *
-     * @return \DateTime|null
-     * @throws \Exception
+     * @return \DateTime
      */
     public function getExpiration()
     {
-        // At the end of the current association year (unless...).
-        $exp = new \DateTime();
-        $exp->setTime(0, 0);
+        return $this->expiration;
+    }
 
-        if ($exp->format('m') >= 7) {
-            $year = (int) $exp->format('Y') + 1;
-        } else {
-            $year = $exp->format('Y');
-        }
-
-        switch ($this->getType()) {
-            case self::TYPE_ORDINARY:
-            case self::TYPE_EXTERNAL:
-            case self::TYPE_GRADUATE:
-                // If the membership ends within this association year, set expiration to an additional year. This
-                // accounts for expiration of their original membership and their new one.
-                if (null !== ($membershipEndsOn = $this->getMembershipEndsOn())) {
-                    if ($membershipEndsOn->format('Y') >= $year) {
-                        $year += 1;
-                    }
-                }
-
-                break;
-            case self::TYPE_HONORARY:
-                // infinity (1000 is close enough, right?)
-                $year += 1000;
-                break;
-        }
-
-        // At the end of the current association year.
-        $exp->setDate($year, 7, 1);
-
-        return $exp;
+    /**
+     * Set the expiration date.
+     *
+     * @param \DateTime $expiration
+     *
+     * @return void
+     */
+    public function setExpiration(\DateTime $expiration)
+    {
+        $this->expiration = $expiration;
     }
 
     /**

--- a/module/Database/src/Database/Model/Member.php
+++ b/module/Database/src/Database/Model/Member.php
@@ -483,7 +483,8 @@ class Member
     }
 
     /**
-     * Get the date on which the member's membership will expire and has to be renewed.
+     * Get the date on which the membership of the member is set to expire and will therefore have to be renewed, which
+     * happens either automatically or has to be done manually.
      *
      * The information comes from the statuten and HR.
      *

--- a/module/Database/src/Database/Model/ProspectiveMember.php
+++ b/module/Database/src/Database/Model/ProspectiveMember.php
@@ -512,7 +512,8 @@ class ProspectiveMember
     }
 
     /**
-     * Get the date on which the member's membership will expire and has to be renewed.
+     * Get the date on which the membership of the member is set to expire and will therefore have to be renewed, which
+     * happens either automatically or has to be done manually.
      *
      * The information comes from the statuten and HR.
      *

--- a/module/Database/src/Database/Model/ProspectiveMember.php
+++ b/module/Database/src/Database/Model/ProspectiveMember.php
@@ -133,7 +133,7 @@ class ProspectiveMember
      *
      * @ORM\Column(type="date", nullable=true)
      */
-    protected $membershipEndsOn;
+    protected $membershipEndsOn = null;
 
     /**
      * Member birth date.

--- a/module/Database/src/Database/Model/ProspectiveMember.php
+++ b/module/Database/src/Database/Model/ProspectiveMember.php
@@ -88,11 +88,11 @@ class ProspectiveMember
     protected $generation;
 
     /**
-     * TU/e registration number.
+     * TU/e username.
      *
-     * @ORM\Column(type="integer",nullable=true)
+     * @ORM\Column(type="string", nullable=true)
      */
-    protected $tuenumber;
+    protected $tueUsername;
 
     /**
      * Study of the member.
@@ -447,23 +447,23 @@ class ProspectiveMember
     }
 
     /**
-     * Get the TU/e registration number.
+     * Get the TU/e username.
      *
-     * @return int
+     * @return string|null
      */
-    public function getTuenumber()
+    public function getTueUsername()
     {
-        return $this->tuenumber;
+        return $this->tueUsername;
     }
 
     /**
-     * Set the TU/e registration number.
+     * Set the TU/e username.
      *
-     * @param int $tuenumber
+     * @param string|null $tueUsername
      */
-    public function setTuenumber($tuenumber)
+    public function setTueUsername($tueUsername)
     {
-        $this->tuenumber = $tuenumber;
+        $this->tueUsername = $tueUsername;
     }
 
     /**

--- a/module/Database/src/Database/Model/ProspectiveMember.php
+++ b/module/Database/src/Database/Model/ProspectiveMember.php
@@ -78,16 +78,6 @@ class ProspectiveMember
     protected $gender;
 
     /**
-     * Generation.
-     *
-     * This is the year that this member became a GEWIS member. This is not
-     * a academic year, but rather a calendar year.
-     *
-     * @ORM\Column(type="integer")
-     */
-    protected $generation;
-
-    /**
      * TU/e username.
      *
      * @ORM\Column(type="string", nullable=true)
@@ -125,23 +115,6 @@ class ProspectiveMember
      * @ORM\Column(type="date")
      */
     protected $changedOn;
-
-    /**
-     * Date when the real membership ("ordinary" or "external") of the member will have ended, in other words, from this
-     * date onwards they are "graduate". If `null`, the expiration is rolling and will be silently renewed if the member
-     * still meets the requirements as set forth in the bylaws and internal regulations.
-     *
-     * @ORM\Column(type="date", nullable=true)
-     */
-    protected $membershipEndsOn = null;
-
-    /**
-     * The date on which the membership of the member is set to expire and will therefore have to be renewed, which
-     * happens either automatically or has to be done manually, as set forth in the bylaws and internal regulations.
-     *
-     * @ORM\Column(type="date")
-     */
-    protected $expiration;
 
     /**
      * Member birth date.
@@ -435,26 +408,6 @@ class ProspectiveMember
     }
 
     /**
-     * Get the generation.
-     *
-     * @return string
-     */
-    public function getGeneration()
-    {
-        return $this->generation;
-    }
-
-    /**
-     * Set the generation.
-     *
-     * @param string $generation
-     */
-    public function setGeneration($generation)
-    {
-        $this->generation = $generation;
-    }
-
-    /**
      * Get the TU/e username.
      *
      * @return string|null
@@ -520,28 +473,6 @@ class ProspectiveMember
     }
 
     /**
-     * Get the expiration date.
-     *
-     * @return \DateTime
-     */
-    public function getExpiration()
-    {
-        return $this->expiration;
-    }
-
-    /**
-     * Set the expiration date.
-     *
-     * @param \DateTime $expiration
-     *
-     * @return void
-     */
-    public function setExpiration(\DateTime $expiration)
-    {
-        $this->expiration = $expiration;
-    }
-
-    /**
      * Get the birth date.
      *
      * @return \DateTime
@@ -579,26 +510,6 @@ class ProspectiveMember
     public function setChangedOn($changedOn)
     {
         $this->changedOn = $changedOn;
-    }
-
-    /**
-     * Get the date on which the membership of the member will have ended (i.e., they have become "graduate").
-     *
-     * @return \DateTime|null
-     */
-    public function getMembershipEndsOn()
-    {
-        return $this->membershipEndsOn;
-    }
-
-    /**
-     * Set the date on which the membership of the member will have ended (i.e., they have become "graduate").
-     *
-     * @param \DateTime|null $membershipEndsOn
-     */
-    public function setMembershipEndsOn($membershipEndsOn)
-    {
-        $this->membershipEndsOn = $membershipEndsOn;
     }
 
     /**
@@ -726,8 +637,6 @@ class ProspectiveMember
             'middleName' => $this->getMiddleName(),
             'initials' => $this->getInitials(),
             'firstName' => $this->getFirstName(),
-            'generation' => $this->getGeneration(),
-            'expiration' => $this->getExpiration()->format('l j F Y'),
             'gender' => $this->getGender(),
             'study' => $this->getStudy(),
             'birth' => $this->getBirth()->format('Y-m-d'),

--- a/module/Database/src/Database/Model/ProspectiveMember.php
+++ b/module/Database/src/Database/Model/ProspectiveMember.php
@@ -18,9 +18,8 @@ class ProspectiveMember
     const GENDER_OTHER = 'o';
 
     const TYPE_ORDINARY = 'ordinary';
-    const TYPE_PROLONGED = 'prolonged';
     const TYPE_EXTERNAL = 'external';
-    const TYPE_EXTRAORDINARY = 'extraordinary';
+    const TYPE_GRADUATE = 'graduate';
     const TYPE_HONORARY = 'honorary';
 
     /**
@@ -108,16 +107,13 @@ class ProspectiveMember
      * This can be one of the following, as defined by the GEWIS statuten:
      *
      * - ordinary
-     * - prolonged
      * - external
-     * - extraordinary
+     * - graduate
      * - honorary
      *
-     * You can find the GEWIS Statuten here:
+     * You can find the GEWIS statuten here: https://gewis.nl/vereniging/statuten/statuten.
      *
-     * http://gewis.nl/vereniging/statuten/statuten.php
-     *
-     * Zie artikel 7 lid 1 en 2.
+     * See artikel 7.
      *
      * @ORM\Column(type="string")
      */
@@ -243,9 +239,8 @@ class ProspectiveMember
     {
         return array(
             self::TYPE_ORDINARY,
-            self::TYPE_PROLONGED,
             self::TYPE_EXTERNAL,
-            self::TYPE_EXTRAORDINARY,
+            self::TYPE_GRADUATE,
             self::TYPE_HONORARY
         );
     }
@@ -518,20 +513,16 @@ class ProspectiveMember
     {
         $exp = clone $this->getChangedOn();
         switch ($this->getType()) {
-        case self::TYPE_ORDINARY:
-            // 6 years
-            $exp->add(new \DateInterval('P6Y'));
-            break;
-        case self::TYPE_PROLONGED:
-        case self::TYPE_EXTERNAL:
-        case self::TYPE_EXTRAORDINARY:
-            $exp->add(new \DateInterval('P1Y'));
-            // 1 year
-            break;
-        case self::TYPE_HONORARY:
-            // infinity (1000 is close enough, right?)
-            $exp->add(new \DateInterval('P1000Y'));
-            break;
+            case self::TYPE_ORDINARY:
+            case self::TYPE_EXTERNAL:
+            case self::TYPE_GRADUATE:
+                $exp->add(new \DateInterval('P1Y'));
+                // 1 year
+                break;
+            case self::TYPE_HONORARY:
+                // infinity (1000 is close enough, right?)
+                $exp->add(new \DateInterval('P1000Y'));
+                break;
         }
         return $exp;
     }

--- a/module/Database/src/Database/Model/ProspectiveMember.php
+++ b/module/Database/src/Database/Model/ProspectiveMember.php
@@ -128,12 +128,20 @@ class ProspectiveMember
 
     /**
      * Date when the real membership ("ordinary" or "external") of the member will have ended, in other words, from this
-     * date onwards they are "graduate". If `null`, the expiration is rolling and will be the end of the current
-     * association year.
+     * date onwards they are "graduate". If `null`, the expiration is rolling and will be silently renewed if the member
+     * still meets the requirements as set forth in the bylaws and internal regulations.
      *
      * @ORM\Column(type="date", nullable=true)
      */
     protected $membershipEndsOn = null;
+
+    /**
+     * The date on which the membership of the member is set to expire and will therefore have to be renewed, which
+     * happens either automatically or has to be done manually, as set forth in the bylaws and internal regulations.
+     *
+     * @ORM\Column(type="date")
+     */
+    protected $expiration;
 
     /**
      * Member birth date.
@@ -512,54 +520,25 @@ class ProspectiveMember
     }
 
     /**
-     * Get the date on which the membership of the member is set to expire and will therefore have to be renewed, which
-     * happens either automatically or has to be done manually.
+     * Get the expiration date.
      *
-     * The information comes from the statuten and HR.
-     *
-     * @return \DateTime|null
-     * @throws \Exception
+     * @return \DateTime
      */
     public function getExpiration()
     {
-        // At the end of the current association year (unless...).
-        $exp = new \DateTime();
-        $exp->setTime(0, 0);
+        return $this->expiration;
+    }
 
-        if ($exp->format('m') >= 7) {
-            $year = (int) $exp->format('Y') + 1;
-        } else {
-            $year = $exp->format('Y');
-        }
-
-        switch ($this->getType()) {
-            case self::TYPE_ORDINARY:
-            case self::TYPE_EXTERNAL:
-                // No changes needed.
-                break;
-            case self::TYPE_GRADUATE:
-                if (null === $this->getMembershipEndsOn()) {
-                    throw new \Exception('Graduates must have a `membershipEndsOn` set.');
-                }
-
-                // If the membership ends within this association year, set expiration to an additional year. This
-                // accounts for expiration of their original membership and their new one.
-                $membershipEndsOn = $this->getMembershipEndsOn();
-                if ($membershipEndsOn->format('Y') >= $year) {
-                    $year += 1;
-                }
-
-                break;
-            case self::TYPE_HONORARY:
-                // infinity (1000 is close enough, right?)
-                $year += 1000;
-                break;
-        }
-
-        // At the end of the current association year.
-        $exp->setDate($year, 7, 1);
-
-        return $exp;
+    /**
+     * Set the expiration date.
+     *
+     * @param \DateTime $expiration
+     *
+     * @return void
+     */
+    public function setExpiration(\DateTime $expiration)
+    {
+        $this->expiration = $expiration;
     }
 
     /**

--- a/module/Database/src/Database/Model/SubDecision/Board/Installation.php
+++ b/module/Database/src/Database/Model/SubDecision/Board/Installation.php
@@ -26,8 +26,8 @@ class Installation extends SubDecision
      * Member.
      *
      * Note that only members that are older than 18 years can be board members.
-     * Also, honorary, external and extraordinary members cannot be board members.
-     * (See the Statuten, Art. 13 Lid 2.
+     * Also, honorary members cannot be board members.
+     * (See the Statuten, Art. 13A Lid 2.
      *
      * @todo Inversed relation
      *

--- a/module/Database/src/Database/Service/Member.php
+++ b/module/Database/src/Database/Service/Member.php
@@ -80,9 +80,6 @@ class Member extends AbstractService
             return null;
         }
 
-        // generation is the current year
-        $prospectiveMember->setGeneration((int) date('Y'));
-
         // by default, we only add ordinary members
         $prospectiveMember->setType(MemberModel::TYPE_ORDINARY);
 
@@ -90,18 +87,6 @@ class Member extends AbstractService
         $date = new \DateTime();
         $date->setTime(0, 0);
         $prospectiveMember->setChangedOn($date);
-
-        // set expiration of membership, always at the end of the current association year.
-        $expiration = clone $date;
-
-        if ($expiration->format('m') >= 7) {
-            $year = (int) $expiration->format('Y') + 1;
-        } else {
-            $year = (int) $expiration->format('Y');
-        }
-
-        $expiration->setDate($year, 7, 1);
-        $prospectiveMember->setExpiration($expiration);
 
         // store the address
         $address = $form->get('studentAddress')->getObject();
@@ -227,14 +212,28 @@ class Member extends AbstractService
 
         // Copy all remaining information
         $member->setTueUsername($prospectiveMember->getTueUsername());
-        $member->setGeneration($prospectiveMember->getGeneration());
         $member->setType($prospectiveMember->getType());
-        $member->setExpiration($prospectiveMember->getExpiration());
 
         // changed on date
         $date = new \DateTime();
         $date->setTime(0, 0);
         $member->setChangedOn($date);
+
+        // set generation (first year of the current association year) and expiration of the membership (always at the
+        // end of the current association year).
+        $expiration = clone $date;
+
+        if ($expiration->format('m') >= 7) {
+            $generationYear = (int) $expiration->format('Y');
+            $expirationYear = (int) $expiration->format('Y') + 1;
+        } else {
+            $generationYear = (int) $expiration->format('Y') - 1;
+            $expirationYear = (int) $expiration->format('Y');
+        }
+
+        $expiration->setDate($expirationYear, 7, 1);
+        $member->setExpiration($expiration);
+        $member->setGeneration($generationYear);
 
         // add mailing lists
         foreach ($form->getLists() as $list) {

--- a/module/Database/src/Database/Service/Member.php
+++ b/module/Database/src/Database/Service/Member.php
@@ -450,14 +450,14 @@ class Member extends AbstractService
         $date->setTime(0, 0);
         $member->setChangedOn($date);
 
-        // update expiration and 'membership ends on' date
-        // TODO: Figure out what exactly to do (retroactively, direct, or future).
+        // update expiration and 'membership ends on' date (should become effective at the end of the current
+        // association year).
         $expiration = clone $date;
 
         if ($expiration->format('m') >= 7) {
-            $year = (int) $expiration->format('Y') + 1;
+            $year = (int) $expiration->format('Y') + 2;
         } else {
-            $year = (int) $expiration->format('Y');
+            $year = (int) $expiration->format('Y') + 1;
         }
 
         switch ($member->getType()) {

--- a/module/Database/src/Database/Service/Member.php
+++ b/module/Database/src/Database/Service/Member.php
@@ -44,13 +44,13 @@ class Member extends AbstractService
         if (isset($data['studentAddress']) && isset($data['studentAddress']['street']) && !empty($data['studentAddress']['street'])) {
             $form->setValidationGroup(array(
                 'lastName', 'middleName', 'initials', 'firstName',
-                'gender', 'tuenumber', 'study', 'email', 'birth',
+                'gender', 'tueUsername', 'study', 'email', 'birth',
                 'studentAddress', 'agreed', 'iban', 'signature', 'signatureLocation'
             ));
         } else {
             $form->setValidationGroup(array(
                 'lastName', 'middleName', 'initials', 'firstName',
-                'gender', 'tuenumber', 'study', 'email', 'birth',
+                'gender', 'tueUsername', 'study', 'email', 'birth',
                 'agreed', 'iban', 'signature', 'signatureLocation'
             ));
         }
@@ -78,10 +78,6 @@ class Member extends AbstractService
                 'There already is a member with this email address.'
             ]);
             return null;
-        }
-
-        if (!is_numeric($prospectiveMember->getTuenumber())) {
-            $prospectiveMember->setTuenumber(0);
         }
 
         // generation is the current year
@@ -218,7 +214,7 @@ class Member extends AbstractService
         }
 
         // Copy all remaining information
-        $member->setTuenumber($prospectiveMember->getTuenumber());
+        $member->setTueUsername($prospectiveMember->getTueUsername());
         $member->setGeneration($prospectiveMember->getGeneration());
         $member->setType($prospectiveMember->getType());
 
@@ -368,7 +364,7 @@ class Member extends AbstractService
         $member->setEmail('');
         $member->setGender(MemberModel::GENDER_OTHER);
         $member->setGeneration(0);
-        $member->setTuenumber(null);
+        $member->setTueUsername(null);
         $member->setStudy(null);
         $member->setChangedOn(new \DateTime());
         $member->setBirth(new \DateTime('0001-01-01 00:00:00'));

--- a/module/Database/src/Database/Service/Member.php
+++ b/module/Database/src/Database/Service/Member.php
@@ -242,6 +242,7 @@ class Member extends AbstractService
         switch ($member->getType()) {
             case MemberModel::TYPE_ORDINARY:
             case MemberModel::TYPE_EXTERNAL:
+                $member->setIsStudying(true);
                 $member->setMembershipEndsOn(null);
                 break;
             case MemberModel::TYPE_GRADUATE:
@@ -502,14 +503,17 @@ class Member extends AbstractService
         switch ($data['type']) {
             case MemberModel::TYPE_ORDINARY:
             case MemberModel::TYPE_EXTERNAL:
+                $member->setIsStudying(true);
                 $member->setMembershipEndsOn(null);
                 break;
             case MemberModel::TYPE_GRADUATE:
+                $member->setIsStudying(false);
                 $membershipEndsOn = clone $expiration;
                 $membershipEndsOn->setDate($year - 1, 7, 1);
                 $member->setMembershipEndsOn($membershipEndsOn);
                 break;
             case MemberModel::TYPE_HONORARY:
+                $member->setIsStudying(false);
                 // infinity (1000 is close enough, right?)
                 $year += 1000;
                 $member->setMembershipEndsOn(null);

--- a/module/Database/src/Database/Service/Member.php
+++ b/module/Database/src/Database/Service/Member.php
@@ -241,11 +241,15 @@ class Member extends AbstractService
 
         switch ($member->getType()) {
             case MemberModel::TYPE_ORDINARY:
-            case MemberModel::TYPE_EXTERNAL:
                 $member->setIsStudying(true);
                 $member->setMembershipEndsOn(null);
                 break;
+            case MemberModel::TYPE_EXTERNAL:
+                $member->setIsStudying(true);
+                $member->setMembershipEndsOn($expiration);
+                break;
             case MemberModel::TYPE_GRADUATE:
+                $member->setIsStudying(false);
                 // This is a weird situation, as such define the expiration of the membership to be super early. Actual
                 // value will have to be edited manually.
                 $membershipEndsOn = clone $expiration;
@@ -253,6 +257,7 @@ class Member extends AbstractService
                 $member->setMembershipEndsOn($membershipEndsOn);
                 break;
             case MemberModel::TYPE_HONORARY:
+                $member->setIsStudying(false);
                 $member->setMembershipEndsOn(null);
                 // infinity (1000 is close enough, right?)
                 $expirationYear += 1000;
@@ -502,9 +507,16 @@ class Member extends AbstractService
 
         switch ($data['type']) {
             case MemberModel::TYPE_ORDINARY:
-            case MemberModel::TYPE_EXTERNAL:
                 $member->setIsStudying(true);
                 $member->setMembershipEndsOn(null);
+                $member->setType(MemberModel::TYPE_ORDINARY);
+                $year -= 1;
+                break;
+            case MemberModel::TYPE_EXTERNAL:
+                $member->setIsStudying(true);
+                $membershipEndsOn = clone $expiration;
+                $membershipEndsOn->setDate($year - 1, 7, 1);
+                $member->setMembershipEndsOn($membershipEndsOn);
                 break;
             case MemberModel::TYPE_GRADUATE:
                 $member->setIsStudying(false);

--- a/module/Database/view/database/member/edit.phtml
+++ b/module/Database/view/database/member/edit.phtml
@@ -83,7 +83,7 @@ $element->setLabelAttributes(array('class' => 'radio-inline'));
     </div>
 
 <?php
-$element = $form->get('tuenumber');
+$element = $form->get('tueUsername');
 $element->setAttribute('class', 'form-control');
 $element->setAttribute('placeholder', $element->getLabel());
 ?>

--- a/module/Database/view/database/member/edit.phtml
+++ b/module/Database/view/database/member/edit.phtml
@@ -83,6 +83,19 @@ $element->setLabelAttributes(array('class' => 'radio-inline'));
     </div>
 
 <?php
+$element = $form->get('tuenumber');
+$element->setAttribute('class', 'form-control');
+$element->setAttribute('placeholder', $element->getLabel());
+?>
+    <div class="form-group">
+        <label for="<?= $element->getName() ?>" class="control-label col-sm-4"><?= $element->getLabel() ?></label>
+        <div class="col-sm-8">
+            <?= $this->formInput($element) ?>
+            <?= $this->formElementErrors($element) ?>
+        </div>
+    </div>
+
+<?php
 $element = $form->get('email');
 $element->setAttribute('class', 'form-control');
 $element->setAttribute('placeholder', $element->getLabel());

--- a/module/Database/view/database/member/expiration.phtml
+++ b/module/Database/view/database/member/expiration.phtml
@@ -1,0 +1,43 @@
+<?php if (isset($success) && $success): ?>
+    <p>
+        Nieuwe verloopdatum lidmaatschap (<?= $member->getExpiration()->format('l j F Y') ?>) voor <a href="<?= $this->url('member/show', array(
+            'id' => $member->getLidnr()
+        )) ?>"><?= $member->getFullName() ?></a> is opgeslagen!
+    </p>
+<?php else: ?>
+    <h1>Verleng lidmaatschap <?= $member->getFullName() ?></h1>
+    <?php
+    $newExpiration = clone $member->getExpiration();
+    $year = (int) $newExpiration->format('Y') + 1;
+    $newExpiration->setDate($year, 7, 1);
+    ?>
+    <p>
+        Weet je zeker dat je het lidmaatschap van <?= $member->getFullName() ?> wilt verlengen van
+        <?= $member->getExpiration()->format('l j F Y') ?> naar <?= $newExpiration->format('l j F Y') ?>?
+    </p>
+    <?php
+    $form->prepare();
+
+    $form->setAttribute('action', $this->url('member/show/edit/expiration', array('id' => $member->getLidnr())));
+    $form->setAttribute('method', 'post');
+
+    $form->setAttribute('role', 'form');
+    $form->setAttribute('class', 'form-horizontal');
+    ?>
+    <?= $this->form()->openTag($form) ?>
+    <div class="form-group">
+        <?php
+        $submit = $form->get('submit_yes');
+        $submit->setLabel('Ja')
+            ->setAttribute('class', 'btn btn-primary');
+        ?>
+        <?= $this->formButton($submit) ?>
+        <?php
+        $submit = $form->get('submit_no');
+        $submit->setLabel('Nee')
+            ->setAttribute('class', 'btn btn-default');
+        ?>
+        <?= $this->formButton($submit) ?>
+    </div>
+    <?= $this->form()->closeTag() ?>
+<?php endif ?>

--- a/module/Database/view/database/member/membership.phtml
+++ b/module/Database/view/database/member/membership.phtml
@@ -17,6 +17,7 @@ $form->setAttribute('class', 'form-horizontal');
 <?php
 $element = $form->get('type');
 $element->setAttribute('placeholder', $element->getLabel());
+$element->setValue($member->getType());
 //$element->setLabelAttributes(array('class' => 'radio-inline'));
 ?>
     <div class="form-group">

--- a/module/Database/view/database/member/print.phtml
+++ b/module/Database/view/database/member/print.phtml
@@ -97,8 +97,13 @@ switch ($member->getType()) {
             <td><?= $member->getChangedOn()->format('l j F Y') ?></td>
         </tr>
         <tr>
-            <th>Verloopdatum lidmaatschap</th>
-            <td><?= $member->getExpiration()->format('l j F Y') ?></td>
+            <th>Verloopdatum lidmaatschap (hernieuwt op)</th>
+            <td>
+                <?= sprintf('%s (%s)',
+                    (null !== $member->getMembershipEndsOn()) ? $member->getMembershipEndsOn()->format('l j F Y') : 'N.v.t.',
+                    $member->getExpiration()->format('l j F Y')
+                )?>
+            </td>
         </tr>
     </table>
 </div>

--- a/module/Database/view/database/member/print.phtml
+++ b/module/Database/view/database/member/print.phtml
@@ -77,21 +77,18 @@ case Member::GENDER_OTHER:
             <th>Type lid</th>
             <td><?php
 switch ($member->getType()) {
-case Member::TYPE_ORDINARY:
-    echo 'Gewoon';
-    break;
-case Member::TYPE_PROLONGED:
-    echo 'Verlengd';
-    break;
-case Member::TYPE_EXTERNAL:
-    echo 'Extern';
-    break;
-case Member::TYPE_EXTRAORDINARY:
-    echo 'Buitengewoon';
-    break;
-case Member::TYPE_HONORARY:
-    echo 'Erelid';
-    break;
+    case Member::TYPE_ORDINARY:
+        echo 'Gewoon';
+        break;
+    case Member::TYPE_EXTERNAL:
+        echo 'Extern';
+        break;
+    case Member::TYPE_GRADUATE:
+        echo 'Afgestudeerde';
+        break;
+    case Member::TYPE_HONORARY:
+        echo 'Erelid';
+        break;
 }
 ?></td>
         </tr>

--- a/module/Database/view/database/member/print.phtml
+++ b/module/Database/view/database/member/print.phtml
@@ -46,8 +46,8 @@ case Member::GENDER_OTHER:
 ?></td>
         </tr>
         <tr>
-            <th>TU/e nummer</th>
-            <td><?= $member->getTuenumber() ?></td>
+            <th>TU/e-gebruikersnaam</th>
+            <td><?= (null === $member->getTueUsername()) ? 'Onbekend' : $member->getTueUsername() ?></td>
         </tr>
         <tr>
             <th>Studie</th>

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -43,8 +43,8 @@ case Member::GENDER_OTHER:
 ?></td>
         </tr>
         <tr>
-            <th>TU/e nummer</th>
-            <td><?= $member->getTuenumber() ?></td>
+            <th>TU/e-gebruikersnaam</th>
+            <td><?= (null === $member->getTueUsername()) ? 'Onbekend' : $member->getTueUsername() ?></td>
         </tr>
         <tr>
             <th>Email</th>

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -62,21 +62,18 @@ case Member::GENDER_OTHER:
             <th>Type lid</th>
             <td><?php
 switch ($member->getType()) {
-case Member::TYPE_ORDINARY:
-    echo 'Gewoon';
-    break;
-case Member::TYPE_PROLONGED:
-    echo 'Verlengd';
-    break;
-case Member::TYPE_EXTERNAL:
-    echo 'Extern';
-    break;
-case Member::TYPE_EXTRAORDINARY:
-    echo 'Buitengewoon';
-    break;
-case Member::TYPE_HONORARY:
-    echo 'Erelid';
-    break;
+    case Member::TYPE_ORDINARY:
+        echo 'Gewoon';
+        break;
+    case Member::TYPE_EXTERNAL:
+        echo 'Extern';
+        break;
+    case Member::TYPE_GRADUATE:
+        echo 'Afgestudeerde';
+        break;
+    case Member::TYPE_HONORARY:
+        echo 'Erelid';
+        break;
 }
 ?> <a href="<?= $this->url('member/show/edit/membership', array(
     'id' => $member->getLidnr()

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -43,6 +43,10 @@ case Member::GENDER_OTHER:
 ?></td>
         </tr>
         <tr>
+            <th>TU/e nummer</th>
+            <td><?= $member->getTuenumber() ?></td>
+        </tr>
+        <tr>
             <th>Email</th>
             <td><a href="mailto:<?= $member->getEmail() ?>"><?= $member->getEmail() ?></a></td>
         </tr>

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -84,8 +84,13 @@ switch ($member->getType()) {
             <td><?= $member->getChangedOn()->format('l j F Y') ?></td>
         </tr>
         <tr>
-            <th>Verloopdatum lidmaatschap</th>
-            <td><?= $member->getExpiration()->format('l j F Y') ?></td>
+            <th>Verloopdatum lidmaatschap (hernieuwt op)</th>
+            <td>
+                <?= sprintf('%s (%s)',
+                    (null !== $member->getMembershipEndsOn()) ? $member->getMembershipEndsOn()->format('l j F Y') : 'N.v.t.',
+                    $member->getExpiration()->format('l j F Y')
+                )?>
+            </td>
         </tr>
         <tr>
             <th>Wil supremum ontvangen</th>

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -94,6 +94,9 @@ switch ($member->getType()) {
                     (null !== $member->getMembershipEndsOn()) ? $member->getMembershipEndsOn()->format('l j F Y') : 'N.v.t.',
                     $member->getExpiration()->format('l j F Y')
                 )?>
+                <?php if (Member::TYPE_EXTERNAL === $member->getType() || Member::TYPE_GRADUATE === $member->getType()): ?>
+                    <a href="<?= $this->url('member/show/edit/expiration', ['id' => $member->getLidnr()]) ?>" class="btn btn-primary btn-xs">Verleng</a>
+                <?php endif; ?>
             </td>
         </tr>
         <tr>

--- a/module/Database/view/database/member/subscribe.phtml
+++ b/module/Database/view/database/member/subscribe.phtml
@@ -516,10 +516,6 @@ case Member::GENDER_OTHER:
             <td><?= $member->getBirth()->format('l j F Y') ?></td>
         </tr>
         <tr>
-            <th><?= $this->translate('Generatie') ?></th>
-            <td><?= $member->getGeneration() ?></td>
-        </tr>
-        <tr>
             <th><?= $this->translate('IBAN') ?></th>
             <td><?= $member->getIban() ?></td>
         </tr>
@@ -549,15 +545,6 @@ switch ($member->getType()) {
         <tr>
             <th><?= $this->translate('Laatste wijziging lidmaatshap') ?></th>
             <td><?= $member->getChangedOn()->format('l j F Y') ?></td>
-        </tr>
-        <tr>
-            <th><?= $this->translate('Verloopdatum lidmaatschap (hernieuwt op)') ?></th>
-            <td>
-                <?= sprintf('%s (%s)',
-                    (null !== $member->getMembershipEndsOn()) ? $member->getMembershipEndsOn()->format('l j F Y') : 'N.v.t.',
-                    $member->getExpiration()->format('l j F Y')
-                )?>
-            </td>
         </tr>
     </table>
 </div>

--- a/module/Database/view/database/member/subscribe.phtml
+++ b/module/Database/view/database/member/subscribe.phtml
@@ -529,21 +529,18 @@ case Member::GENDER_OTHER:
             <th><?= $this->translate('Type lid') ?></th>
             <td><?php
 switch ($member->getType()) {
-case Member::TYPE_ORDINARY:
-    echo $this->translate('Gewoon');
-    break;
-case Member::TYPE_PROLONGED:
-    echo $this->translate('Verlengd');
-    break;
-case Member::TYPE_EXTERNAL:
-    echo $this->translate('Extern');
-    break;
-case Member::TYPE_EXTRAORDINARY:
-    echo $this->translate('Buitengewoon');
-    break;
-case Member::TYPE_HONORARY:
-    echo $this->translate('Erelid');
-    break;
+    case Member::TYPE_ORDINARY:
+        echo $this->translate('Gewoon');
+        break;
+    case Member::TYPE_EXTERNAL:
+        echo $this->translate('Extern');
+        break;
+    case Member::TYPE_GRADUATE:
+        echo $this->translate('Afgestudeerde');
+        break;
+    case Member::TYPE_HONORARY:
+        echo $this->translate('Erelid');
+        break;
 }
 ?></td>
         </tr>

--- a/module/Database/view/database/member/subscribe.phtml
+++ b/module/Database/view/database/member/subscribe.phtml
@@ -549,8 +549,13 @@ switch ($member->getType()) {
             <td><?= $member->getChangedOn()->format('l j F Y') ?></td>
         </tr>
         <tr>
-            <th><?= $this->translate('Verloopdatum lidmaatschap') ?></th>
-            <td><?= $member->getExpiration()->format('l j F Y') ?></td>
+            <th><?= $this->translate('Verloopdatum lidmaatschap (hernieuwt op)') ?></th>
+            <td>
+                <?= sprintf('%s (%s)',
+                    (null !== $member->getMembershipEndsOn()) ? $member->getMembershipEndsOn()->format('l j F Y') : 'N.v.t.',
+                    $member->getExpiration()->format('l j F Y')
+                )?>
+            </td>
         </tr>
     </table>
 </div>

--- a/module/Database/view/database/member/subscribe.phtml
+++ b/module/Database/view/database/member/subscribe.phtml
@@ -145,7 +145,7 @@ $element->setLabelAttributes(array(
 </div>
 
 <?php
-$element = $form->get('tuenumber');
+$element = $form->get('tueUsername');
 $element->setAttribute('class', 'form-control');
 $element->setAttribute('placeholder', $element->getLabel());
 $element->setLabelAttributes(array(
@@ -498,8 +498,10 @@ case Member::GENDER_OTHER:
 ?></td>
         </tr>
         <tr>
-            <th><?= $this->translate('TU/e nummer') ?></th>
-            <td><?= $member->getTuenumber() ?></td>
+            <th><?= $this->translate('TU/e-gebruikersnaam') ?></th>
+            <td>
+                <?= (null === $member->getTueUsername()) ? $this->translate('Onbekend') : $member->getTueUsername() ?>
+            </td>
         </tr>
         <tr>
             <th><?= $this->translate('Studie') ?></th>

--- a/module/Database/view/database/prospective-member/index.phtml
+++ b/module/Database/view/database/prospective-member/index.phtml
@@ -19,8 +19,6 @@
                         table += '<td>' + link + member.lidnr + '</a></td>';
                         table += '<td>' + link + member.fullName + '</a></td>';
                         table += '<td>' + link + member.email + '</a></td>';
-                        table += '<td>' + link + member.generation + '</a></td>';
-                        table += '<td>' + link + member.expiration + '</a></td>';
                         table += '</tr>';
                     });
                     $('#members-result tbody').html(table);
@@ -57,15 +55,13 @@
         <th>#</th>
         <th>Naam</th>
         <th>Email</th>
-        <th>Generatie</th>
-        <th>Verloopdatum</th>
     </tr>
     </thead>
     <tbody>
     </tbody>
     <tfoot>
     <tr>
-        <td colspan="4"> Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere resultaten te zien.</td>
+        <td colspan="3"> Er zijn teveel resultaten om weer te geven. Probeer te filteren om andere resultaten te zien.</td>
     </tr>
     </tfoot>
 </table>

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -81,13 +81,47 @@ switch ($member->getType()) {
             <th>Laatste wijziging lidmaatshap</th>
             <td><?= $member->getChangedOn()->format('l j F Y') ?></td>
         </tr>
-        </table>
-        <a href="<?= $this->url('prospective-member/show/finalize', array(
-            'id' => $member->getLidnr()
-        )) ?>" class="btn btn-primary">Approve membership</a>
-        <a href="<?= $this->url('prospective-member/show/delete', array(
-            'id' => $member->getLidnr()
-        )) ?>" class="btn btn-danger">Verwijder lid</a>
+    </table>
+    <?php
+    $form->prepare();
+
+    $form->setAttribute('action', $this->url('prospective-member/show/finalize', array('id' => $member->getLidnr())));
+    $form->setAttribute('method', 'post');
+
+    $form->setAttribute('role', 'form');
+    ?>
+    <?= $this->form()->openTag($form) ?>
+    <?php
+    $element = $form->get('type');
+    $element->setAttribute('placeholder', $element->getLabel());
+    //$element->setLabelAttributes(array('class' => 'radio-inline'));
+    ?>
+    <div class="form-group">
+        <label for="<?= $element->getName() ?>" class="control-label col-sm-4 label-required"><?= $element->getLabel() ?></label>
+        <br>
+        <div class="col-sm-12">
+            <?php foreach ($element->getValueOptions() as $option => $text): ?>
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="<?= $element->getName() ?>" id="<?= $element->getName() ?>" value="<?= $option ?>" <?= $element->getValue() == $option ? 'checked' : '' ?>>
+                        <?= $text ?>
+                    </label>
+                </div>
+            <?php endforeach ?>
+            <?= $this->formElementErrors($element) ?>
+        </div>
+    </div>
+
+    <?php
+    $submit = $form->get('submit');
+    $submit->setLabel('Keur lidmaatschap goed');
+    $submit->setAttribute('class', 'btn btn-primary');
+    ?>
+    <?= $this->formButton($submit) ?>
+    <a href="<?= $this->url('prospective-member/show/delete', array(
+        'id' => $member->getLidnr()
+    )) ?>" class="btn btn-danger">Verwijder lid</a>
+    <?= $this->form()->closeTag($form) ?>
 </div>
 <div class="col-md-6">
 <h3>Adressen</h3>

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -62,21 +62,18 @@ case Member::GENDER_OTHER:
             <th>Type lid</th>
             <td><?php
 switch ($member->getType()) {
-case Member::TYPE_ORDINARY:
-    echo 'Gewoon';
-    break;
-case Member::TYPE_PROLONGED:
-    echo 'Verlengd';
-    break;
-case Member::TYPE_EXTERNAL:
-    echo 'Extern';
-    break;
-case Member::TYPE_EXTRAORDINARY:
-    echo 'Buitengewoon';
-    break;
-case Member::TYPE_HONORARY:
-    echo 'Erelid';
-    break;
+    case Member::TYPE_ORDINARY:
+        echo 'Gewoon';
+        break;
+    case Member::TYPE_EXTERNAL:
+        echo 'Extern';
+        break;
+    case Member::TYPE_GRADUATE:
+        echo 'Afgestudeerde';
+        break;
+    case Member::TYPE_HONORARY:
+        echo 'Erelid';
+        break;
 }
 ?></td>
         </tr>

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -43,8 +43,8 @@ case Member::GENDER_OTHER:
 ?></td>
         </tr>
         <tr>
-            <th>TU/e nummer</th>
-            <td><?= $member->getTuenumber() ?></td>
+            <th>TU/e-gebruikersnaam</th>
+            <td><?= (null === $member->getTueUsername()) ? 'Onbekend' : $member->getTueUsername() ?></td>
         </tr>
         <tr>
             <th>Email</th>

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -55,10 +55,6 @@ case Member::GENDER_OTHER:
             <td><?= $member->getBirth()->format('l j F Y') ?></td>
         </tr>
         <tr>
-            <th>Generatie</th>
-            <td><?= $member->getGeneration() ?></td>
-        </tr>
-        <tr>
             <th>Betaald (hoe veel)</th>
             <td><?= $member->getPaid() ?></td>
         </tr>
@@ -84,15 +80,6 @@ switch ($member->getType()) {
         <tr>
             <th>Laatste wijziging lidmaatshap</th>
             <td><?= $member->getChangedOn()->format('l j F Y') ?></td>
-        </tr>
-        <tr>
-            <th>Verloopdatum lidmaatschap (hernieuwt op)</th>
-            <td>
-                <?= sprintf('%s (%s)',
-                    (null !== $member->getMembershipEndsOn()) ? $member->getMembershipEndsOn()->format('l j F Y') : 'N.v.t.',
-                    $member->getExpiration()->format('l j F Y')
-                )?>
-            </td>
         </tr>
         </table>
         <a href="<?= $this->url('prospective-member/show/finalize', array(

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -43,6 +43,10 @@ case Member::GENDER_OTHER:
 ?></td>
         </tr>
         <tr>
+            <th>TU/e nummer</th>
+            <td><?= $member->getTuenumber() ?></td>
+        </tr>
+        <tr>
             <th>Email</th>
             <td><a href="mailto:<?= $member->getEmail() ?>"><?= $member->getEmail() ?></a></td>
         </tr>

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -82,8 +82,13 @@ switch ($member->getType()) {
             <td><?= $member->getChangedOn()->format('l j F Y') ?></td>
         </tr>
         <tr>
-            <th>Verloopdatum lidmaatschap</th>
-            <td><?= $member->getExpiration()->format('l j F Y') ?></td>
+            <th>Verloopdatum lidmaatschap (hernieuwt op)</th>
+            <td>
+                <?= sprintf('%s (%s)',
+                    (null !== $member->getMembershipEndsOn()) ? $member->getMembershipEndsOn()->format('l j F Y') : 'N.v.t.',
+                    $member->getExpiration()->format('l j F Y')
+                )?>
+            </td>
         </tr>
         </table>
         <a href="<?= $this->url('prospective-member/show/finalize', array(

--- a/module/Export/src/Export/Service/Member.php
+++ b/module/Export/src/Export/Service/Member.php
@@ -72,21 +72,18 @@ class Member extends AbstractService
             );
 
             switch ($member->getType()) {
-            case MemberModel::TYPE_ORDINARY:
-                $data['lidsoortid'] = 1;
-                break;
-            case MemberModel::TYPE_PROLONGED:
-                $data['lidsoortid'] = 2;
-                break;
-            case MemberModel::TYPE_EXTERNAL:
-                $data['lidsoortid'] = 3;
-                break;
-            case MemberModel::TYPE_EXTRAORDINARY:
-                $data['lidsoortid'] = 4;
-                break;
-            case MemberModel::TYPE_HONORARY:
-                $data['lidsoortid'] = 5;
-                break;
+                case MemberModel::TYPE_ORDINARY:
+                    $data['lidsoortid'] = 1;
+                    break;
+                case MemberModel::TYPE_EXTERNAL:
+                    $data['lidsoortid'] = 2;
+                    break;
+                case MemberModel::TYPE_GRADUATE:
+                    $data['lidsoortid'] = 3;
+                    break;
+                case MemberModel::TYPE_HONORARY:
+                    $data['lidsoortid'] = 4;
+                    break;
             }
 
             // first check if it is an existing member

--- a/module/Import/src/Import/Service/Member.php
+++ b/module/Import/src/Import/Service/Member.php
@@ -61,26 +61,20 @@ class Member extends AbstractService
         $changed = new \DateTime($data['verloopdatum']);
 
         switch (strtolower($data['lidsoort'])) {
-        case 'basis lid':
-            $member->setType(MemberModel::TYPE_ORDINARY);
-            $changed->sub(new \DateInterval('P6Y'));
-            break;
-        case 'geprolongeerd lid':
-            $member->setType(MemberModel::TYPE_PROLONGED);
-            $changed->sub(new \DateInterval('P1Y'));
-            break;
-        case 'extern lid':
-            $member->setType(MemberModel::TYPE_EXTERNAL);
-            $changed->sub(new \DateInterval('P1Y'));
-            break;
-        case 'buitengewoon lid':
-            $member->setType(MemberModel::TYPE_EXTRAORDINARY);
-            $changed->sub(new \DateInterval('P1Y'));
-            break;
-        case 'erelid':
-            $member->setType(MemberModel::TYPE_HONORARY);
-            $changed = new \DateTime();
-            break;
+            case 'basis lid':
+            case 'geprolongeerd lid':
+            case 'extern lid':
+                $member->setType(MemberModel::TYPE_ORDINARY);
+                $changed->sub(new \DateInterval('P1Y'));
+                break;
+            case 'buitengewoon lid':
+                $member->setType(MemberModel::TYPE_EXTERNAL);
+                $changed->sub(new \DateInterval('P1Y'));
+                break;
+            case 'erelid':
+                $member->setType(MemberModel::TYPE_HONORARY);
+                $changed = new \DateTime();
+                break;
         }
 
         $member->setChangedOn($changed);

--- a/module/Report/src/Report/Model/Member.php
+++ b/module/Report/src/Report/Model/Member.php
@@ -112,6 +112,15 @@ class Member
     protected $changedOn;
 
     /**
+     * Date when the real membership ("ordinary" or "external") of the member will have ended, in other words, from this
+     * date onwards they are "graduate". If `null`, the expiration is rolling and will be the end of the current
+     * association year.
+     *
+     * @ORM\Column(type="date", nullable=true)
+     */
+    protected $membershipEndsOn;
+
+    /**
      * Member birth date.
      *
      * @ORM\Column(type="date")
@@ -119,7 +128,7 @@ class Member
     protected $birth;
 
     /**
-     * Member expiration date.
+     * Get the date on which the member's membership will expire and has to be renewed.
      *
      * @ORM\Column(type="date")
      */
@@ -497,6 +506,26 @@ class Member
     }
 
     /**
+     * Get the date on which the membership of the member will have ended (i.e., they have become "graduate").
+     *
+     * @return \DateTime|null
+     */
+    public function getMembershipEndsOn()
+    {
+        return $this->membershipEndsOn;
+    }
+
+    /**
+     * Set the date on which the membership of the member will have ended (i.e., they have become "graduate").
+     *
+     * @param \DateTime|null $membershipEndsOn
+     */
+    public function setMembershipEndsOn($membershipEndsOn)
+    {
+        $this->membershipEndsOn = $membershipEndsOn;
+    }
+
+    /**
      * Get how much has been paid.
      *
      * @return int
@@ -582,6 +611,7 @@ class Member
             'initials' => $this->getInitials(),
             'firstName' => $this->getFirstName(),
             'generation' => $this->getGeneration(),
+            'memberShipEndsOn' => (null !== $this->getMembershipEndsOn()) ? $this->getMembershipEndsOn()->format('l j F Y') : null,
             'expiration' => $this->getExpiration()->format('l j F Y')
         );
     }

--- a/module/Report/src/Report/Model/Member.php
+++ b/module/Report/src/Report/Model/Member.php
@@ -18,9 +18,8 @@ class Member
     const GENDER_OTHER = 'o';
 
     const TYPE_ORDINARY = 'ordinary';
-    const TYPE_PROLONGED = 'prolonged';
     const TYPE_EXTERNAL = 'external';
-    const TYPE_EXTRAORDINARY = 'extraordinary';
+    const TYPE_GRADUATE = 'graduate';
     const TYPE_HONORARY = 'honorary';
 
     /**
@@ -93,16 +92,13 @@ class Member
      * This can be one of the following, as defined by the GEWIS statuten:
      *
      * - ordinary
-     * - prolonged
      * - external
-     * - extraordinary
+     * - graduate
      * - honorary
      *
-     * You can find the GEWIS Statuten here:
+     * You can find the GEWIS statuten here: https://gewis.nl/vereniging/statuten/statuten.
      *
-     * http://gewis.nl/vereniging/statuten/statuten.php
-     *
-     * Zie artikel 7 lid 1 en 2.
+     * See artikel 7.
      *
      * @ORM\Column(type="string")
      */
@@ -212,9 +208,8 @@ class Member
     {
         return array(
             self::TYPE_ORDINARY,
-            self::TYPE_PROLONGED,
             self::TYPE_EXTERNAL,
-            self::TYPE_EXTRAORDINARY,
+            self::TYPE_GRADUATE,
             self::TYPE_HONORARY
         );
     }

--- a/module/Report/src/Report/Model/Member.php
+++ b/module/Report/src/Report/Model/Member.php
@@ -610,7 +610,7 @@ class Member
             'initials' => $this->getInitials(),
             'firstName' => $this->getFirstName(),
             'generation' => $this->getGeneration(),
-            'memberShipEndsOn' => (null !== $this->getMembershipEndsOn()) ? $this->getMembershipEndsOn()->format('l j F Y') : null,
+            'membershipEndsOn' => (null !== $this->getMembershipEndsOn()) ? $this->getMembershipEndsOn()->format('l j F Y') : null,
             'expiration' => $this->getExpiration()->format('l j F Y')
         );
     }

--- a/module/Report/src/Report/Model/Member.php
+++ b/module/Report/src/Report/Model/Member.php
@@ -113,8 +113,8 @@ class Member
 
     /**
      * Date when the real membership ("ordinary" or "external") of the member will have ended, in other words, from this
-     * date onwards they are "graduate". If `null`, the expiration is rolling and will be the end of the current
-     * association year.
+     * date onwards they are "graduate". If `null`, the expiration is rolling and will be silently renewed if the member
+     * still meets the requirements as set forth in the bylaws and internal regulations.
      *
      * @ORM\Column(type="date", nullable=true)
      */
@@ -129,7 +129,7 @@ class Member
 
     /**
      * The date on which the membership of the member is set to expire and will therefore have to be renewed, which
-     * happens either automatically or has to be done manually.
+     * happens either automatically or has to be done manually, as set forth in the bylaws and internal regulations.
      *
      * @ORM\Column(type="date")
      */
@@ -445,10 +445,7 @@ class Member
     }
 
     /**
-     * Get the date on which the membership of the member is set to expire and will therefore have to be renewed, which
-     * happens either automatically or has to be done manually.
-     *
-     * The information comes from the statuten and HR.
+     * Get the expiration date.
      *
      * @return \DateTime
      */

--- a/module/Report/src/Report/Model/Member.php
+++ b/module/Report/src/Report/Model/Member.php
@@ -128,7 +128,8 @@ class Member
     protected $birth;
 
     /**
-     * Get the date on which the member's membership will expire and has to be renewed.
+     * The date on which the membership of the member is set to expire and will therefore have to be renewed, which
+     * happens either automatically or has to be done manually.
      *
      * @ORM\Column(type="date")
      */
@@ -444,7 +445,8 @@ class Member
     }
 
     /**
-     * Get the expiration date.
+     * Get the date on which the membership of the member is set to expire and will therefore have to be renewed, which
+     * happens either automatically or has to be done manually.
      *
      * The information comes from the statuten and HR.
      *

--- a/module/Report/src/Report/Model/SubDecision/Board/Installation.php
+++ b/module/Report/src/Report/Model/SubDecision/Board/Installation.php
@@ -26,8 +26,8 @@ class Installation extends SubDecision
      * Member.
      *
      * Note that only members that are older than 18 years can be board members.
-     * Also, honorary, external and extraordinary members cannot be board members.
-     * (See the Statuten, Art. 13 Lid 2.
+     * Also, honorary members cannot be board members.
+     * (See the Statuten, Art. 13A Lid 2.
      *
      * @todo Inversed relation
      *

--- a/module/Report/src/Report/Service/Member.php
+++ b/module/Report/src/Report/Service/Member.php
@@ -63,6 +63,7 @@ class Member extends AbstractService
         $reportMember->setGender($member->getGender());
         $reportMember->setGeneration($member->getGeneration());
         $reportMember->setType($member->getType());
+        $reportMember->setMembershipEndsOn($member->getMembershipEndsOn());
         $reportMember->setExpiration($member->getExpiration());
         $reportMember->setBirth($member->getBirth());
         $reportMember->setChangedOn($member->getChangedOn());

--- a/module/User/Module.php
+++ b/module/User/Module.php
@@ -53,11 +53,14 @@ class Module
         }, -100);
 
         $eventManager->attach(MvcEvent::EVENT_DISPATCH_ERROR, function ($e) use ($authService) {
-            if (!$authService->hasIdentity()) {
-                $response = $e->getResponse();
-                $response->getHeaders()->addHeaderLine('Location', '/user');
-                $response->setStatusCode(302);
-                return $response;
+            // Check if not a console route, as the console has no headers.
+            if (!($e->getResponse() instanceof \Zend\Console\Response)) {
+                if (!$authService->hasIdentity()) {
+                    $response = $e->getResponse();
+                    $response->getHeaders()->addHeaderLine('Location', '/user');
+                    $response->setStatusCode(302);
+                    return $response;
+                }
             }
         });
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -40,3 +40,8 @@ canvas#signature-canvas {
     border: 0.125rem solid #333333;
     border-radius: 0.25rem;
 }
+
+.label-required::after {
+    content:" *";
+    color:#D40026
+}


### PR DESCRIPTION
**This is a draft but please already check the changes.**

This updates the different membership types we have:

- `ordinary` (previously `ordinary`, `prolonged`, and `external`)
- `external` (previously `extraordinary`)
- `honorary`
- `graduate` (not an actual member, but still a member)

Memberships now always end at the end of the association year and a checker has been added to check whether or not the membership type of a member should change (`./db check memberships`).

As such, `ordinary` members will have their membership automatically renewed if they are still studying at the M&CS department (i.e. a rolling membership). If an `ordinary` member is no longer studying they will have their `membershipEndsOn` determined. At this date, the membership will either become `external` or `graduate`. If the member is still an active member their membership type will be converted to `external` (and have their `membershipEndsOn` updated). If this is not the case, they will become `graduate`. `external` members will have their `membershipEndsOn` automatically updated as long as they are still an active member.

Currently not implemented (but will be soon):
- [ ] Manual checking of a member's membership state.
- [ ] Updated https://join.gewis.nl subscription form (ask for TU/e-username and permission to check with ESA). 
- [ ] Donors (you can see a stub at tomudding/gewisdb@4c16f6e0c42dbfed602e602caada17bf65784d94 though the actual implementation may change).

Currently not implemented but should ideally still be done but I do not have the time for it:
- [ ] E-mailing `graduate` and non-active `external` members.

Closes #152.