### PR TITLE
Allow nullable e-mail addresses and fix uniqueness

### DIFF
--- a/module/Database/src/Database/Form/MemberEdit.php
+++ b/module/Database/src/Database/Form/MemberEdit.php
@@ -175,6 +175,17 @@ class MemberEdit extends Form implements InputFilterProviderInterface
                 'filters' => array(
                     array('name' => 'tonull')
                 )
+            ),
+            'email' => array(
+                'required' => false,
+                'validators' => array(
+                    array(
+                        'name' => 'emailaddress',
+                    )
+                ),
+                'filters' => array(
+                    array('name' => 'tonull')
+                )
             )
         );
     }

--- a/module/Database/src/Database/Mapper/Member.php
+++ b/module/Database/src/Database/Mapper/Member.php
@@ -41,7 +41,7 @@ class Member
 
         $qb->select('m')
             ->from('Database\Model\Member', 'm')
-            ->where("m.email = :email")
+            ->where("LOWER(m.email) = LOWER(:email)")
             ->setMaxResults(1);
 
         $qb->setParameter(':email', $email);

--- a/module/Database/src/Database/Mapper/ProspectiveMember.php
+++ b/module/Database/src/Database/Mapper/ProspectiveMember.php
@@ -40,7 +40,7 @@ class ProspectiveMember
 
         $qb->select('m')
             ->from('Database\Model\ProspectiveMember', 'm')
-            ->where("m.email = :email")
+            ->where("LOWER(m.email) = LOWER(:email)")
             ->setMaxResults(1);
 
         $qb->setParameter(':email', $email);

--- a/module/Database/src/Database/Model/Member.php
+++ b/module/Database/src/Database/Model/Member.php
@@ -34,7 +34,7 @@ class Member
     /**
      * Member's email address.
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", nullable=true)
      */
     protected $email;
 
@@ -264,7 +264,7 @@ class Member
     /**
      * Get the member's email address.
      *
-     * @return string
+     * @return string|null
      */
     public function getEmail()
     {
@@ -324,7 +324,7 @@ class Member
     /**
      * Set the member's email address.
      *
-     * @param string $email
+     * @param string|null $email
      */
     public function setEmail($email)
     {

--- a/module/Database/src/Database/Service/Member.php
+++ b/module/Database/src/Database/Service/Member.php
@@ -73,7 +73,10 @@ class Member extends AbstractService
         }
 
         // find if there is an earlier member with the same email or name
-        if ($this->getMemberMapper()->hasMemberWith($prospectiveMember->getEmail())) {
+        if (
+            $this->getMemberMapper()->hasMemberWith($prospectiveMember->getEmail())
+            || $this->getProspectiveMemberMapper()->hasMemberWith($prospectiveMember->getEmail())
+        ) {
             $form->get('email')->setMessages([
                 'There already is a member with this email address.'
             ]);

--- a/module/Database/src/Database/Service/Member.php
+++ b/module/Database/src/Database/Service/Member.php
@@ -410,7 +410,7 @@ class Member extends AbstractService
 
         $date = new \DateTime('0001-01-01 00:00:00');
 
-        $member->setEmail('');
+        $member->setEmail(null);
         $member->setGender(MemberModel::GENDER_OTHER);
         $member->setGeneration(0);
         $member->setTueUsername(null);

--- a/module/Database/view/database/member/index.phtml
+++ b/module/Database/view/database/member/index.phtml
@@ -18,7 +18,7 @@ $(document).ready(function () {
                     table += '<tr>';
                     table += '<td>' + link + member.lidnr + '</a></td>';
                     table += '<td>' + link + member.fullName + '</a></td>';
-                    table += '<td>' + link + member.email + '</a></td>';
+                    table += '<td>' + link + ((null == member.email) ? 'Onbekend' : member.email) + '</a></td>';
                     table += '<td>' + link + member.generation + '</a></td>';
                     table += '<td>' + link + member.expiration + '</a></td>';
                     table += '</tr>';

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -48,7 +48,11 @@ case Member::GENDER_OTHER:
         </tr>
         <tr>
             <th>Email</th>
-            <td><a href="mailto:<?= $member->getEmail() ?>"><?= $member->getEmail() ?></a></td>
+            <?php if (null !== ($emailAddress = $member->getEmail())): ?>
+                <td><a href="mailto:<?= $emailAddress ?>"><?= $emailAddress ?></a></td>
+            <?php else: ?>
+                <td>Onbekend</td>
+            <?php endif; ?>
         </tr>
         <tr>
             <th>Geboortedatum</th>

--- a/module/Report/src/Report/Model/Member.php
+++ b/module/Report/src/Report/Model/Member.php
@@ -33,7 +33,7 @@ class Member
     /**
      * Member's email address.
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", nullable=true)
      */
     protected $email;
 
@@ -250,7 +250,7 @@ class Member
     /**
      * Get the member's email address.
      *
-     * @return string
+     * @return string|null
      */
     public function getEmail()
     {
@@ -310,7 +310,7 @@ class Member
     /**
      * Set the member's email address.
      *
-     * @param string $email
+     * @param string|null $email
      */
     public function setEmail($email)
     {


### PR DESCRIPTION
**This does require an update in GEWISWEB!**

This makes the e-mail address of members nullable through the interface. This does **not** apply to prospective members, they still need to provide a (valid) e-mail address.

Additionally, this fixes uniqueness of the e-mail addresses of members when subscribing (checks against both prospective members and members).

Fixes #126 and closes #155.