### PR TITLE
Fix incorrect installation date for `BoardMember`s

### DIFF
--- a/module/Report/src/Report/Model/BoardMember.php
+++ b/module/Report/src/Report/Model/BoardMember.php
@@ -62,6 +62,13 @@ class BoardMember
     protected $installationDec;
 
     /**
+     * Release date.
+     *
+     * @ORM\Column(type="date", nullable=true)
+     */
+    protected $releaseDate;
+
+    /**
      * Discharge date.
      *
      * @ORM\Column(type="date", nullable=true)
@@ -157,6 +164,26 @@ class BoardMember
     public function setInstallationDec(Installation $installationDec)
     {
         $this->installationDec = $installationDec;
+    }
+
+    /**
+     * Get the release date.
+     *
+     * @return \DateTime
+     */
+    public function getReleaseDate()
+    {
+        return $this->releaseDate;
+    }
+
+    /**
+     * Set the release date.
+     *
+     * @param \DateTime $releaseDate
+     */
+    public function setReleaseDate($releaseDate)
+    {
+        $this->releaseDate = $releaseDate;
     }
 
     /**

--- a/module/Report/src/Report/Service/Board.php
+++ b/module/Report/src/Report/Service/Board.php
@@ -25,13 +25,16 @@ class Board extends AbstractService
                 $boardMember = new BoardMember();
                 $boardMember->setInstallationDec($install);
             }
+
             $boardMember->setMember($install->getMember());
             $boardMember->setFunction($install->getFunction());
-            $boardMember->setInstallDate($install->getDecision()->getMeeting()->getDate());
+            $boardMember->setInstallDate($install->getDate());
+
             $discharge = $install->getDischarge();
             if (null !== $discharge) {
                 $boardMember->setDischargeDate($discharge->getDecision()->getMeeting()->getDate());
             }
+
             $em->persist($boardMember);
         }
         $em->flush();

--- a/module/Report/src/Report/Service/Board.php
+++ b/module/Report/src/Report/Service/Board.php
@@ -30,6 +30,11 @@ class Board extends AbstractService
             $boardMember->setFunction($install->getFunction());
             $boardMember->setInstallDate($install->getDate());
 
+            $release = $install->getRelease();
+            if (null !== $release) {
+                $boardMember->setReleaseDate($release->getDate());
+            }
+            
             $discharge = $install->getDischarge();
             if (null !== $discharge) {
                 $boardMember->setDischargeDate($discharge->getDecision()->getMeeting()->getDate());


### PR DESCRIPTION
This fixes #167.

I have also added the release date of a board member to allow for simplification of any checks against the end of a board member's term.