### PR TITLE
Switch to Alpine based images

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,6 @@
-FROM nginx:latest as gewisdb_nginx
+FROM nginx:stable-alpine as gewisdb_nginx
+
+RUN adduser -D -H -u 1000 -s /bin/bash www-data -G www-data
 
 COPY --chown=www-data:www-data . /etc/nginx
 COPY --chown=www-data:www-data nginx.conf /etc/nginx/nginx.conf.template

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:stable-alpine as gewisdb_nginx
 
-RUN adduser -D -H -u 1000 -s /bin/bash www-data -G www-data
+RUN adduser -D -H -u 1000 -s /bin/sh www-data -G www-data
 
 COPY --chown=www-data:www-data . /etc/nginx
 COPY --chown=www-data:www-data nginx.conf /etc/nginx/nginx.conf.template

--- a/docker/web/development/Dockerfile
+++ b/docker/web/development/Dockerfile
@@ -1,19 +1,16 @@
-FROM php:8.1-fpm as gewisdb_web_development
+FROM php:8.1-fpm-alpine as gewisdb_web_development
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        cron \
-        git \
-        libcurl4-openssl-dev \
-        libicu-dev \
-        libpq-dev \
-        libsqlite3-dev \
-        libzip-dev \
-        nano \
-        unzip \
-        zip \
-    && apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    $PHPIZE_DEPS \
+    curl-dev \
+    git \
+    icu-dev \
+    libpq-dev \
+    libzip-dev \
+    nano \
+    sqlite-dev \
+    unzip \
+    zip
 
 RUN docker-php-ext-install -j$(nproc) \
     calendar \
@@ -34,13 +31,6 @@ WORKDIR /code
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php composer-setup.php \
     && php -r "unlink('composer-setup.php');"
-
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        nodejs \
-    && apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=www-data:www-data ./composer.json ./
 RUN php composer.phar install

--- a/docker/web/development/Dockerfile
+++ b/docker/web/development/Dockerfile
@@ -1,30 +1,38 @@
 FROM php:8.1-fpm-alpine as gewisdb_web_development
 
-RUN apk add --no-cache \
-    $PHPIZE_DEPS \
-    curl-dev \
-    git \
-    icu-dev \
-    libpq-dev \
-    libzip-dev \
-    nano \
-    sqlite-dev \
-    unzip \
-    zip
-
-RUN docker-php-ext-install -j$(nproc) \
-    calendar \
-    curl \
-    intl \
-    opcache \
-    pgsql \
-    pdo \
-    pdo_pgsql \
-    pdo_sqlite \
-    zip
-
-RUN pecl install xdebug \
-    && docker-php-ext-enable xdebug
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        curl-dev \
+        icu-dev \
+        libpq-dev \
+        libzip-dev \
+        sqlite-dev \
+    && apk add --no-cache --virtual .runtime-programs \
+        git \
+        nano \
+        unzip \
+        zip \
+    && docker-php-ext-install -j$(nproc) \
+        calendar \
+        curl \
+        intl \
+        opcache \
+        pgsql \
+        pdo \
+        pdo_pgsql \
+        pdo_sqlite \
+        zip \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && rm -r /tmp/pear \
+    && runtimeDeps="$( \
+            scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        )" \
+    && apk add --virtual .gewisdb-runtime-deps $runtimeDeps \
+    && apk del .build-deps
 
 WORKDIR /code
 

--- a/docker/web/production/Dockerfile
+++ b/docker/web/production/Dockerfile
@@ -1,16 +1,12 @@
-FROM php:8.1-fpm as php-target
+FROM php:8.1-fpm-alpine as php-target
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        cron \
-        git \
-        libcurl4-openssl-dev \
-        libicu-dev \
-        libpq-dev \
-        libzip-dev \
-        unzip \
-    && apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    curl-dev \
+    git \
+    icu-dev \
+    libpq-dev \
+    libzip-dev \
+    unzip
 
 RUN docker-php-ext-install -j$(nproc) \
     calendar \

--- a/docker/web/production/Dockerfile
+++ b/docker/web/production/Dockerfile
@@ -1,21 +1,28 @@
 FROM php:8.1-fpm-alpine as php-target
 
-RUN apk add --no-cache \
-    curl-dev \
-    git \
-    icu-dev \
-    libpq-dev \
-    libzip-dev \
-    unzip
-
-RUN docker-php-ext-install -j$(nproc) \
-    calendar \
-    curl \
-    intl \
-    opcache \
-    pgsql \
-    pdo_pgsql \
-    zip
+RUN apk add --no-cache --virtual .build-deps \
+        curl-dev \
+        icu-dev \
+        libpq-dev \
+        libzip-dev \
+    && apk add --no-cache --virtual .runtime-programs \
+        unzip \
+    && docker-php-ext-install -j$(nproc) \
+        calendar \
+        curl \
+        intl \
+        opcache \
+        pgsql \
+        pdo_pgsql \
+        zip \
+    && runtimeDeps="$( \
+            scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        )" \
+    && apk add --virtual .gewisdb-runtime-deps $runtimeDeps \
+    && apk del .build-deps
 
 FROM php-target as gewisdb_web_production
 WORKDIR /code

--- a/printing/scriptje.sh
+++ b/printing/scriptje.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # todo wkhtmltopdf
 

--- a/translate-helper
+++ b/translate-helper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 dir="$PWD"
 cd `dirname $0`
 


### PR DESCRIPTION
~~I wanted to change a bit more, but I think this is a good start.~~ This replaces all the existing base images for our images with Alpine based images. This should result in images that are generally ~~200-300~~ **500** MB smaller.

**Important changes:**
- NGINX no longer uses the latest version (now `stable`) and
- `bash` is no longer available (use `sh`).