### PR TITLE
Make membership type changes retroactive again

### DIFF
--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -39,6 +39,7 @@ use Laminas\Mime\{
 };
 use Laminas\View\Model\ViewModel;
 use Laminas\View\Renderer\PhpRenderer;
+use RuntimeException;
 
 class Member
 {
@@ -511,7 +512,7 @@ class Member
         // It is not possible to have another membership type after being an honorary member and there does not exist a
         // good transition to a different membership type (because of the dates/expiration etc.).
         if (MembershipTypes::Honorary === $member->getType()) {
-            throw new \RuntimeException('Er is geen pad waarop dit lid correct een ander lidmaatschapstype kan krijgen');
+            throw new RuntimeException('Er is geen pad waarop dit lid correct een ander lidmaatschapstype kan krijgen');
         }
 
         $form->setData($data);
@@ -527,14 +528,14 @@ class Member
         $date->setTime(0, 0);
         $member->setChangedOn($date);
 
-        // update expiration and 'membership ends on' date (should become effective at the end of the current
+        // update expiration and 'membership ends on' date (should become effective at the end of the previous
         // association year).
         $expiration = clone $date;
 
         if ($expiration->format('m') >= 7) {
-            $year = (int) $expiration->format('Y') + 2;
-        } else {
             $year = (int) $expiration->format('Y') + 1;
+        } else {
+            $year = (int) $expiration->format('Y');
         }
 
         switch (MembershipTypes::from($data['type'])) {
@@ -542,19 +543,20 @@ class Member
                 $member->setIsStudying(true);
                 $member->setMembershipEndsOn(null);
                 $member->setType(MembershipTypes::Ordinary);
-                $year -= 1;
                 break;
             case MembershipTypes::External:
                 $member->setIsStudying(true);
                 $membershipEndsOn = clone $expiration;
                 $membershipEndsOn->setDate($year - 1, 7, 1);
                 $member->setMembershipEndsOn($membershipEndsOn);
+                $member->setType(MembershipTypes::External);
                 break;
             case MembershipTypes::Graduate:
                 $member->setIsStudying(false);
                 $membershipEndsOn = clone $expiration;
                 $membershipEndsOn->setDate($year - 1, 7, 1);
                 $member->setMembershipEndsOn($membershipEndsOn);
+                $member->setType(MembershipTypes::Graduate);
                 break;
             case MembershipTypes::Honorary:
                 $member->setIsStudying(false);


### PR DESCRIPTION
This puts back the original idea of how manual membership type changes are computed. They are now retroactively applied. Any changes made will appear to have been like this since the end of the previous association year.

For example, if a member is currently `graduate` on 2022-08-04 with a `membershipEndsOn` of 2022-07-1, changing them to `member` removes the `membershipEndsOn` and puts their `expiration` on 2023-07-01.

Another example, if a member is currently `member` on 2022-08-04, changing them to `external` will put `membershipEndsOn` to 2022-07-01 and their `expiration` on 2023-07-01.

Fixes #170.