### PR TITLE
Don't show historic organ installations for simple members

### DIFF
--- a/module/Database/src/Controller/MemberController.php
+++ b/module/Database/src/Controller/MemberController.php
@@ -87,9 +87,12 @@ class MemberController extends AbstractActionController
     {
         $lidnr = (int) $this->params()->fromRoute('id');
         $member = $this->memberService->getMemberWithDecisions($lidnr);
+        $hasCorrectInstallations = true;
 
         if (null === $member) {
             $member = $this->memberService->getMember($lidnr);
+            // `$member` is simple and has no correct installations (otherwise it would not have been `null`).
+            $hasCorrectInstallations = false;
 
             if (null === $member) {
                 return $this->notFoundAction();
@@ -100,7 +103,10 @@ class MemberController extends AbstractActionController
             return $this->memberIsDeleted($member);
         }
 
-        return new ViewModel(['member' => $member]);
+        return new ViewModel([
+            'member' => $member,
+            'hasCorrectInstallations' => $hasCorrectInstallations,
+        ]);
     }
 
     /**

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -4,6 +4,10 @@ use Application\Model\Enums\{
     AddressTypes,
     MembershipTypes,
 };
+use Database\Model\Member as MemberModel;
+
+/** @var MemberModel $member */
+/** @var bool $hasCorrectInstallations */
 
 ?>
 <div class="row">
@@ -125,17 +129,25 @@ switch ($member->getType()) {
             'id' => $member->getLidnr()
         )) ?>" class="btn btn-danger">Verwijder lid</a>
     <h3>Lidmaatschap commissies en disputen</h3>
-    <ul>
-        <?php foreach ($member->getInstallations() as $install): ?>
-            <li><a href="<?= $this->url('organ/view', array(
-            'type' => $install->getFoundation()->getDecision()->getMeeting()->getType()->value,
-            'number' => $install->getFoundation()->getDecision()->getMeeting()->getNumber(),
-            'point' => $install->getFoundation()->getDecision()->getPoint(),
-            'decision' => $install->getFoundation()->getDecision()->getNumber(),
-            'subdecision' => $install->getFoundation()->getNumber()
-        )) ?>"><?= $install->getFoundation()->getAbbr() ?></a></li>
-        <?php endforeach; ?>
-    </ul>
+    <?php if ($hasCorrectInstallations): ?>
+        <ul>
+            <?php foreach ($member->getInstallations() as $install): ?>
+                <li>
+                    <a href="<?= $this->url('organ/view', array(
+                        'type' => $install->getFoundation()->getDecision()->getMeeting()->getType()->value,
+                        'number' => $install->getFoundation()->getDecision()->getMeeting()->getNumber(),
+                        'point' => $install->getFoundation()->getDecision()->getPoint(),
+                        'decision' => $install->getFoundation()->getDecision()->getNumber(),
+                        'subdecision' => $install->getFoundation()->getNumber()
+                    )) ?>">
+                        <?= $install->getFoundation()->getAbbr() ?>
+                    </a>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php else: ?>
+        <p><?= $this->translate('This member is not installed in an organ.') ?></p>
+    <?php endif; ?>
 </div>
 <div class="col-md-6">
 <h3>Adressen</h3>


### PR DESCRIPTION
Due to my refactoring w.r.t. the retrieval of `Member` objects the installations shown on a member's information page would be incorrect if the member was retrieved as a "simple" member.

These members do not have any "active" installations, but they can have old installations. This means that by calling `getInstallations()` all these installations would be returned. This should not be the case.