### PR TITLE
Unable to delete `Foundation` installation

### DIFF
--- a/module/Report/src/Model/Organ.php
+++ b/module/Report/src/Model/Organ.php
@@ -21,6 +21,7 @@ use Doctrine\ORM\Mapping\{
     OneToOne,
 };
 use Report\Model\SubDecision\Foundation;
+use Report\Model\SubDecision\FoundationReference;
 
 /**
  * Organ entity.
@@ -121,6 +122,7 @@ class Organ
         name: "organ_id",
         referencedColumnName: "id",
         nullable: false,
+        onDelete: "CASCADE",
     )]
     #[InverseJoinColumn(
         name: "meeting_type",

--- a/module/Report/src/Model/Organ.php
+++ b/module/Report/src/Model/Organ.php
@@ -116,7 +116,10 @@ class Organ
     /**
      * Reference to subdecisions.
      */
-    #[ManyToMany(targetEntity: SubDecision::class)]
+    #[ManyToMany(
+        targetEntity: SubDecision::class,
+        cascade: ["remove", "persist"],
+    )]
     #[JoinTable(name: "organs_subdecisions")]
     #[JoinColumn(
         name: "organ_id",


### PR DESCRIPTION
This ensures that `Foundation` subdecisions can be deleted properly by cascading final `DELETE`s to the `organs_subdecisions` join-table. Additionally, this ensures that that same table is properly populated when decisions are added to the database, instead of after a forced (re)generation.