### PR TITLE
Generate a `Message-Id` for e-mails

### DIFF
--- a/module/Checker/src/Service/Checker.php
+++ b/module/Checker/src/Service/Checker.php
@@ -21,6 +21,7 @@ use Checker\Service\{
 use Database\Model\Member as MemberModel;
 use Database\Model\Meeting as MeetingModel;
 use DateTime;
+use Laminas\Mail\Header\MessageId;
 use Laminas\Mail\Message;
 use Laminas\Mail\Transport\TransportInterface;
 
@@ -104,6 +105,7 @@ class Checker
     private function sendMail($body): void
     {
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->addTo($this->config['email']['to']['checker_result'])
             ->addFrom($this->config['email']['from'])
             ->setSubject('Database Checker Report')

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -35,8 +35,9 @@ use Database\Model\{
 };
 use Database\Service\MailingList as MailingListService;
 use DateTime;
-use Laminas\Mail\Transport\TransportInterface;
+use Laminas\Mail\Header\MessageId;
 use Laminas\Mail\Message;
+use Laminas\Mail\Transport\TransportInterface;
 use Laminas\Mime\{
     Mime,
     Part as MimePart,
@@ -175,6 +176,7 @@ class Member
         }
 
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
         $message->setFrom($config['from']);
         $message->addTo($config['to']['subscription']);
@@ -182,6 +184,7 @@ class Member
         $this->getMailTransport()->send($message);
 
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
         $message->setFrom($config['from']);
         $message->addTo($member->getEmail());
@@ -212,6 +215,7 @@ class Member
         $mimeMessage->addPart($html);
 
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
         $message->setFrom($config['from']);
         $message->addTo($config['to']['subscription']);
@@ -219,6 +223,7 @@ class Member
         $this->getMailTransport()->send($message);
 
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
         $message->setFrom($config['from']);
         $message->addTo($member->getEmail());

--- a/module/Report/src/Service/Meeting.php
+++ b/module/Report/src/Service/Meeting.php
@@ -12,8 +12,9 @@ use Database\Model\{
 use Doctrine\ORM\EntityManager;
 use Exception;
 use LogicException;
-use Laminas\Mail\Transport\TransportInterface;
+use Laminas\Mail\Header\MessageId;
 use Laminas\Mail\Message;
+use Laminas\Mail\Transport\TransportInterface;
 use Laminas\ProgressBar\Adapter\Console;
 use Laminas\ProgressBar\ProgressBar;
 use Report\Model\{
@@ -364,6 +365,7 @@ class Meeting
             BODYTEXT;
 
         $message = new Message();
+        $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($body);
         $message->setFrom($config['from']);
         $message->addTo($config['to']['report_error']);


### PR DESCRIPTION
`laminas/laminas-mail` does not do this automatically and not having a `Message-Id` can be bad for the spam score of our e-mails.

Fixes #226.