### PR TITLE
Switch `AV` to `ALV`, including the taskforce and committee organs

### DIFF
--- a/module/Application/src/Model/Enums/MeetingTypes.php
+++ b/module/Application/src/Model/Enums/MeetingTypes.php
@@ -8,7 +8,7 @@ namespace Application\Model\Enums;
 enum MeetingTypes: string
 {
     case BV = 'BV'; // bestuursvergadering
-    case AV = 'AV'; // algemene leden vergadering
+    case ALV = 'ALV'; // algemene leden vergadering
     case VV = 'VV'; // voorzitters vergadering
     case VIRT = 'Virt'; // virtual meeting
 

--- a/module/Application/src/Model/Enums/OrganTypes.php
+++ b/module/Application/src/Model/Enums/OrganTypes.php
@@ -18,10 +18,10 @@ enum OrganTypes: string
     {
         return match ($this) {
             self::Committee => 'Commissie',
-            self::AVC => 'AV-commissie',
+            self::AVC => 'ALV-Commissie',
             self::Fraternity => 'Dispuut',
             self::KCC => 'KCC',
-            self::AVW => 'AV-werkgroep',
+            self::AVW => 'ALV-Werkgroep',
             self::RvA => 'RvA',
         };
     }

--- a/module/Checker/src/Model/Error/OrganMeetingType.php
+++ b/module/Checker/src/Model/Error/OrganMeetingType.php
@@ -10,7 +10,7 @@ use Database\Model\SubDecision\Foundation as FoundationModel;
 /**
  * Error for when an organ is founded during a meeting that it cannot be founded in.
  *
- * AV-commissies can only be created during AV's
+ * ALV-commissies can only be created during ALV's
  * All other organs can only be created during BV's and Virt's
  *
  * @extends Error<FoundationModel>

--- a/module/Checker/src/Service/Checker.php
+++ b/module/Checker/src/Service/Checker.php
@@ -236,7 +236,7 @@ class Checker
 
     /**
      * Checks all Organ creation, and check if they are created at the correct Meeting
-     * e.g. AVCommissies are only created at an AV
+     * e.g. ALV-Commissies are only created at an ALV
      *
      * @param MeetingModel $meeting After which meeting do we do the validation
      *
@@ -251,9 +251,9 @@ class Checker
             $organType = $organ->getOrganType();
             $meetingType = $organ->getDecision()->getMeeting()->getType();
 
-            // Chair's Meetings (VV) cannot be used to found an(y) organ. During General Members Meetings (AV) only
+            // Chair's Meetings (VV) cannot be used to found an(y) organ. During General Members Meetings (ALV) only
             // specific organs can be founded, namely: AVC, AVW, KCC, Fraternity, and RvA. Furthermore, these organ can
-            // only be founded in AVs, not in any other meeting (except virtual meetings).
+            // only be founded in ALVs, not in any other meeting (except virtual meetings).
             //
             // However, this only holds after October 7, 2021, when the Internal Regulations of the association were
             // updated to reflect changes with respect to fraternities (before October 7, 2021, they could be founded
@@ -261,7 +261,7 @@ class Checker
             if (
                 MeetingTypes::VV === $meetingType
                 || (
-                    MeetingTypes::AV === $meetingType
+                    MeetingTypes::ALV === $meetingType
                     && (
                         OrganTypes::AVC !== $organType
                         && OrganTypes::AVW !== $organType
@@ -278,7 +278,7 @@ class Checker
             // Special case for the updates to the internal regulations. Skip fraternities when they were founded during
             // a BV before October 7, 2021.
             if (
-                MeetingTypes::AV !== $meetingType
+                MeetingTypes::ALV !== $meetingType
                 && MeetingTypes::VIRT !== $meetingType
                 && (
                     OrganTypes::AVC === $organType

--- a/module/Checker/test/Model/Error.php
+++ b/module/Checker/test/Model/Error.php
@@ -25,7 +25,7 @@ abstract class Error extends TestCase
     public function getMeeting(): MeetingModel
     {
         $meeting = new MeetingModel();
-        $meeting->setType(MeetingTypes::AV);
+        $meeting->setType(MeetingTypes::ALV);
         $meeting->setNumber(1);
 
         return $meeting;

--- a/module/Database/config/module.config.php
+++ b/module/Database/config/module.config.php
@@ -95,7 +95,7 @@ return [
                                 'options' => [
                                     'route' => '/:type/:number/:point/:decision',
                                     'constraints' => [
-                                        'type' => 'AV|BV|VV|Virt',
+                                        'type' => 'ALV|BV|VV|Virt',
                                         'number' => '[0-9]*',
                                         'point' => '[0-9]*',
                                         'decision' => '[0-9]*',
@@ -107,7 +107,7 @@ return [
                                 'options' => [
                                     'route' => '/delete/:type/:number/:point/:decision',
                                     'constraints' => [
-                                        'type' => 'AV|BV|VV|Virt',
+                                        'type' => 'ALV|BV|VV|Virt',
                                         'number' => '[0-9]*',
                                         'point' => '[0-9]*',
                                         'decision' => '[0-9]*',
@@ -124,7 +124,7 @@ return [
                         'options' => [
                             'route' => '/:type/:number',
                             'constraints' => [
-                                'type' => 'AV|BV|VV|Virt',
+                                'type' => 'ALV|BV|VV|Virt',
                                 'number' => '\-?[0-9]*',
                             ],
                             'defaults' => [
@@ -180,7 +180,7 @@ return [
                                 'action' => 'info',
                             ],
                             'constraints' => [
-                                'type' => 'AV|BV|VV|Virt',
+                                'type' => 'ALV|BV|VV|Virt',
                                 'number' => '[0-9]*',
                                 'point' => '[0-9]*',
                                 'decision' => '[0-9]*',
@@ -196,7 +196,7 @@ return [
                                 'action' => 'view',
                             ],
                             'constraints' => [
-                                'type' => 'AV|BV|VV|Virt',
+                                'type' => 'ALV|BV|VV|Virt',
                                 'number' => '[0-9]*',
                                 'point' => '[0-9]*',
                                 'decision' => '[0-9]*',

--- a/module/Database/src/Form/CreateMeeting.php
+++ b/module/Database/src/Form/CreateMeeting.php
@@ -31,7 +31,7 @@ class CreateMeeting extends Form implements InputFilterProviderInterface
                 'label' => 'Vergadertype',
                 'value_options' => [
                     'BV' => 'BV (Bestuursvergadering)',
-                    'AV' => 'AV (Algemene Ledenvergadering)',
+                    'ALV' => 'ALV (Algemene Ledenvergadering)',
                     'VV' => 'VV (Voorzittersvergadering)',
                     'Virt' => 'Virt (Virtuele vergadering)',
                 ],

--- a/module/Database/src/Form/Foundation.php
+++ b/module/Database/src/Form/Foundation.php
@@ -33,8 +33,8 @@ class Foundation extends AbstractDecision implements InputFilterProviderInterfac
                 'label' => 'Type',
                 'value_options' => [
                     'committee' => 'Commissie',
-                    'avc' => 'AV-Commissie',
-                    'avw' => 'AV-Werkgroep',
+                    'avc' => 'ALV-Commissie',
+                    'avw' => 'ALV-Werkgroep',
                     'kcc' => 'KCC',
                     'fraternity' => 'Dispuut',
                     'rva' => 'RvA',


### PR DESCRIPTION
This is the result of the changes made to the bylaws and internal regulations 1.5 year ago, however, they were never implemented.

This is a dangerous change, as it changes a value that is a fundamental part of almost everything. It also requires an update to GEWISWEB.