### PR TITLE
Filter member search in decisions

### DIFF
--- a/module/Database/src/Controller/MemberController.php
+++ b/module/Database/src/Controller/MemberController.php
@@ -78,6 +78,20 @@ class MemberController extends AbstractActionController
         ]);
     }
 
+    public function searchFilteredAction(): JsonModel
+    {
+        $query = $this->params()->fromQuery('q');
+        $res = $this->memberService->searchFiltered($query);
+
+        $res = array_map(function ($member) {
+            return $member->toArray();
+        }, $res);
+
+        return new JsonModel([
+            'json' => $res,
+        ]);
+    }
+
     /**
      * Show action.
      *

--- a/module/Database/src/Mapper/Member.php
+++ b/module/Database/src/Mapper/Member.php
@@ -51,8 +51,10 @@ class Member
      *
      * @return array<array-key, MemberModel>
      */
-    public function search(string $query): array
-    {
+    public function search(
+        string $query,
+        bool $filtered = false,
+    ): array {
         $qb = $this->em->createQueryBuilder();
 
         $qb->select('m')
@@ -74,6 +76,10 @@ class Member
         if (is_numeric($query)) {
             $qb->orWhere("m.lidnr = :nr");
             $qb->setParameter(':nr', $query);
+        }
+
+        if ($filtered) {
+            $qb->andWhere('m.deleted = False AND m.hidden = False AND m.expiration > CURRENT_TIMESTAMP()');
         }
 
         return $qb->getQuery()->getResult();

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -499,6 +499,16 @@ class Member
     }
 
     /**
+     * Search for a member that is not deleted, expired, and hidden.
+     *
+     * @return array<array-key, MemberModel>
+     */
+    public function searchFiltered(string $query): array
+    {
+        return $this->getMemberMapper()->search($query, true);
+    }
+
+    /**
      * Search for a prospective member.
      *
      * @return array<array-key, ProspectiveMemberModel>

--- a/module/Database/view/database/meeting/abolishform.phtml
+++ b/module/Database/view/database/meeting/abolishform.phtml
@@ -22,7 +22,7 @@ $(document).ready(function () {
                 // make an AJAX request
                 $.ajax({
                     dataType: 'json',
-                    url: '<?= $this->url('organ/default', array('action' => 'search')) ?>?q=' + rq.term,
+                    url: '<?= $this->url('organ/default', ['action' => 'search']) ?>?q=' + rq.term,
                     context: document.body
                 }).done(function(data) {
                     var ret = [];

--- a/module/Database/view/database/meeting/board/installform.phtml
+++ b/module/Database/view/database/meeting/board/installform.phtml
@@ -7,7 +7,7 @@ $(document).ready(function() {
             // make an AJAX request
             $.ajax({
                 dataType: 'json',
-                url: '<?= $this->url('member/default', array('action' => 'search')) ?>?q=' + rq.term,
+                url: '<?= $this->url('member/default', ['action' => 'searchFiltered']) ?>?q=' + rq.term,
                 context: document.body
             }).done(function(data) {
                 var ret = [];

--- a/module/Database/view/database/meeting/budgetform.phtml
+++ b/module/Database/view/database/meeting/budgetform.phtml
@@ -7,7 +7,7 @@ $(document).ready(function () {
                 // make an AJAX request
                 $.ajax({
                     dataType: 'json',
-                    url: '<?= $this->url('member/default', array('action' => 'search')) ?>?q=' + rq.term,
+                    url: '<?= $this->url('member/default', ['action' => 'searchFiltered']) ?>?q=' + rq.term,
                     context: document.body
                 }).done(function(data) {
                     var ret = [];

--- a/module/Database/view/database/meeting/foundationform.phtml
+++ b/module/Database/view/database/meeting/foundationform.phtml
@@ -7,7 +7,7 @@
                 // make an AJAX request
                 $.ajax({
                     dataType: 'json',
-                    url: '<?= $this->url('member/default', array('action' => 'search')) ?>?q=' + rq.term,
+                    url: '<?= $this->url('member/default', ['action' => 'searchFiltered']) ?>?q=' + rq.term,
                     context: document.body
                 }).done(function(data) {
                     var ret = [];

--- a/module/Database/view/database/meeting/installform.phtml
+++ b/module/Database/view/database/meeting/installform.phtml
@@ -22,7 +22,7 @@ $(document).ready(function () {
             // make an AJAX request
             $.ajax({
                 dataType: 'json',
-                url: '<?= $this->url('organ/default', array('action' => 'search')) ?>?q=' + rq.term,
+                url: '<?= $this->url('organ/default', ['action' => 'search']) ?>?q=' + rq.term,
                 context: document.body
             }).done(function(data) {
                 var ret = [];
@@ -157,7 +157,7 @@ $(document).ready(function () {
             // make an AJAX request
             $.ajax({
                 dataType: 'json',
-                url: '<?= $this->url('member/default', array('action' => 'search')) ?>?q=' + rq.term,
+                url: '<?= $this->url('member/default', ['action' => 'searchFiltered']) ?>?q=' + rq.term,
                 context: document.body
             }).done(function(data) {
                 var ret = [];

--- a/module/Database/view/database/meeting/key/grantform.phtml
+++ b/module/Database/view/database/meeting/key/grantform.phtml
@@ -7,7 +7,7 @@
                 // make an AJAX request
                 $.ajax({
                     dataType: 'json',
-                    url: '<?= $this->url('member/default', array('action' => 'search')) ?>?q=' + rq.term,
+                    url: '<?= $this->url('member/default', ['action' => 'searchFiltered']) ?>?q=' + rq.term,
                     context: document.body
                 }).done(function(data) {
                     var ret = [];


### PR DESCRIPTION
This makes sure that members who have been deleted, are hidden, or are expired do not appear in the search. This should prevent using/mentioning these members in decisions.

Closes GH-253.