### PR TITLE
Fix e-mails not being sent when headers contain unicode

### DIFF
--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -49,6 +49,7 @@ use ReflectionClass;
 use RuntimeException;
 
 use function bin2hex;
+use function mb_encode_mimeheader;
 use function random_bytes;
 
 class Member
@@ -179,7 +180,7 @@ class Member
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
         $message->setFrom($config['from']['address'], $config['from']['name']);
-        $message->addTo($config['to']['subscription']['address'], $config['to']['subscription']['name']);
+        $message->setTo($config['to']['subscription']['address'], $config['to']['subscription']['name']);
         $message->setSubject('New member subscription: ' . $member->getFullName());
         $this->getMailTransport()->send($message);
 
@@ -187,7 +188,15 @@ class Member
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
         $message->setFrom($config['from']['address'], $config['from']['name']);
-        $message->addTo($member->getEmail(), $member->getFullName());
+        $message->setTo(
+            $member->getEmail(),
+            mb_encode_mimeheader(
+                $member->getFullName(),
+                'UTF-8',
+                'Q',
+                '',
+            ),
+        );
         $message->setReplyTo($config['to']['subscription']['address'], $config['to']['subscription']['name']);
         $message->setSubject('GEWIS Subscription');
         $this->getMailTransport()->send($message);
@@ -218,7 +227,7 @@ class Member
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
         $message->setFrom($config['from']['address'], $config['from']['name']);
-        $message->addTo($config['to']['subscription']['address'], $config['to']['subscription']['name']);
+        $message->setTo($config['to']['subscription']['address'], $config['to']['subscription']['name']);
         $message->setSubject('Membership confirmed: ' . $member->getFullName());
         $this->getMailTransport()->send($message);
 
@@ -226,7 +235,15 @@ class Member
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($mimeMessage);
         $message->setFrom($config['from']['address'], $config['from']['name']);
-        $message->addTo($member->getEmail(), $member->getFullName());
+        $message->setTo(
+            $member->getEmail(),
+            mb_encode_mimeheader(
+                $member->getFullName(),
+                'UTF-8',
+                'Q',
+                '',
+            ),
+        );
         $message->setReplyTo($config['to']['subscription']['address'], $config['to']['subscription']['name']);
         $message->setSubject('Your GEWIS membership has been confirmed');
         $this->getMailTransport()->send($message);

--- a/module/Report/src/Service/Meeting.php
+++ b/module/Report/src/Service/Meeting.php
@@ -414,7 +414,7 @@ class Meeting
         $message->getHeaders()->addHeader((new MessageId())->setId());
         $message->setBody($body);
         $message->setFrom($config['from']['address'], $config['from']['name']);
-        $message->addTo($config['to']['report_error']['address'], $config['to']['report_error']['name']);
+        $message->setTo($config['to']['report_error']['address'], $config['to']['report_error']['name']);
         $message->setSubject('Database fout');
 
         $this->mailTransport->send($message);


### PR DESCRIPTION
Unfortunately, the e-mail protocols are still archaic. Even with RFCs like 6532, there is no support for actual unicode characters in e-mail headers.

We can circumvent this to a certain degree by re-encoding strings that may contain unicode characters. This is done through `mb_encode_mimeheader`. However, it should be pointed out that this function has a hard line length of 74 characters. This is rather annoying (and incredibly stupid), as it also breaks the e-mail headers (CRLF injection), so we also have to fix this by replacing the EOL with nothing.

This fixes GH-263.