### PR TITLE
More and better typing

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -20,10 +20,13 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: '8.2'
-                    tools: cs2pr, phpcs, php-cs-fixer
+                    tools: cs2pr, php-cs-fixer
+
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Run PHPCS
-                run: phpcs --standard=PSR1,PSR12 --extensions=php,dist --report=checkstyle -q module config | cs2pr --graceful-warnings
+                run: vendor/bin/phpcs --standard=PSR1,PSR12 --extensions=php,dist --report=checkstyle -q module config | cs2pr --graceful-warnings
 
             -   name: Run php-cs-fixer
                 run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -43,17 +43,6 @@ jobs:
                     extensions: calendar, curl, intl, opcache, pgsql, pdo_pgsql, zip, memcached, xdebug
                     tools: cs2pr
 
-            -   name: Get Composer cache directory
-                id: composer-cache-head
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: Cache dependencies
-                uses: actions/cache@v3
-                with:
-                    path: ${{ steps.composer-cache-head.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: ${{ runner.os }}-composer-
-
             -   name: Extract configuration files
                 run: |
                     cp config/autoload/doctrine.local.development.php.dist config/autoload/doctrine.local.php
@@ -68,8 +57,8 @@ jobs:
                     git update-ref refs/heads/temp-phpstanpr refs/remotes/origin/master
                     git checkout --detach temp-phpstanpr
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Load environment variables
                 uses: c-py/action-dotenv-to-setenv@v3
@@ -101,8 +90,8 @@ jobs:
                     git checkout --theirs -- config/modules.config.php
                     git checkout -
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Load environment variables
                 uses: c-py/action-dotenv-to-setenv@v3
@@ -140,17 +129,6 @@ jobs:
                     php-version: '8.2'
                     extensions: calendar, curl, intl, opcache, pgsql, pdo_pgsql, zip, memcached, xdebug
 
-            -   name: Get Composer cache directory
-                id: composer-cache-head
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: Cache dependencies
-                uses: actions/cache@v3
-                with:
-                    path: ${{ steps.composer-cache-head.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: ${{ runner.os }}-composer-
-
             -   name: Extract configuration files
                 run: |
                     cp config/autoload/doctrine.local.development.php.dist config/autoload/doctrine.local.php
@@ -163,8 +141,8 @@ jobs:
                     git update-ref refs/heads/temp-psalmpr refs/remotes/origin/master
                     git checkout --detach temp-psalmpr
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Load environment variables
                 uses: c-py/action-dotenv-to-setenv@v3
@@ -182,8 +160,8 @@ jobs:
                     git checkout --theirs -- config/modules.config.php
                     git checkout -
 
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Load environment variables
                 uses: c-py/action-dotenv-to-setenv@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,19 +25,8 @@ jobs:
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            -   name: Cache dependencies
-                uses: actions/cache@v3
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: ${{ runner.os }}-composer-
-
-            -   name: Install dependencies
-                run: composer install --no-interaction
+            -   name: Install dependencies with Composer
+                uses: ramsey/composer-install@v2
 
             -   name: Extract configuration files
                 run: |

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="codingStandard" value="PSR12" />
+    <option name="extensions" value="php" />
+    <option name="highlightLevel" value="WARNING" />
+    <option name="showSniffs" value="true" />
+    <option name="transferred" value="true" />
+  </component>
   <component name="PhpCSFixer">
     <phpcsfixer_settings>
       <PhpCSFixerConfiguration tool_path="$PROJECT_DIR$/vendor/bin/php-cs-fixer" />
@@ -166,12 +179,14 @@
       <path value="$PROJECT_DIR$/vendor/spatie/array-to-xml" />
       <path value="$PROJECT_DIR$/vendor/fidry/cpu-core-counter" />
       <path value="$PROJECT_DIR$/vendor/stella-maris/clock" />
+      <path value="$PROJECT_DIR$/vendor/slevomat/coding-standard" />
+      <path value="$PROJECT_DIR$/vendor/dealerdirect/phpcodesniffer-composer-installer" />
     </include_path>
   </component>
   <component name="PhpInterpreters">
     <interpreters>
-      <interpreter id="b6502dad-7c78-4cdb-b177-76e9f54dbca6" name="abc-db.docker-registry.gewis.nl/gewisdb_web:development" home="docker://DATA" debugger_id="php.debugger.XDebug">
-        <remote_data INTERPRETER_PATH="php" HELPERS_PATH="/opt/.phpstorm_helpers" INITIALIZED="false" VALID="true" RUN_AS_ROOT_VIA_SUDO="false" DOCKER_ACCOUNT_NAME="Docker" DOCKER_IMAGE_NAME="abc-db.docker-registry.gewis.nl/gewisdb_web:development" DOCKER_REMOTE_PROJECT_PATH="/opt/project" />
+      <interpreter id="b6502dad-7c78-4cdb-b177-76e9f54dbca6" name="abc-db.docker-registry.gewis.nl/gewisdb_web:development" home="docker://DATA" false="false" debugger_id="php.debugger.XDebug">
+        <remote_data INTERPRETER_PATH="php" HELPERS_PATH="/opt/.phpstorm_helpers" VALID="true" RUN_AS_ROOT_VIA_SUDO="false" DOCKER_ACCOUNT_NAME="Docker" DOCKER_IMAGE_NAME="abc-db.docker-registry.gewis.nl/gewisdb_web:development" DOCKER_REMOTE_PROJECT_PATH="/opt/project" />
       </interpreter>
     </interpreters>
   </component>
@@ -244,6 +259,12 @@
       <PhpStanConfiguration tool_path="$PROJECT_DIR$/vendor/bin/phpstan" />
     </PhpStan_settings>
   </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="config" value="$PROJECT_DIR$/phpstan.neon" />
+    <option name="fullProject" value="true" />
+    <option name="level" value="5" />
+    <option name="transferred" value="true" />
+  </component>
   <component name="PhpUnit">
     <phpunit_settings>
       <phpunit_by_interpreter interpreter_id="b6502dad-7c78-4cdb-b177-76e9f54dbca6" bootstrap_file_path="/code/bootstrap.php" configuration_file_path="/code/phpunit.xml" custom_loader_path="/code/vendor/autoload.php" use_bootstrap_file="true" use_configuration_file="true" />
@@ -254,5 +275,9 @@
     <Psalm_settings>
       <PsalmConfiguration tool_path="$PROJECT_DIR$/vendor/bin/psalm" />
     </Psalm_settings>
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="config" value="$PROJECT_DIR$/psalm.xml" />
+    <option name="transferred" value="true" />
   </component>
 </project>

--- a/.idea/phpunit.xml
+++ b/.idea/phpunit.xml
@@ -3,14 +3,8 @@
   <component name="PHPUnit">
     <option name="directories">
       <list>
-        <option value="$PROJECT_DIR$/module/Activity/test" />
         <option value="$PROJECT_DIR$/module/Application/test" />
-        <option value="$PROJECT_DIR$/module/Company/test" />
-        <option value="$PROJECT_DIR$/module/Decision/test" />
-        <option value="$PROJECT_DIR$/module/Education/test" />
-        <option value="$PROJECT_DIR$/module/Frontpage/test" />
-        <option value="$PROJECT_DIR$/module/Photo/test" />
-        <option value="$PROJECT_DIR$/module/User/test" />
+        <option value="$PROJECT_DIR$/module/Checker/test" />
       </list>
     </option>
   </component>

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
         "weirdan/doctrine-psalm-plugin": "^2.6.0",
         "psalm/plugin-phpunit": "^0.18.0",
         "maglnet/composer-require-checker": "^4.3.0",
-        "icanhazstring/composer-unused": "^0.8.2"
+        "icanhazstring/composer-unused": "^0.8.2",
+        "slevomat/coding-standard": "^8.11"
     },
     "config": {
         "preferred-install": {
@@ -86,7 +87,8 @@
             "cweagans/composer-patches": true,
             "laminas/laminas-component-installer": true,
             "phpstan/extension-installer": true,
-            "icanhazstring/composer-unused": true
+            "icanhazstring/composer-unused": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "discard-changes" : true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b32170d1540da1e22090928735ea9672",
+    "content-hash": "6dcde4169d8749f9a6c46ec92094757c",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -6360,6 +6360,84 @@
             "time": "2022-02-25T21:32:43+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "time": "2023-01-05T11:28:13+00:00"
+        },
+        {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "v0.1.1",
             "source": {
@@ -7691,16 +7769,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.15.3",
+            "version": "1.20.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "61800f71a5526081d1b5633766aa88341f1ade76"
+                "reference": "90490bd8fd8530a272043c4950c180b6d0cf5f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/61800f71a5526081d1b5633766aa88341f1ade76",
-                "reference": "61800f71a5526081d1b5633766aa88341f1ade76",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/90490bd8fd8530a272043c4950c180b6d0cf5f81",
+                "reference": "90490bd8fd8530a272043c4950c180b6d0cf5f81",
                 "shasum": ""
             },
             "require": {
@@ -7730,9 +7808,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.15.3"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.2"
             },
-            "time": "2022-12-20T20:56:55+00:00"
+            "time": "2023-04-22T12:59:35+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -9533,6 +9611,71 @@
             "time": "2022-12-12T07:05:02+00:00"
         },
         {
+            "name": "slevomat/coding-standard",
+            "version": "8.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "af87461316b257e46e15bb041dca6fca3796d822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/af87461316b257e46e15bb041dca6fca3796d822",
+                "reference": "af87461316b257e46e15bb041dca6fca3796d822",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": ">=1.20.0 <1.21.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.10.14",
+                "phpstan/phpstan-deprecation-rules": "1.1.3",
+                "phpstan/phpstan-phpunit": "1.3.11",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.6|10.1.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.11.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-04-24T08:19:01+00:00"
+        },
+        {
             "name": "spatie/array-to-xml",
             "version": "2.17.0",
             "source": {
@@ -9598,16 +9741,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -9643,14 +9786,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/config",
@@ -11068,7 +11212,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1.0",
+        "php": "^8.2.0",
         "ext-intl": "*",
         "ext-pdo_pgsql": "*",
         "ext-pgsql": "*",

--- a/config/application.config.php
+++ b/config/application.config.php
@@ -8,6 +8,8 @@
  * @see https://docs.zend.dev/tutorials/advanced-config/#environment-specific-application-configuration
  */
 
+declare(strict_types=1);
+
 return [
     // Retrieve list of modules used in this application.
     'modules' => require __DIR__ . '/modules.config.php',

--- a/config/autoload/doctrine.local.development.php.dist
+++ b/config/autoload/doctrine.local.development.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Doctrine\DBAL\Driver\PDO\PgSQL\Driver as PgSQLDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 

--- a/config/autoload/doctrine.local.production.php.dist
+++ b/config/autoload/doctrine.local.production.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Doctrine\DBAL\Driver\PDO\PgSQL\Driver as PgSQLDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 

--- a/config/autoload/doctrine.local.test.php.dist
+++ b/config/autoload/doctrine.local.test.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver as SQLiteDriver;
 
 // Use the production config, but apply test configs.

--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -12,6 +12,8 @@
  * file.
  */
 
+declare(strict_types=1);
+
 return [
     /**
      * Settings for storing files.

--- a/config/autoload/laminas-developer-tools.local.php.dist
+++ b/config/autoload/laminas-developer-tools.local.php.dist
@@ -6,6 +6,8 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
+declare(strict_types=1);
+
 /**
  * This is configuration for the Laminas\DeveloperTools development toolbar.
  *

--- a/config/autoload/local.development.php.dist
+++ b/config/autoload/local.development.php.dist
@@ -12,6 +12,8 @@
  * credentials from accidentally being committed into version control.
  */
 
+declare(strict_types=1);
+
 return [
     /**
      * Checker service configuration.

--- a/config/autoload/local.production.php.dist
+++ b/config/autoload/local.production.php.dist
@@ -12,6 +12,8 @@
  * credentials from accidentally being committed into version control.
  */
 
+declare(strict_types=1);
+
 return [
     /**
      * Checker service configuration.

--- a/config/autoload/local.test.php.dist
+++ b/config/autoload/local.test.php.dist
@@ -1,3 +1,5 @@
 <?php
 
+declare(strict_types=1);
+
 return require __DIR__ . '/local.php';

--- a/config/development.config.php
+++ b/config/development.config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     // This should be an array of module namespaces used in the application.
     'modules' => [

--- a/config/modules.config.php
+++ b/config/modules.config.php
@@ -6,6 +6,8 @@
  * This should be an array of module namespaces used in the application.
  */
 
+declare(strict_types=1);
+
 return [
     'Laminas\I18n',
     'Laminas\Mvc\I18n',

--- a/config/test.config.php
+++ b/config/test.config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // Use the production config, but apply test configs.
 $applicationConfig = require __DIR__ . '/application.config.php';
 $applicationConfig['module_listener_options']['config_glob_paths'] = [

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Application\Controller\IndexController;
 use Laminas\I18n\Translator\Resources;
 use Laminas\Router\Http\Segment;

--- a/module/Application/src/Controller/IndexController.php
+++ b/module/Application/src/Controller/IndexController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\Controller;
 
 use Laminas\Http\Response;

--- a/module/Application/src/Model/Enums/AddressTypes.php
+++ b/module/Application/src/Model/Enums/AddressTypes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\Model\Enums;
 
 use Laminas\Mvc\I18n\Translator;

--- a/module/Application/src/Model/Enums/MeetingTypes.php
+++ b/module/Application/src/Model/Enums/MeetingTypes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\Model\Enums;
 
 /**

--- a/module/Application/src/Model/Enums/MembershipTypes.php
+++ b/module/Application/src/Model/Enums/MembershipTypes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\Model\Enums;
 
 use Laminas\Mvc\I18n\Translator;

--- a/module/Application/src/Model/Enums/OrganTypes.php
+++ b/module/Application/src/Model/Enums/OrganTypes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\Model\Enums;
 
 /**

--- a/module/Application/src/Model/Enums/PostalRegions.php
+++ b/module/Application/src/Model/Enums/PostalRegions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\Model\Enums;
 
 /**

--- a/module/Application/src/Module.php
+++ b/module/Application/src/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application;
 
 use Application\Service\Factory\FileStorageFactory as FileStorageServiceFactory;
@@ -32,7 +34,7 @@ use Report\Listener\{
 
 class Module
 {
-    public function init(ModuleManager $moduleManager)
+    public function init(ModuleManager $moduleManager): void
     {
         // Register event listener for when all modules are loaded to register our database listeners. This is necessary
         // because `onBootstrap` is never called when using `laminas/laminas-cli`.
@@ -40,7 +42,7 @@ class Module
         $events->attach('loadModules.post', [$this, 'modulesLoaded']);
     }
 
-    public function onBootstrap(MvcEvent $e)
+    public function onBootstrap(MvcEvent $e): void
     {
         $eventManager        = $e->getApplication()->getEventManager();
         $moduleRouteListener = new ModuleRouteListener();
@@ -64,7 +66,7 @@ class Module
         AbstractValidator::setDefaultTranslator($mvcTranslator);
     }
 
-    public function modulesLoaded(EventInterface $event)
+    public function modulesLoaded(EventInterface $event): void
     {
         /** @var ServiceManager $container */
         $container = $event->getParam('ServiceManager');
@@ -79,7 +81,7 @@ class Module
     /**
      * @param MvcEvent $e
      */
-    public function logError($e)
+    public function logError(MvcEvent $e): void
     {
         $container = $e->getApplication()->getServiceManager();
         $logger = $container->get('logger');
@@ -97,7 +99,7 @@ class Module
         $logger->error($e->getError());
     }
 
-    protected function determineLocale(MvcEvent $e)
+    protected function determineLocale(MvcEvent $e): string
     {
         $session = new SessionContainer('lang');
         if (!isset($session->lang)) {

--- a/module/Application/src/Service/Factory/FileStorageFactory.php
+++ b/module/Application/src/Service/Factory/FileStorageFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\Service\Factory;
 
 use Application\Service\FileStorage as FileStorageService;

--- a/module/Application/src/Service/FileStorage.php
+++ b/module/Application/src/Service/FileStorage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\Service;
 
 class FileStorage

--- a/module/Application/src/View/Helper/FileUrl.php
+++ b/module/Application/src/View/Helper/FileUrl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\View\Helper;
 
 use Laminas\View\Helper\AbstractHelper;

--- a/module/Application/src/View/Helper/IsModuleActive.php
+++ b/module/Application/src/View/Helper/IsModuleActive.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Application\View\Helper;
 
 use Laminas\View\Helper\AbstractHelper;

--- a/module/Application/src/View/HelperTrait.php
+++ b/module/Application/src/View/HelperTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\View;
+
+use Laminas\Form\View\HelperTrait as FormHelperTrait;
+use Laminas\I18n\View\HelperTrait as I18nHelperTrait;
+use Laminas\Mvc\Plugin\FlashMessenger\View\HelperTrait as FlashMessengerHelperTrait;
+
+/**
+ * Helper trait for auto-completion of code in modern IDEs.
+ *
+ * The trait provides convenience methods for view helpers, defined in the application module. It is designed to be used
+ * for type-hinting $this variable inside laminas-view templates via doc blocks.
+ *
+ * Other traits from laminas are already chained into this trait. This includes support for the FlashMessenger, Form,
+ * and i18n view helpers.
+ *
+ * @method string fileUrl(string $path)
+ * @method bool moduleIsActive(array $condition)
+ */
+trait HelperTrait
+{
+    use FlashMessengerHelperTrait;
+    use FormHelperTrait;
+    use I18nHelperTrait;
+}

--- a/module/Application/test/AutomaticControllerTest.php
+++ b/module/Application/test/AutomaticControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest;
 
 use Exception;

--- a/module/Application/test/BaseControllerTest.php
+++ b/module/Application/test/BaseControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest;
 
 use Laminas\Mvc\Application;

--- a/module/Application/test/TestConfigProvider.php
+++ b/module/Application/test/TestConfigProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ApplicationTest;
 
 class TestConfigProvider

--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 ?>
 <h1><?php echo $this->translate('A 404 error occurred') ?></h1>
 <h2><?php echo $this->message ?></h2>

--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1><?php echo $this->translate('A 404 error occurred') ?></h1>
 <h2><?php echo $this->message ?></h2>
 

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1><?php echo $this->translate('An error occurred') ?></h1>
 <h2><?php echo $this->message ?></h2>
 

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1><?php echo $this->translate('An error occurred') ?></h1>
 <h2><?php echo $this->message ?></h2>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laminas\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger;
 use User\Model\User;
 

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-use Laminas\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger;
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
 use User\Model\User;
 
-$lang = $this->plugin('translate')->getTranslator()->getLocale();
+/** @var PhpRenderer|HelperTrait $this */
 
-// The FlashMessenger config does allow for namespaced options, hence we need to define all classes below.
-/** @var FlashMessenger $flash */
-$flash = $this->plugin('FlashMessenger');
+$lang = $this->plugin('translate')->getTranslator()->getLocale();
 
 echo $this->doctype();
 ?>
@@ -232,11 +231,11 @@ $(document).ready(function() {
         </nav>
 <?php endif ?>
         <div class="container">
-            <?= $flash->render('default', ['alert', 'alert-dismissible', 'alert-info']) ?>
-            <?= $flash->render('error', ['alert', 'alert-dismissible', 'alert-danger']) ?>
-            <?= $flash->render('info', ['alert', 'alert-dismissible', 'alert-info']) ?>
-            <?= $flash->render('success', ['alert', 'alert-dismissible', 'alert-success']) ?>
-            <?= $flash->render('warning', ['alert', 'alert-dismissible', 'alert-warning']) ?>
+            <?= $this->flashMessenger()->render('default', ['alert', 'alert-dismissible', 'alert-info']) ?>
+            <?= $this->flashMessenger()->render('error', ['alert', 'alert-dismissible', 'alert-danger']) ?>
+            <?= $this->flashMessenger()->render('info', ['alert', 'alert-dismissible', 'alert-info']) ?>
+            <?= $this->flashMessenger()->render('success', ['alert', 'alert-dismissible', 'alert-success']) ?>
+            <?= $this->flashMessenger()->render('warning', ['alert', 'alert-dismissible', 'alert-warning']) ?>
             <?php echo $this->content; ?>
             <hr>
             <footer>

--- a/module/Checker/config/module.config.php
+++ b/module/Checker/config/module.config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Checker\Command\{
     CheckAuthenticationKeysCommand,
     CheckDatabaseCommand,

--- a/module/Checker/src/Command/AbstractCheckerCommand.php
+++ b/module/Checker/src/Command/AbstractCheckerCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Command;
 
 use Checker\Service\Checker as CheckerService;

--- a/module/Checker/src/Command/CheckAuthenticationKeysCommand.php
+++ b/module/Checker/src/Command/CheckAuthenticationKeysCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/module/Checker/src/Command/CheckDatabaseCommand.php
+++ b/module/Checker/src/Command/CheckDatabaseCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/module/Checker/src/Command/CheckDischargesCommand.php
+++ b/module/Checker/src/Command/CheckDischargesCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/module/Checker/src/Command/CheckMembershipExpirationCommand.php
+++ b/module/Checker/src/Command/CheckMembershipExpirationCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/module/Checker/src/Command/CheckMembershipTUeCommand.php
+++ b/module/Checker/src/Command/CheckMembershipTUeCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/module/Checker/src/Command/CheckMembershipTypeCommand.php
+++ b/module/Checker/src/Command/CheckMembershipTypeCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/module/Checker/src/Command/Factory/AbstractCheckerCommandFactory.php
+++ b/module/Checker/src/Command/Factory/AbstractCheckerCommandFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Command\Factory;
 
 use Checker\Service\Checker as CheckerService;

--- a/module/Checker/src/Mapper/Factory/InstallationFactory.php
+++ b/module/Checker/src/Mapper/Factory/InstallationFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper\Factory;
 
 use Checker\Mapper\Installation as InstallationMapper;

--- a/module/Checker/src/Mapper/Factory/KeyFactory.php
+++ b/module/Checker/src/Mapper/Factory/KeyFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper\Factory;
 
 use Checker\Mapper\Key as KeyMapper;

--- a/module/Checker/src/Mapper/Factory/MemberFactory.php
+++ b/module/Checker/src/Mapper/Factory/MemberFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper\Factory;
 
 use Checker\Mapper\Member as MemberMapper;

--- a/module/Checker/src/Mapper/Factory/OrganFactory.php
+++ b/module/Checker/src/Mapper/Factory/OrganFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper\Factory;
 
 use Checker\Mapper\Organ as OrganMapper;

--- a/module/Checker/src/Mapper/Filter.php
+++ b/module/Checker/src/Mapper/Filter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper;
 
 use Database\Model\SubDecision\Destroy as DestroyModel;

--- a/module/Checker/src/Mapper/Installation.php
+++ b/module/Checker/src/Mapper/Installation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper;
 
 use Database\Model\Meeting as MeetingModel;

--- a/module/Checker/src/Mapper/Key.php
+++ b/module/Checker/src/Mapper/Key.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper;
 
 use Database\Model\Meeting as MeetingModel;

--- a/module/Checker/src/Mapper/Member.php
+++ b/module/Checker/src/Mapper/Member.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper;
 
 use Database\Model\Member as MemberModel;
+use DateTime;
 use Doctrine\ORM\EntityManager;
 
 /**
@@ -33,7 +36,7 @@ class Member
      *
      * @return array
      */
-    public function getMembersToCheck($limit)
+    public function getMembersToCheck(int $limit): array
     {
         $qb = $this->em->createQueryBuilder();
 
@@ -59,7 +62,7 @@ class Member
      *
      * @return array
      */
-    public function getEndingMembershipsWithNormalTypes()
+    public function getEndingMembershipsWithNormalTypes(): array
     {
         $qb = $this->em->createQueryBuilder();
 
@@ -79,7 +82,7 @@ class Member
      *
      * @return array
      */
-    public function getExpiringMembershipsWithNormalTypes()
+    public function getExpiringMembershipsWithNormalTypes(): array
     {
         $qb = $this->em->createQueryBuilder();
 
@@ -111,7 +114,7 @@ class Member
     /**
      * @return \DateTime
      */
-    private function getEndOfCurrentAssociationYear()
+    private function getEndOfCurrentAssociationYear(): DateTime
     {
         $end = new \DateTime();
         $end->setTime(0, 0);
@@ -132,7 +135,7 @@ class Member
      *
      * @param MemberModel $member Member to persist.
      */
-    public function persist(MemberModel $member)
+    public function persist(MemberModel $member): void
     {
         $this->em->persist($member);
         $this->em->flush();

--- a/module/Checker/src/Mapper/Organ.php
+++ b/module/Checker/src/Mapper/Organ.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Mapper;
 
 use Database\Model\Meeting as MeetingModel;

--- a/module/Checker/src/Model/Error.php
+++ b/module/Checker/src/Model/Error.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model;
 
 use Database\Model\Meeting as MeetingModel;

--- a/module/Checker/src/Model/Error/KeyGrantedInThePast.php
+++ b/module/Checker/src/Model/Error/KeyGrantedInThePast.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/KeyGrantedLongerThanOneYear.php
+++ b/module/Checker/src/Model/Error/KeyGrantedLongerThanOneYear.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/KeyGrantedPastBoundary.php
+++ b/module/Checker/src/Model/Error/KeyGrantedPastBoundary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/KeyWithdrawnPastOriginalGranting.php
+++ b/module/Checker/src/Model/Error/KeyWithdrawnPastOriginalGranting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/MemberActiveAndInactiveInOrgan.php
+++ b/module/Checker/src/Model/Error/MemberActiveAndInactiveInOrgan.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/MemberActiveWithRoleAndInactiveInOrgan.php
+++ b/module/Checker/src/Model/Error/MemberActiveWithRoleAndInactiveInOrgan.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/MemberExpiredButStillInOrgan.php
+++ b/module/Checker/src/Model/Error/MemberExpiredButStillInOrgan.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/MemberHasRoleButNotInOrgan.php
+++ b/module/Checker/src/Model/Error/MemberHasRoleButNotInOrgan.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/MemberInNonExistingOrgan.php
+++ b/module/Checker/src/Model/Error/MemberInNonExistingOrgan.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/MemberInactiveInOrganButHasOtherRole.php
+++ b/module/Checker/src/Model/Error/MemberInactiveInOrganButHasOtherRole.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Checker\Model\Error;

--- a/module/Checker/src/Model/Error/OrganMeetingType.php
+++ b/module/Checker/src/Model/Error/OrganMeetingType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Error;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Checker/src/Model/Exception/LookupException.php
+++ b/module/Checker/src/Model/Exception/LookupException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model\Exception;
 
 use RuntimeException;

--- a/module/Checker/src/Model/TueData.php
+++ b/module/Checker/src/Model/TueData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Model;
 
 use Checker\Model\Exception\LookupException;

--- a/module/Checker/src/Module.php
+++ b/module/Checker/src/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker;
 
 use Checker\Command\{

--- a/module/Checker/src/Service/Checker.php
+++ b/module/Checker/src/Service/Checker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service;
 
 use Database\Model\SubDecision\Key\Granting;
@@ -108,7 +110,7 @@ class Checker
      *
      * @param $body
      */
-    private function sendMail($body): void
+    private function sendMail(string $body): void
     {
         $message = new Message();
         $message->getHeaders()->addHeader((new MessageId())->setId());

--- a/module/Checker/src/Service/Factory/CheckerFactory.php
+++ b/module/Checker/src/Service/Factory/CheckerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service\Factory;
 
 use Checker\Service\{

--- a/module/Checker/src/Service/Factory/InstallationFactory.php
+++ b/module/Checker/src/Service/Factory/InstallationFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service\Factory;
 
 use Checker\Mapper\Installation as InstallationMapper;

--- a/module/Checker/src/Service/Factory/KeyFactory.php
+++ b/module/Checker/src/Service/Factory/KeyFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service\Factory;
 
 use Checker\Mapper\Key as KeyMapper;

--- a/module/Checker/src/Service/Factory/MeetingFactory.php
+++ b/module/Checker/src/Service/Factory/MeetingFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service\Factory;
 
 use Checker\Service\Meeting as MeetingService;

--- a/module/Checker/src/Service/Factory/MemberFactory.php
+++ b/module/Checker/src/Service/Factory/MemberFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service\Factory;
 
 use Checker\Mapper\Member as MemberMapper;

--- a/module/Checker/src/Service/Factory/OrganFactory.php
+++ b/module/Checker/src/Service/Factory/OrganFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service\Factory;
 
 use Checker\Mapper\Organ as OrganMapper;

--- a/module/Checker/src/Service/Installation.php
+++ b/module/Checker/src/Service/Installation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service;
 
 use Checker\Mapper\Installation as InstallationMapper;

--- a/module/Checker/src/Service/Key.php
+++ b/module/Checker/src/Service/Key.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service;
 
 use Checker\Mapper\Key as KeyMapper;

--- a/module/Checker/src/Service/Meeting.php
+++ b/module/Checker/src/Service/Meeting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service;
 
 use Database\Model\Meeting as MeetingModel;

--- a/module/Checker/src/Service/Member.php
+++ b/module/Checker/src/Service/Member.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service;
 
 use Checker\Mapper\Member as MemberMapper;

--- a/module/Checker/src/Service/Organ.php
+++ b/module/Checker/src/Service/Organ.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Checker\Service;
 
 use Checker\Mapper\Organ as OrganMapper;

--- a/module/Checker/test/Model/Error.php
+++ b/module/Checker/test/Model/Error.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CheckerTest\Model;
 
 use Application\Model\Enums\{
@@ -66,19 +68,19 @@ abstract class Error extends TestCase
         return $member;
     }
 
-    public function testGetSubDecision()
+    public function testGetSubDecision(): void
     {
         $error = $this->create();
         $this->assertInstanceOf(SubDecisionModel::class, $error->getSubDecision());
     }
 
-    public function testGetMeeting()
+    public function testGetMeeting(): void
     {
         $error = $this->create();
         $this->assertInstanceOf(MeetingModel::class, $error->getMeeting());
     }
 
-    public function testAsText()
+    public function testAsText(): void
     {
         $error = $this->create();
         $this->assertTrue(is_string($error->asText()));

--- a/module/Checker/test/Model/Error/MemberHasRoleButNotInOrganTest.php
+++ b/module/Checker/test/Model/Error/MemberHasRoleButNotInOrganTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CheckerTest\Model\Error;
 
 use Checker\Model\Error\MemberHasRoleButNotInOrgan;
@@ -24,13 +26,13 @@ class MemberHasRoleButNotInOrganTest extends Error
         return new MemberHasRoleButNotInOrgan($meeting, $installation, 'test');
     }
 
-    public function testGetFoundation()
+    public function testGetFoundation(): void
     {
         $error = $this->create();
         $this->assertInstanceOf(FoundationModel::class, $error->getOrgan());
     }
 
-    public function testGetMember()
+    public function testGetMember(): void
     {
         $error = $this->create();
         $this->assertInstanceOf(MemberModel::class, $error->getMember());

--- a/module/Checker/test/Model/Error/MemberInNonExistingOrganTest.php
+++ b/module/Checker/test/Model/Error/MemberInNonExistingOrganTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CheckerTest\Model\Error;
 
 use Checker\Model\Error\MemberInNonExistingOrgan;
@@ -23,7 +25,7 @@ class MemberInNonExistingOrganTest extends Error
         return new MemberInNonExistingOrgan($meeting, $installation);
     }
 
-    public function testGetFoundation()
+    public function testGetFoundation(): void
     {
         $error = $this->create();
         $this->assertInstanceOf(FoundationModel::class, $error->getOrgan());

--- a/module/Checker/test/Model/Error/OrganMeetingTypeTest.php
+++ b/module/Checker/test/Model/Error/OrganMeetingTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CheckerTest\Model\Error;
 
 use Checker\Model\Error\OrganMeetingType;

--- a/module/Database/config/module.config.php
+++ b/module/Database/config/module.config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database;
 
 use Database\Controller\{

--- a/module/Database/src/Command/DeleteExpiredMembersCommand.php
+++ b/module/Database/src/Command/DeleteExpiredMembersCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Command;
 
 use Database\Service\Member as MemberService;

--- a/module/Database/src/Command/Factory/DeleteExpiredMembersCommandFactory.php
+++ b/module/Database/src/Command/Factory/DeleteExpiredMembersCommandFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Command\Factory;
 
 use Database\Command\DeleteExpiredMembersCommand;

--- a/module/Database/src/Command/Factory/GenerateAuthenticationKeysCommandFactory.php
+++ b/module/Database/src/Command/Factory/GenerateAuthenticationKeysCommandFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Command\Factory;
 
 use Database\Command\GenerateAuthenticationKeysCommand;

--- a/module/Database/src/Command/GenerateAuthenticationKeysCommand.php
+++ b/module/Database/src/Command/GenerateAuthenticationKeysCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Command;
 
 use Database\Service\Member as MemberService;

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Application\Model\Enums\AddressTypes;

--- a/module/Database/src/Controller/ExportController.php
+++ b/module/Database/src/Controller/ExportController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Database\Service\Meeting as MeetingService;

--- a/module/Database/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/Database/src/Controller/Factory/ApiControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Database\Controller\ApiController;

--- a/module/Database/src/Controller/Factory/ExportControllerFactory.php
+++ b/module/Database/src/Controller/Factory/ExportControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Database\Controller\ExportController;

--- a/module/Database/src/Controller/Factory/IndexControllerFactory.php
+++ b/module/Database/src/Controller/Factory/IndexControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Database\Controller\IndexController;

--- a/module/Database/src/Controller/Factory/MeetingControllerFactory.php
+++ b/module/Database/src/Controller/Factory/MeetingControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Database\Controller\MeetingController;

--- a/module/Database/src/Controller/Factory/MemberControllerFactory.php
+++ b/module/Database/src/Controller/Factory/MemberControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Checker\Service\Checker as CheckerService;

--- a/module/Database/src/Controller/Factory/OrganControllerFactory.php
+++ b/module/Database/src/Controller/Factory/OrganControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Database\Controller\OrganController;

--- a/module/Database/src/Controller/Factory/ProspectiveMemberControllerFactory.php
+++ b/module/Database/src/Controller/Factory/ProspectiveMemberControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Database\Controller\ProspectiveMemberController;

--- a/module/Database/src/Controller/Factory/QueryControllerFactory.php
+++ b/module/Database/src/Controller/Factory/QueryControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Database\Controller\QueryController;

--- a/module/Database/src/Controller/Factory/SettingsControllerFactory.php
+++ b/module/Database/src/Controller/Factory/SettingsControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller\Factory;
 
 use Database\Controller\SettingsController;

--- a/module/Database/src/Controller/IndexController.php
+++ b/module/Database/src/Controller/IndexController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Database\Service\Member as MemberService;

--- a/module/Database/src/Controller/MeetingController.php
+++ b/module/Database/src/Controller/MeetingController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Controller/MemberController.php
+++ b/module/Database/src/Controller/MemberController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Application\Model\Enums\AddressTypes;

--- a/module/Database/src/Controller/OrganController.php
+++ b/module/Database/src/Controller/OrganController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Controller/ProspectiveMemberController.php
+++ b/module/Database/src/Controller/ProspectiveMemberController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Database\Service\Member as MemberService;

--- a/module/Database/src/Controller/QueryController.php
+++ b/module/Database/src/Controller/QueryController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Database\Service\Query as QueryService;

--- a/module/Database/src/Controller/SettingsController.php
+++ b/module/Database/src/Controller/SettingsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Controller;
 
 use Database\Service\{

--- a/module/Database/src/Form/Abolish.php
+++ b/module/Database/src/Form/Abolish.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Form\Fieldset\{

--- a/module/Database/src/Form/AbstractDecision.php
+++ b/module/Database/src/Form/AbstractDecision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Form\Fieldset\Meeting as MeetingFieldset;

--- a/module/Database/src/Form/Address.php
+++ b/module/Database/src/Form/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Application\Model\Enums\PostalRegions;

--- a/module/Database/src/Form/Board/Discharge.php
+++ b/module/Database/src/Form/Board/Discharge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Board;
 
 use Database\Form\AbstractDecision;

--- a/module/Database/src/Form/Board/Install.php
+++ b/module/Database/src/Form/Board/Install.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Board;
 
 use Database\Form\AbstractDecision;

--- a/module/Database/src/Form/Board/Release.php
+++ b/module/Database/src/Form/Board/Release.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Board;
 
 use Database\Form\AbstractDecision;

--- a/module/Database/src/Form/Budget.php
+++ b/module/Database/src/Form/Budget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Form\Fieldset\{

--- a/module/Database/src/Form/CreateMeeting.php
+++ b/module/Database/src/Form/CreateMeeting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Form/DeleteAddress.php
+++ b/module/Database/src/Form/DeleteAddress.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\Submit;

--- a/module/Database/src/Form/DeleteDecision.php
+++ b/module/Database/src/Form/DeleteDecision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\Submit;

--- a/module/Database/src/Form/DeleteList.php
+++ b/module/Database/src/Form/DeleteList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\Submit;

--- a/module/Database/src/Form/Destroy.php
+++ b/module/Database/src/Form/Destroy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Form\Fieldset\{

--- a/module/Database/src/Form/Export.php
+++ b/module/Database/src/Form/Export.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Mapper\Meeting as MeetingMapper;

--- a/module/Database/src/Form/Fieldset/Address.php
+++ b/module/Database/src/Form/Fieldset/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Application\Model\Enums\{

--- a/module/Database/src/Form/Fieldset/CollectionWithErrors.php
+++ b/module/Database/src/Form/Fieldset/CollectionWithErrors.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Laminas\Form\Element;

--- a/module/Database/src/Form/Fieldset/Decision.php
+++ b/module/Database/src/Form/Fieldset/Decision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Form/Fieldset/Granting.php
+++ b/module/Database/src/Form/Fieldset/Granting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Database\Form\Fieldset\Member as MemberFieldset;

--- a/module/Database/src/Form/Fieldset/Installation.php
+++ b/module/Database/src/Form/Fieldset/Installation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Database\Form\Fieldset\Member as MemberFieldset;

--- a/module/Database/src/Form/Fieldset/Meeting.php
+++ b/module/Database/src/Form/Fieldset/Meeting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Database\Model\Meeting as MeetingModel;
@@ -30,7 +32,7 @@ class Meeting extends Fieldset
      *
      * @param MeetingModel $meeting
      */
-    public function setMeetingData(MeetingModel $meeting)
+    public function setMeetingData(MeetingModel $meeting): void
     {
         $this->get('type')->setValue($meeting->getType()->value);
         $this->get('number')->setValue($meeting->getNumber());

--- a/module/Database/src/Form/Fieldset/Member.php
+++ b/module/Database/src/Form/Fieldset/Member.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Laminas\Form\Element\{

--- a/module/Database/src/Form/Fieldset/MemberFunction.php
+++ b/module/Database/src/Form/Fieldset/MemberFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Database\Service\InstallationFunction as FunctionService;

--- a/module/Database/src/Form/Fieldset/SubDecision.php
+++ b/module/Database/src/Form/Fieldset/SubDecision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Fieldset;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Form/Foundation.php
+++ b/module/Database/src/Form/Foundation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Form\Fieldset\{

--- a/module/Database/src/Form/Install.php
+++ b/module/Database/src/Form/Install.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Form\Fieldset\{

--- a/module/Database/src/Form/InstallationFunction.php
+++ b/module/Database/src/Form/InstallationFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\{

--- a/module/Database/src/Form/Key/Grant.php
+++ b/module/Database/src/Form/Key/Grant.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Key;
 
 use Database\Form\AbstractDecision;

--- a/module/Database/src/Form/Key/Withdraw.php
+++ b/module/Database/src/Form/Key/Withdraw.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form\Key;
 
 use Database\Form\AbstractDecision;

--- a/module/Database/src/Form/MailingList.php
+++ b/module/Database/src/Form/MailingList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\{

--- a/module/Database/src/Form/Member.php
+++ b/module/Database/src/Form/Member.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Application\Model\Enums\AddressTypes;

--- a/module/Database/src/Form/MemberApprove.php
+++ b/module/Database/src/Form/MemberApprove.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\Checkbox;

--- a/module/Database/src/Form/MemberEdit.php
+++ b/module/Database/src/Form/MemberEdit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Filter\ToNull;

--- a/module/Database/src/Form/MemberExpiration.php
+++ b/module/Database/src/Form/MemberExpiration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\Submit;

--- a/module/Database/src/Form/MemberLists.php
+++ b/module/Database/src/Form/MemberLists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Model\Member as MemberModel;

--- a/module/Database/src/Form/MemberType.php
+++ b/module/Database/src/Form/MemberType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Application\Model\Enums\MembershipTypes;

--- a/module/Database/src/Form/Other.php
+++ b/module/Database/src/Form/Other.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Database\Form\Fieldset\Meeting as MeetingFieldset;

--- a/module/Database/src/Form/Query.php
+++ b/module/Database/src/Form/Query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Mvc\I18n\Translator;
@@ -10,10 +12,6 @@ use Laminas\Form\Element\{
 use Laminas\Form\Form;
 use Laminas\InputFilter\InputFilterProviderInterface;
 
-/**
- * @psalm-import-type InputFilterSpecification from \Laminas\InputFilter\InputFilterInterface
- * @psalm-import-type CollectionSpecification from \Laminas\InputFilter\InputFilterInterface
- */
 class Query extends Form implements InputFilterProviderInterface
 {
     public function __construct(private readonly Translator $translator)
@@ -43,7 +41,7 @@ class Query extends Form implements InputFilterProviderInterface
     /**
      * Specification of input filter.
      *
-     * @psalm-return InputFilterSpecification|CollectionSpecification
+     * @return array
      */
     public function getInputFilterSpecification(): array
     {

--- a/module/Database/src/Form/QueryExport.php
+++ b/module/Database/src/Form/QueryExport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\Select;
@@ -26,6 +28,9 @@ class QueryExport extends Query implements InputFilterProviderInterface
         $this->get('submit')->setLabel($this->translator->translate('Export'));
     }
 
+    /**
+     * @return array
+     */
     public function getInputFilterSpecification(): array
     {
         $filter = parent::getInputFilterSpecification();

--- a/module/Database/src/Form/QuerySave.php
+++ b/module/Database/src/Form/QuerySave.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Form;
 
 use Laminas\Form\Element\{
@@ -33,6 +35,9 @@ class QuerySave extends Query implements InputFilterProviderInterface
         ]);
     }
 
+    /**
+     * @return array
+     */
     public function getInputFilterSpecification(): array
     {
         $filter = parent::getInputFilterSpecification();

--- a/module/Database/src/Hydrator/Abolish.php
+++ b/module/Database/src/Hydrator/Abolish.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator;
 
 use Database\Model\Decision as DecisionModel;

--- a/module/Database/src/Hydrator/AbstractDecision.php
+++ b/module/Database/src/Hydrator/AbstractDecision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator;
 
 use Laminas\Hydrator\HydratorInterface;
@@ -24,8 +26,8 @@ abstract class AbstractDecision implements HydratorInterface
         }
 
         $object->setMeeting($data['meeting']);
-        $object->setPoint($data['point']);
-        $object->setNumber($data['decision']);
+        $object->setPoint(intval($data['point']));
+        $object->setNumber(intval($data['decision']));
 
         return $object;
     }

--- a/module/Database/src/Hydrator/Board/Discharge.php
+++ b/module/Database/src/Hydrator/Board/Discharge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator\Board;
 
 use Database\Model\Decision as DecisionModel;

--- a/module/Database/src/Hydrator/Board/Install.php
+++ b/module/Database/src/Hydrator/Board/Install.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator\Board;
 
 use Database\Model\Decision as DecisionModel;

--- a/module/Database/src/Hydrator/Board/Release.php
+++ b/module/Database/src/Hydrator/Board/Release.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator\Board;
 
 use Database\Model\SubDecision\Board\Release as BoardRelease;

--- a/module/Database/src/Hydrator/Budget.php
+++ b/module/Database/src/Hydrator/Budget.php
@@ -41,8 +41,8 @@ class Budget extends AbstractDecision
         $subdecision->setName($data['name']);
         $subdecision->setAuthor($data['author']);
         $subdecision->setVersion($data['version']);
-        $subdecision->setApproval($data['approve']);
-        $subdecision->setChanges($data['changes']);
+        $subdecision->setApproval(boolval($data['approve']));
+        $subdecision->setChanges(boolval($data['changes']));
 
         $subdecision->setDecision($object);
 

--- a/module/Database/src/Hydrator/Budget.php
+++ b/module/Database/src/Hydrator/Budget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator;
 
 use Database\Model\Decision as DecisionModel;

--- a/module/Database/src/Hydrator/Destroy.php
+++ b/module/Database/src/Hydrator/Destroy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator;
 
 use Database\Model\Decision as DecisionModel;

--- a/module/Database/src/Hydrator/Foundation.php
+++ b/module/Database/src/Hydrator/Foundation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator;
 
 use Application\Model\Enums\OrganTypes;

--- a/module/Database/src/Hydrator/Install.php
+++ b/module/Database/src/Hydrator/Install.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator;
 
 use Database\Model\Decision as DecisionModel;

--- a/module/Database/src/Hydrator/Key/Grant.php
+++ b/module/Database/src/Hydrator/Key/Grant.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator\Key;
 
 use Database\Hydrator\AbstractDecision;

--- a/module/Database/src/Hydrator/Key/Withdraw.php
+++ b/module/Database/src/Hydrator/Key/Withdraw.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator\Key;
 
 use Database\Hydrator\AbstractDecision;

--- a/module/Database/src/Hydrator/Other.php
+++ b/module/Database/src/Hydrator/Other.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator;
 
 use Database\Model\Decision as DecisionModel;

--- a/module/Database/src/Hydrator/Strategy/AddressHydratorStrategy.php
+++ b/module/Database/src/Hydrator/Strategy/AddressHydratorStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator\Strategy;
 
 use Application\Model\Enums\AddressTypes;

--- a/module/Database/src/Hydrator/Strategy/MeetingHydratorStrategy.php
+++ b/module/Database/src/Hydrator/Strategy/MeetingHydratorStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator\Strategy;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Hydrator/Strategy/PostalRegionHydratorStrategy.php
+++ b/module/Database/src/Hydrator/Strategy/PostalRegionHydratorStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Hydrator\Strategy;
 
 use Application\Model\Enums\PostalRegions;

--- a/module/Database/src/Mapper/Factory/InstallationFunctionFactory.php
+++ b/module/Database/src/Mapper/Factory/InstallationFunctionFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper\Factory;
 
 use Database\Mapper\InstallationFunction as InstallationFunctionMapper;

--- a/module/Database/src/Mapper/Factory/MailingListFactory.php
+++ b/module/Database/src/Mapper/Factory/MailingListFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper\Factory;
 
 use Database\Mapper\MailingList as MailingListMapper;

--- a/module/Database/src/Mapper/Factory/MeetingFactory.php
+++ b/module/Database/src/Mapper/Factory/MeetingFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper\Factory;
 
 use Database\Mapper\Meeting as MeetingMapper;

--- a/module/Database/src/Mapper/Factory/MemberFactory.php
+++ b/module/Database/src/Mapper/Factory/MemberFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper\Factory;
 
 use Database\Mapper\Member as MemberMapper;

--- a/module/Database/src/Mapper/Factory/MemberUpdateFactory.php
+++ b/module/Database/src/Mapper/Factory/MemberUpdateFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper\Factory;
 
 use Database\Mapper\MemberUpdate as MemberUpdateMapper;

--- a/module/Database/src/Mapper/Factory/OrganFactory.php
+++ b/module/Database/src/Mapper/Factory/OrganFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper\Factory;
 
 use Database\Mapper\Organ as OrganMapper;

--- a/module/Database/src/Mapper/Factory/ProspectiveMemberFactory.php
+++ b/module/Database/src/Mapper/Factory/ProspectiveMemberFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper\Factory;
 
 use Database\Mapper\ProspectiveMember as ProspectiveMemberMapper;

--- a/module/Database/src/Mapper/Factory/SavedQueryFactory.php
+++ b/module/Database/src/Mapper/Factory/SavedQueryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper\Factory;
 
 use Database\Mapper\SavedQuery as SavedQueryMapper;

--- a/module/Database/src/Mapper/InstallationFunction.php
+++ b/module/Database/src/Mapper/InstallationFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper;
 
 use Database\Model\InstallationFunction as InstallationFunctionModel;

--- a/module/Database/src/Mapper/MailingList.php
+++ b/module/Database/src/Mapper/MailingList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper;
 
 use Database\Model\MailingList as MailingListModel;

--- a/module/Database/src/Mapper/Meeting.php
+++ b/module/Database/src/Mapper/Meeting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Mapper/Member.php
+++ b/module/Database/src/Mapper/Member.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper;
 
 use Application\Model\Enums\AddressTypes;

--- a/module/Database/src/Mapper/MemberUpdate.php
+++ b/module/Database/src/Mapper/MemberUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper;
 
 use Database\Model\MemberUpdate as MemberUpdateModel;

--- a/module/Database/src/Mapper/Organ.php
+++ b/module/Database/src/Mapper/Organ.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Mapper/ProspectiveMember.php
+++ b/module/Database/src/Mapper/ProspectiveMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper;
 
 use Database\Model\ProspectiveMember as ProspectiveMemberModel;
@@ -103,7 +105,7 @@ class ProspectiveMember
     /**
      * Remove a member.
      */
-    public function remove(ProspectiveMemberModel $member)
+    public function remove(ProspectiveMemberModel $member): void
     {
         $this->em->remove($member);
         $this->em->flush();

--- a/module/Database/src/Mapper/SavedQuery.php
+++ b/module/Database/src/Mapper/SavedQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Mapper;
 
 use Database\Model\SavedQuery as SavedQueryModel;

--- a/module/Database/src/Model/Address.php
+++ b/module/Database/src/Model/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Application\Model\Enums\{

--- a/module/Database/src/Model/Decision.php
+++ b/module/Database/src/Model/Decision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Model/InstallationFunction.php
+++ b/module/Database/src/Model/InstallationFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Doctrine\ORM\Mapping\{

--- a/module/Database/src/Model/MailingList.php
+++ b/module/Database/src/Model/MailingList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Doctrine\Common\Collections\{
@@ -205,7 +207,7 @@ class MailingList
      *
      * @param Member $member
      */
-    public function addMember(Member $member)
+    public function addMember(Member $member): void
     {
         $this->members->add($member);
     }

--- a/module/Database/src/Model/Meeting.php
+++ b/module/Database/src/Model/Meeting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Model/Member.php
+++ b/module/Database/src/Model/Member.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Application\Model\Enums\MembershipTypes;

--- a/module/Database/src/Model/MemberUpdate.php
+++ b/module/Database/src/Model/MemberUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use DateTime;

--- a/module/Database/src/Model/ProspectiveMember.php
+++ b/module/Database/src/Model/ProspectiveMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Application\Model\Enums\{

--- a/module/Database/src/Model/SavedQuery.php
+++ b/module/Database/src/Model/SavedQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Doctrine\ORM\Mapping\{

--- a/module/Database/src/Model/SubDecision.php
+++ b/module/Database/src/Model/SubDecision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Model/SubDecision/Abrogation.php
+++ b/module/Database/src/Model/SubDecision/Abrogation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\Entity;

--- a/module/Database/src/Model/SubDecision/Board/Discharge.php
+++ b/module/Database/src/Model/SubDecision/Board/Discharge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision\Board;
 
 use Database\Model\SubDecision;

--- a/module/Database/src/Model/SubDecision/Board/Installation.php
+++ b/module/Database/src/Model/SubDecision/Board/Installation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision\Board;
 
 use Database\Model\{

--- a/module/Database/src/Model/SubDecision/Board/Release.php
+++ b/module/Database/src/Model/SubDecision/Board/Release.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision\Board;
 
 use Database\Model\SubDecision;

--- a/module/Database/src/Model/SubDecision/Budget.php
+++ b/module/Database/src/Model/SubDecision/Budget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Database\Model\{

--- a/module/Database/src/Model/SubDecision/Destroy.php
+++ b/module/Database/src/Model/SubDecision/Destroy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Database\Model\{

--- a/module/Database/src/Model/SubDecision/Discharge.php
+++ b/module/Database/src/Model/SubDecision/Discharge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Database\Model\SubDecision;

--- a/module/Database/src/Model/SubDecision/Foundation.php
+++ b/module/Database/src/Model/SubDecision/Foundation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Application\Model\Enums\OrganTypes;

--- a/module/Database/src/Model/SubDecision/FoundationReference.php
+++ b/module/Database/src/Model/SubDecision/FoundationReference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Database\Model\SubDecision;

--- a/module/Database/src/Model/SubDecision/Installation.php
+++ b/module/Database/src/Model/SubDecision/Installation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Database\Model\Member;

--- a/module/Database/src/Model/SubDecision/Key/Granting.php
+++ b/module/Database/src/Model/SubDecision/Key/Granting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision\Key;
 
 use Database\Model\{

--- a/module/Database/src/Model/SubDecision/Key/Withdrawal.php
+++ b/module/Database/src/Model/SubDecision/Key/Withdrawal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision\Key;
 
 use Database\Model\SubDecision;

--- a/module/Database/src/Model/SubDecision/Other.php
+++ b/module/Database/src/Model/SubDecision/Other.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Database\Model\SubDecision;

--- a/module/Database/src/Model/SubDecision/Reckoning.php
+++ b/module/Database/src/Model/SubDecision/Reckoning.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\Entity;

--- a/module/Database/src/Module.php
+++ b/module/Database/src/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database;
 
 use Database\Form\{

--- a/module/Database/src/Service/Api.php
+++ b/module/Database/src/Service/Api.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service;
 
 use Database\Mapper\{

--- a/module/Database/src/Service/Factory/ApiFactory.php
+++ b/module/Database/src/Service/Factory/ApiFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service\Factory;
 
 use Database\Mapper\Member as MemberMapper;

--- a/module/Database/src/Service/Factory/InstallationFunctionFactory.php
+++ b/module/Database/src/Service/Factory/InstallationFunctionFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service\Factory;
 
 use Database\Form\InstallationFunction as InstallationFunctionForm;

--- a/module/Database/src/Service/Factory/MailingListFactory.php
+++ b/module/Database/src/Service/Factory/MailingListFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service\Factory;
 
 use Database\Form\DeleteList as DeleteListForm;

--- a/module/Database/src/Service/Factory/MeetingFactory.php
+++ b/module/Database/src/Service/Factory/MeetingFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service\Factory;
 
 use Database\Form\Abolish as AbolishForm;

--- a/module/Database/src/Service/Factory/MemberFactory.php
+++ b/module/Database/src/Service/Factory/MemberFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service\Factory;
 
 use Application\Service\FileStorage as FileStorageService;

--- a/module/Database/src/Service/Factory/QueryFactory.php
+++ b/module/Database/src/Service/Factory/QueryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service\Factory;
 
 use Database\Form\Query as QueryForm;

--- a/module/Database/src/Service/InstallationFunction.php
+++ b/module/Database/src/Service/InstallationFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service;
 
 use Database\Form\InstallationFunction as InstallationFunctionForm;

--- a/module/Database/src/Service/MailingList.php
+++ b/module/Database/src/Service/MailingList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service;
 
 use Database\Form\DeleteList as DeleteListForm;

--- a/module/Database/src/Service/Meeting.php
+++ b/module/Database/src/Service/Meeting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service;
 
 use Application\Model\Enums\{

--- a/module/Database/src/Service/Query.php
+++ b/module/Database/src/Service/Query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Service;
 
 use Database\Form\{

--- a/module/Database/view/database/email/member-welcome.phtml
+++ b/module/Database/view/database/email/member-welcome.phtml
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 use Database\Model\Member as MemberModel;
 
 /** @var MemberModel $member */
@@ -104,7 +107,7 @@ Registration&nbsp;Confirmation&nbsp;GEWIS
             <td>
                 <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-1" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;" width="100%">
                     <tbody style="width: 100%;">
-                        
+
 <tr>
 <td style="width: 100%;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000;" width="720">
@@ -297,7 +300,7 @@ With kind regards,<br> The board of GEWIS
                             </table>
                         </td>
                         </tr>
-                        
+
                         <tr>
                         <td>
                             <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000; width: 720px;" width="720">
@@ -332,7 +335,7 @@ With kind regards,<br> The board of GEWIS
                                                         <p class="pleft" style="margin: 0; font-size: 14px;">
                                                             <a href="mailto:secr@gewis.nl" style="color:white; text-decoration:none;">secr@gewis.nl</a><br/>
                                                             <a href="tel:+31402472815" style="color:white; text-decoration:none;">+31 40 247 2815</a><br/>
-                                                            
+
                                                         </p>
                                                     </div>
                                                 </div>

--- a/module/Database/view/database/export/index.phtml
+++ b/module/Database/view/database/export/index.phtml
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Database\Form\QueryExport as QueryExportForm;
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var QueryExportForm $form
+ */
+
 $escaper = new Laminas\Escaper\Escaper('UTF-8');
 
 function showDecisionNumber($decision)

--- a/module/Database/view/database/export/index.phtml
+++ b/module/Database/view/database/export/index.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $escaper = new Laminas\Escaper\Escaper('UTF-8');
 
 function showDecisionNumber($decision)

--- a/module/Database/view/database/export/latex.phtml
+++ b/module/Database/view/database/export/latex.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 \documentclass[a4paper, twoside, 11pt]{article}
 \usepackage[dutch]{babel}
 \usepackage{a4wide}

--- a/module/Database/view/database/export/latex.phtml
+++ b/module/Database/view/database/export/latex.phtml
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var array $decisions
+ */
 ?>
 \documentclass[a4paper, twoside, 11pt]{article}
 \usepackage[dutch]{babel}

--- a/module/Database/view/database/index/index.phtml
+++ b/module/Database/view/database/index/index.phtml
@@ -1,6 +1,17 @@
 <?php
 
 declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var int $members
+ * @var int $prospectives
+ * @var int $updates
+ */
+
 $showPendingUpdates = 0 < $updates;
 ?>
 <div class="row">

--- a/module/Database/view/database/index/index.phtml
+++ b/module/Database/view/database/index/index.phtml
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 $showPendingUpdates = 0 < $updates;
 ?>
 <div class="row">

--- a/module/Database/view/database/meeting/abolishform.phtml
+++ b/module/Database/view/database/meeting/abolishform.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
 var urlTemplate = '<?= $this->url('organ/info', array(
     'type' => '__type__',

--- a/module/Database/view/database/meeting/abolishform.phtml
+++ b/module/Database/view/database/meeting/abolishform.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
 var urlTemplate = '<?= $this->url('organ/info', array(

--- a/module/Database/view/database/meeting/board/dischargeform.phtml
+++ b/module/Database/view/database/meeting/board/dischargeform.phtml
@@ -1,6 +1,12 @@
 <?php
 
 declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 $arrInstalls = array();
 
 foreach ($installs as $key => $install) {

--- a/module/Database/view/database/meeting/board/dischargeform.phtml
+++ b/module/Database/view/database/meeting/board/dischargeform.phtml
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 $arrInstalls = array();
 
 foreach ($installs as $key => $install) {

--- a/module/Database/view/database/meeting/board/installform.phtml
+++ b/module/Database/view/database/meeting/board/installform.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
 $(document).ready(function() {
     $('#board-member .member-autocomplete').autocomplete({

--- a/module/Database/view/database/meeting/board/installform.phtml
+++ b/module/Database/view/database/meeting/board/installform.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
 $(document).ready(function() {

--- a/module/Database/view/database/meeting/board/releaseform.phtml
+++ b/module/Database/view/database/meeting/board/releaseform.phtml
@@ -1,6 +1,12 @@
 <?php
 
 declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 $arrInstalls = array();
 
 foreach ($installs as $key => $install) {

--- a/module/Database/view/database/meeting/board/releaseform.phtml
+++ b/module/Database/view/database/meeting/board/releaseform.phtml
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 $arrInstalls = array();
 
 foreach ($installs as $key => $install) {

--- a/module/Database/view/database/meeting/budgetform.phtml
+++ b/module/Database/view/database/meeting/budgetform.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
 $(document).ready(function () {
     $('#budget-author').autocomplete({

--- a/module/Database/view/database/meeting/budgetform.phtml
+++ b/module/Database/view/database/meeting/budgetform.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
 $(document).ready(function () {

--- a/module/Database/view/database/meeting/create.phtml
+++ b/module/Database/view/database/meeting/create.phtml
@@ -1,6 +1,12 @@
 <?php
 
 declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 if (isset($success) && $success): ?>
     <?= $this->translate('Meeting added successfully!') ?>
 <?php else: ?>

--- a/module/Database/view/database/meeting/create.phtml
+++ b/module/Database/view/database/meeting/create.phtml
@@ -1,4 +1,7 @@
-<?php if (isset($success) && $success): ?>
+<?php
+
+declare(strict_types=1);
+if (isset($success) && $success): ?>
     <?= $this->translate('Meeting added successfully!') ?>
 <?php else: ?>
 <?php

--- a/module/Database/view/database/meeting/decision.phtml
+++ b/module/Database/view/database/meeting/decision.phtml
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 use Database\Model\Meeting;
 ?>
 <?php if (isset($error) && $error): ?>

--- a/module/Database/view/database/meeting/decision.phtml
+++ b/module/Database/view/database/meeting/decision.phtml
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
 use Database\Model\Meeting;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <?php if (isset($error) && $error): ?>
 <h1><?= $this->translate('Decision Already Exists') ?></h1>

--- a/module/Database/view/database/meeting/decisionform.phtml
+++ b/module/Database/view/database/meeting/decisionform.phtml
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 use Database\Model\Meeting;
 ?>
 <?php if (isset($form)): ?>

--- a/module/Database/view/database/meeting/decisionform.phtml
+++ b/module/Database/view/database/meeting/decisionform.phtml
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
 use Database\Model\Meeting;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <?php if (isset($form)): ?>
 <?php

--- a/module/Database/view/database/meeting/delete.phtml
+++ b/module/Database/view/database/meeting/delete.phtml
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
 use Database\Model\Meeting;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <?php if (isset($error) && $error): ?>
 <h1><?= $this->translate('Decision Cannot Be Removed') ?></h1>

--- a/module/Database/view/database/meeting/delete.phtml
+++ b/module/Database/view/database/meeting/delete.phtml
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 use Database\Model\Meeting;
 ?>
 <?php if (isset($error) && $error): ?>

--- a/module/Database/view/database/meeting/destroyform.phtml
+++ b/module/Database/view/database/meeting/destroyform.phtml
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Database\Form\Destroy as DestroyForm;
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var DestroyForm $form
+ */
 ?>
 <script>
 $(document).ready(function() {

--- a/module/Database/view/database/meeting/destroyform.phtml
+++ b/module/Database/view/database/meeting/destroyform.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
 $(document).ready(function() {
     $('#destroy-decision').autocomplete({

--- a/module/Database/view/database/meeting/foundationform.phtml
+++ b/module/Database/view/database/meeting/foundationform.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
     function enable_autocomplete() {

--- a/module/Database/view/database/meeting/foundationform.phtml
+++ b/module/Database/view/database/meeting/foundationform.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
     function enable_autocomplete() {
         $('#members .member-autocomplete').autocomplete({

--- a/module/Database/view/database/meeting/index.phtml
+++ b/module/Database/view/database/meeting/index.phtml
@@ -2,7 +2,14 @@
 
 declare(strict_types=1);
 
-use Database\Model\Meeting;
+use Application\View\HelperTrait;
+use Database\Model\Meeting as MeetingModel;
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var MeetingModel[] $meetings
+ */
 ?>
 <a href="<?= $this->url('meeting/create') ?>" class="btn btn-success">
     <span class="glyphicon glyphicon-plus"></span> <?= $this->translate('Add New Meeting') ?>

--- a/module/Database/view/database/meeting/index.phtml
+++ b/module/Database/view/database/meeting/index.phtml
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 use Database\Model\Meeting;
 ?>
 <a href="<?= $this->url('meeting/create') ?>" class="btn btn-success">

--- a/module/Database/view/database/meeting/installform.phtml
+++ b/module/Database/view/database/meeting/installform.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
 var urlTemplate = '<?= $this->url('organ/info', array(
     'type' => '__type__',

--- a/module/Database/view/database/meeting/installform.phtml
+++ b/module/Database/view/database/meeting/installform.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
 var urlTemplate = '<?= $this->url('organ/info', array(

--- a/module/Database/view/database/meeting/key/grantform.phtml
+++ b/module/Database/view/database/meeting/key/grantform.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
     $(document).ready(function () {

--- a/module/Database/view/database/meeting/key/grantform.phtml
+++ b/module/Database/view/database/meeting/key/grantform.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
     $(document).ready(function () {
         $('#key-grantee').autocomplete({

--- a/module/Database/view/database/meeting/key/withdrawform.phtml
+++ b/module/Database/view/database/meeting/key/withdrawform.phtml
@@ -1,6 +1,12 @@
 <?php
 
 declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 $arrGrants = array();
 
 foreach ($grants as $key => $grant) {

--- a/module/Database/view/database/meeting/key/withdrawform.phtml
+++ b/module/Database/view/database/meeting/key/withdrawform.phtml
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 $arrGrants = array();
 
 foreach ($grants as $key => $grant) {

--- a/module/Database/view/database/meeting/otherform.phtml
+++ b/module/Database/view/database/meeting/otherform.phtml
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 $form->prepare();
 
 $form->setAttribute('action', $this->url('meeting/decision/form', array('form' => 'other')));

--- a/module/Database/view/database/meeting/otherform.phtml
+++ b/module/Database/view/database/meeting/otherform.phtml
@@ -1,6 +1,16 @@
 <?php
 
 declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Database\Form\Other as OtherForm;
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var OtherForm $form
+ */
+
 $form->prepare();
 
 $form->setAttribute('action', $this->url('meeting/decision/form', array('form' => 'other')));

--- a/module/Database/view/database/meeting/view.phtml
+++ b/module/Database/view/database/meeting/view.phtml
@@ -1,6 +1,12 @@
 <?php
 
 declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 // determine last decision of each point
 $map = array();
 foreach ($meeting->getDecisions() as $decision) {

--- a/module/Database/view/database/meeting/view.phtml
+++ b/module/Database/view/database/meeting/view.phtml
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 // determine last decision of each point
 $map = array();
 foreach ($meeting->getDecisions() as $decision) {

--- a/module/Database/view/database/member/delete.phtml
+++ b/module/Database/view/database/member/delete.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1><?= $member->getFullname() ?></h1>
 <?php if ($canRemove): ?>

--- a/module/Database/view/database/member/delete.phtml
+++ b/module/Database/view/database/member/delete.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1><?= $member->getFullname() ?></h1>
 <?php if ($canRemove): ?>
     <p>

--- a/module/Database/view/database/member/deleted.phtml
+++ b/module/Database/view/database/member/deleted.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <div class="row">
     <div class="col-md-12">
         <h1><?= $member->getFullName() ?></h1>

--- a/module/Database/view/database/member/deleted.phtml
+++ b/module/Database/view/database/member/deleted.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <div class="row">
     <div class="col-md-12">

--- a/module/Database/view/database/member/edit-address.phtml
+++ b/module/Database/view/database/member/edit-address.phtml
@@ -2,9 +2,14 @@
 
 declare(strict_types=1);
 
-use Database\Model\Address;
+use Application\View\HelperTrait;
+use Database\Model\Address as AddressModel;
+use Laminas\View\Renderer\PhpRenderer;
 
-/** @var Address $address */
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var AddressModel $address
+ */
 $type = $address->getType()->getName($this->plugin('translate')->getTranslator());
 ?>
 <?php if (isset($add) && $add): ?>

--- a/module/Database/view/database/member/edit-address.phtml
+++ b/module/Database/view/database/member/edit-address.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Database\Model\Address;
 
 /** @var Address $address */

--- a/module/Database/view/database/member/edit.phtml
+++ b/module/Database/view/database/member/edit.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1>Wijzigen gegevens <?= $member->getFullName() ?></h1>
 <div class="row">

--- a/module/Database/view/database/member/edit.phtml
+++ b/module/Database/view/database/member/edit.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1>Wijzigen gegevens <?= $member->getFullName() ?></h1>
 <div class="row">
 <div class="col-md-6">

--- a/module/Database/view/database/member/expiration.phtml
+++ b/module/Database/view/database/member/expiration.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1>
     <?=

--- a/module/Database/view/database/member/expiration.phtml
+++ b/module/Database/view/database/member/expiration.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1>
     <?=
         sprintf(

--- a/module/Database/view/database/member/index.phtml
+++ b/module/Database/view/database/member/index.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
 var urlTemplate = '<?= $this->url('member/show', array('id' => '__LIDNR__')) ?>';

--- a/module/Database/view/database/member/index.phtml
+++ b/module/Database/view/database/member/index.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
 var urlTemplate = '<?= $this->url('member/show', array('id' => '__LIDNR__')) ?>';
 $(document).ready(function () {

--- a/module/Database/view/database/member/lists.phtml
+++ b/module/Database/view/database/member/lists.phtml
@@ -2,6 +2,20 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Database\Form\MailingList as MailingListForm;
+use Database\Model\{
+    MailingList as MailingListModel,
+    Member as MemberModel,
+};
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var MailingListModel[] $lists
+ * @var MemberModel $member
+ * @var MailingListForm $form
+ */
 ?>
 <h1>
     <?=

--- a/module/Database/view/database/member/lists.phtml
+++ b/module/Database/view/database/member/lists.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1>
     <?=
         sprintf(

--- a/module/Database/view/database/member/membership.phtml
+++ b/module/Database/view/database/member/membership.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1>
     <?=

--- a/module/Database/view/database/member/membership.phtml
+++ b/module/Database/view/database/member/membership.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1>
     <?=
         sprintf(

--- a/module/Database/view/database/member/remove-address.phtml
+++ b/module/Database/view/database/member/remove-address.phtml
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 $form->prepare();
 
 $form->setAttribute(

--- a/module/Database/view/database/member/remove-address.phtml
+++ b/module/Database/view/database/member/remove-address.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $form->prepare();
 
 $form->setAttribute(

--- a/module/Database/view/database/member/show-update.phtml
+++ b/module/Database/view/database/member/show-update.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <div class="row">
     <div class="col-md-6">

--- a/module/Database/view/database/member/show-update.phtml
+++ b/module/Database/view/database/member/show-update.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <div class="row">
     <div class="col-md-6">
         <h1><?= $member->getFullName() ?></h1>

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -2,14 +2,19 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
 use Application\Model\Enums\{
     AddressTypes,
     MembershipTypes,
 };
 use Database\Model\Member as MemberModel;
+use Laminas\View\Renderer\PhpRenderer;
 
-/** @var MemberModel $member */
-/** @var bool $hasCorrectInstallations */
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var MemberModel $member
+ * @var bool $hasCorrectInstallations
+ */
 
 ?>
 <div class="row">

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Application\Model\Enums\{
     AddressTypes,
     MembershipTypes,

--- a/module/Database/view/database/member/subscribe.phtml
+++ b/module/Database/view/database/member/subscribe.phtml
@@ -3,9 +3,14 @@
 declare(strict_types=1);
 
 use Application\Model\Enums\PostalRegions;
+use Application\View\HelperTrait;
 use Database\Model\Member as MemberModel;
+use Laminas\View\Renderer\PhpRenderer;
 
-/** @var MemberModel $member */
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var MemberModel $member
+ */
 ?>
 <?php if (isset($form)): ?>
 <?php

--- a/module/Database/view/database/member/subscribe.phtml
+++ b/module/Database/view/database/member/subscribe.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Application\Model\Enums\PostalRegions;
 use Database\Model\Member as MemberModel;
 

--- a/module/Database/view/database/member/tue-lookup.phtml
+++ b/module/Database/view/database/member/tue-lookup.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1><?= $this->translate('TU/e Raw Data Lookup') ?></h1>
 
 <?php if('development' === APP_ENV):?>

--- a/module/Database/view/database/member/tue-lookup.phtml
+++ b/module/Database/view/database/member/tue-lookup.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1><?= $this->translate('TU/e Raw Data Lookup') ?></h1>
 

--- a/module/Database/view/database/member/updates.phtml
+++ b/module/Database/view/database/member/updates.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1><?= $this->translate('Data Update Requests')?></h1>
 <?php if (empty($updates)): ?>
     <?= $this->translate('There are currently no data update requests.') ?>

--- a/module/Database/view/database/member/updates.phtml
+++ b/module/Database/view/database/member/updates.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1><?= $this->translate('Data Update Requests')?></h1>
 <?php if (empty($updates)): ?>

--- a/module/Database/view/database/organ/index.phtml
+++ b/module/Database/view/database/organ/index.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
 var urlTemplate = '<?= $this->url('organ/view', array(

--- a/module/Database/view/database/organ/index.phtml
+++ b/module/Database/view/database/organ/index.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
 var urlTemplate = '<?= $this->url('organ/view', array(
     'type' => '__type__',

--- a/module/Database/view/database/organ/view.phtml
+++ b/module/Database/view/database/organ/view.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1><?= $foundation->getAbbr() ?> <small><?= $foundation->getName() ?></small></h1>
 

--- a/module/Database/view/database/organ/view.phtml
+++ b/module/Database/view/database/organ/view.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1><?= $foundation->getAbbr() ?> <small><?= $foundation->getName() ?></small></h1>
 
 <h2><?= $this->translate('Members') ?></h2>

--- a/module/Database/view/database/prospective-member/index.phtml
+++ b/module/Database/view/database/prospective-member/index.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <script>
     var urlTemplate = '<?= $this->url('prospective-member/show', array('id' => '__LIDNR__')) ?>';

--- a/module/Database/view/database/prospective-member/index.phtml
+++ b/module/Database/view/database/prospective-member/index.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <script>
     var urlTemplate = '<?= $this->url('prospective-member/show', array('id' => '__LIDNR__')) ?>';
     $(document).ready(function () {

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Application\Model\Enums\AddressTypes;
 use Laminas\Form\Element\Checkbox;
 

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -3,8 +3,11 @@
 declare(strict_types=1);
 
 use Application\Model\Enums\AddressTypes;
+use Application\View\HelperTrait;
 use Laminas\Form\Element\Checkbox;
+use Laminas\View\Renderer\PhpRenderer;
 
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <div class="row">
 <div class="col-md-6">

--- a/module/Database/view/database/query/export.phtml
+++ b/module/Database/view/database/query/export.phtml
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 $new = array();
 // preprocessing, render the DateTime objects
 foreach ($result as $row) {

--- a/module/Database/view/database/query/export.phtml
+++ b/module/Database/view/database/query/export.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $new = array();
 // preprocessing, render the DateTime objects
 foreach ($result as $row) {

--- a/module/Database/view/database/query/index.phtml
+++ b/module/Database/view/database/query/index.phtml
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 // add codemirror
 $this->headLink()->appendStylesheet($this->basePath() . '/css/codemirror.css');
 $this->headScript()->appendFile($this->basePath() . '/js/codemirror-compressed.js');

--- a/module/Database/view/database/query/index.phtml
+++ b/module/Database/view/database/query/index.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // add codemirror
 $this->headLink()->appendStylesheet($this->basePath() . '/css/codemirror.css');
 $this->headScript()->appendFile($this->basePath() . '/js/codemirror-compressed.js');

--- a/module/Database/view/database/settings/delete-list.phtml
+++ b/module/Database/view/database/settings/delete-list.phtml
@@ -1,6 +1,12 @@
 <?php
 
 declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 if (!isset($form)): ?>
     <?= $this->translate('Mailing list deleted.') ?>
 <?php else: ?>

--- a/module/Database/view/database/settings/delete-list.phtml
+++ b/module/Database/view/database/settings/delete-list.phtml
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 if (!isset($form)): ?>
     <?= $this->translate('Mailing list deleted.') ?>
 <?php else: ?>

--- a/module/Database/view/database/settings/function.phtml
+++ b/module/Database/view/database/settings/function.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1><?= $this->translate('Current Functions') ?></h1>
 <ul>

--- a/module/Database/view/database/settings/function.phtml
+++ b/module/Database/view/database/settings/function.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1><?= $this->translate('Current Functions') ?></h1>
 <ul>
     <?php foreach ($functions as $function): ?>

--- a/module/Database/view/database/settings/index.phtml
+++ b/module/Database/view/database/settings/index.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1>Settings</h1>
 
 <ul>

--- a/module/Database/view/database/settings/index.phtml
+++ b/module/Database/view/database/settings/index.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1>Settings</h1>
 

--- a/module/Database/view/database/settings/list.phtml
+++ b/module/Database/view/database/settings/list.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <div class="row">
     <div class="col-md-12">
         <h2><?= $this->translate('Current Mailing Lists') ?></h2>

--- a/module/Database/view/database/settings/list.phtml
+++ b/module/Database/view/database/settings/list.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <div class="row">
     <div class="col-md-12">

--- a/module/Report/config/module.config.php
+++ b/module/Report/config/module.config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report;
 
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;

--- a/module/Report/src/Command/Factory/GenerateFullCommandFactory.php
+++ b/module/Report/src/Command/Factory/GenerateFullCommandFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Command\Factory;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/Report/src/Command/Factory/GeneratePartialCommandFactory.php
+++ b/module/Report/src/Command/Factory/GeneratePartialCommandFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Command\Factory;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/Report/src/Command/GenerateFullCommand.php
+++ b/module/Report/src/Command/GenerateFullCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Command;
 
 use Report\Service\{

--- a/module/Report/src/Command/GeneratePartialCommand.php
+++ b/module/Report/src/Command/GeneratePartialCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Command;
 
 use Report\Service\{

--- a/module/Report/src/Listener/DatabaseDeletionListener.php
+++ b/module/Report/src/Listener/DatabaseDeletionListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Listener;
 
 use Database\Model\{
@@ -29,7 +31,7 @@ class DatabaseDeletionListener
     ) {
     }
 
-    public function preRemove(LifecycleEventArgs $eventArgs)
+    public function preRemove(LifecycleEventArgs $eventArgs): void
     {
         $entity = $eventArgs->getEntity();
         switch (true) {

--- a/module/Report/src/Listener/DatabaseUpdateListener.php
+++ b/module/Report/src/Listener/DatabaseUpdateListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Listener;
 
 use Database\Model\{
@@ -50,7 +52,7 @@ class DatabaseUpdateListener
     ) {
     }
 
-    protected static function safeFlush(callable $func)
+    protected static function safeFlush(callable $func): void
     {
         if (self::$isflushing) {
             return;
@@ -61,12 +63,12 @@ class DatabaseUpdateListener
         self::$isflushing = false;
     }
 
-    public function postPersist(LifecycleEventArgs $eventArgs)
+    public function postPersist(LifecycleEventArgs $eventArgs): void
     {
         $this->postUpdate($eventArgs);
     }
 
-    public function postUpdate(LifecycleEventArgs $eventArgs)
+    public function postUpdate(LifecycleEventArgs $eventArgs): void
     {
         $entity = $eventArgs->getEntity();
 

--- a/module/Report/src/Listener/Factory/DatabaseDeletionListenerFactory.php
+++ b/module/Report/src/Listener/Factory/DatabaseDeletionListenerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Listener\Factory;
 
 use Doctrine\ORM\EntityManager;

--- a/module/Report/src/Listener/Factory/DatabaseUpdateListenerFactory.php
+++ b/module/Report/src/Listener/Factory/DatabaseUpdateListenerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Listener\Factory;
 
 use Doctrine\ORM\EntityManager;

--- a/module/Report/src/Model/Address.php
+++ b/module/Report/src/Model/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use Application\Model\Enums\{

--- a/module/Report/src/Model/BoardMember.php
+++ b/module/Report/src/Model/BoardMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use DateTime;

--- a/module/Report/src/Model/Decision.php
+++ b/module/Report/src/Model/Decision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Report/src/Model/Keyholder.php
+++ b/module/Report/src/Model/Keyholder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use DateTime;

--- a/module/Report/src/Model/MailingList.php
+++ b/module/Report/src/Model/MailingList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use Doctrine\Common\Collections\{
@@ -210,7 +212,7 @@ class MailingList
     /**
      * Remove a member.
      */
-    public function removeMember(Member $member)
+    public function removeMember(Member $member): void
     {
         $this->members->removeElement($member);
     }

--- a/module/Report/src/Model/Meeting.php
+++ b/module/Report/src/Model/Meeting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Report/src/Model/Member.php
+++ b/module/Report/src/Model/Member.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use Application\Model\Enums\MembershipTypes;

--- a/module/Report/src/Model/Organ.php
+++ b/module/Report/src/Model/Organ.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use Application\Model\Enums\OrganTypes;

--- a/module/Report/src/Model/OrganMember.php
+++ b/module/Report/src/Model/OrganMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use DateTime;

--- a/module/Report/src/Model/SubDecision.php
+++ b/module/Report/src/Model/SubDecision.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model;
 
 use Application\Model\Enums\MeetingTypes;

--- a/module/Report/src/Model/SubDecision/Abrogation.php
+++ b/module/Report/src/Model/SubDecision/Abrogation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\Entity;

--- a/module/Report/src/Model/SubDecision/Board/Discharge.php
+++ b/module/Report/src/Model/SubDecision/Board/Discharge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision\Board;
 
 use Doctrine\ORM\Mapping\{

--- a/module/Report/src/Model/SubDecision/Board/Installation.php
+++ b/module/Report/src/Model/SubDecision/Board/Installation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision\Board;
 
 use DateTime;

--- a/module/Report/src/Model/SubDecision/Board/Release.php
+++ b/module/Report/src/Model/SubDecision/Board/Release.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision\Board;
 
 use DateTime;

--- a/module/Report/src/Model/SubDecision/Budget.php
+++ b/module/Report/src/Model/SubDecision/Budget.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use DateTime;

--- a/module/Report/src/Model/SubDecision/Destroy.php
+++ b/module/Report/src/Model/SubDecision/Destroy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\{

--- a/module/Report/src/Model/SubDecision/Discharge.php
+++ b/module/Report/src/Model/SubDecision/Discharge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\{

--- a/module/Report/src/Model/SubDecision/Foundation.php
+++ b/module/Report/src/Model/SubDecision/Foundation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use Application\Model\Enums\OrganTypes;

--- a/module/Report/src/Model/SubDecision/FoundationReference.php
+++ b/module/Report/src/Model/SubDecision/FoundationReference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\{

--- a/module/Report/src/Model/SubDecision/Installation.php
+++ b/module/Report/src/Model/SubDecision/Installation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\{

--- a/module/Report/src/Model/SubDecision/Key/Granting.php
+++ b/module/Report/src/Model/SubDecision/Key/Granting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision\Key;
 
 use Report\Model\{

--- a/module/Report/src/Model/SubDecision/Key/Withdrawal.php
+++ b/module/Report/src/Model/SubDecision/Key/Withdrawal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision\Key;
 
 use Report\Model\SubDecision;

--- a/module/Report/src/Model/SubDecision/Other.php
+++ b/module/Report/src/Model/SubDecision/Other.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\Entity;

--- a/module/Report/src/Model/SubDecision/Reckoning.php
+++ b/module/Report/src/Model/SubDecision/Reckoning.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Model\SubDecision;
 
 use Doctrine\ORM\Mapping\Entity;

--- a/module/Report/src/Module.php
+++ b/module/Report/src/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report;
 
 use Report\Command\{

--- a/module/Report/src/Service/Board.php
+++ b/module/Report/src/Service/Board.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service;
 
 use Doctrine\ORM\EntityManager;
@@ -21,7 +23,7 @@ class Board
     /**
      * Export board info.
      */
-    public function generate()
+    public function generate(): void
     {
         $repo = $this->emReport->getRepository(ReportBoardInstallationModel::class);
 

--- a/module/Report/src/Service/Factory/BoardFactory.php
+++ b/module/Report/src/Service/Factory/BoardFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service\Factory;
 
 use Doctrine\ORM\EntityManager;

--- a/module/Report/src/Service/Factory/KeyholderFactory.php
+++ b/module/Report/src/Service/Factory/KeyholderFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service\Factory;
 
 use Doctrine\ORM\EntityManager;

--- a/module/Report/src/Service/Factory/MeetingFactory.php
+++ b/module/Report/src/Service/Factory/MeetingFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service\Factory;
 
 use Database\Mapper\Meeting as MeetingMapper;

--- a/module/Report/src/Service/Factory/MemberFactory.php
+++ b/module/Report/src/Service/Factory/MemberFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service\Factory;
 
 use Database\Mapper\Member as MemberMapper;

--- a/module/Report/src/Service/Factory/MiscFactory.php
+++ b/module/Report/src/Service/Factory/MiscFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service\Factory;
 
 use Database\Mapper\MailingList as MailingListMapper;

--- a/module/Report/src/Service/Factory/OrganFactory.php
+++ b/module/Report/src/Service/Factory/OrganFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service\Factory;
 
 use Doctrine\ORM\EntityManager;

--- a/module/Report/src/Service/Keyholder.php
+++ b/module/Report/src/Service/Keyholder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service;
 
 use Doctrine\ORM\EntityManager;
@@ -22,7 +24,7 @@ class Keyholder
     /**
      * Export keyholder info.
      */
-    public function generate()
+    public function generate(): void
     {
         $grantingRepo = $this->emReport->getRepository(ReportKeyGrantingModel::class);
 

--- a/module/Report/src/Service/Meeting.php
+++ b/module/Report/src/Service/Meeting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service;
 
 use Database\Mapper\Meeting as MeetingMapper;
@@ -374,6 +376,8 @@ class Meeting
     /**
      * Obtain the correct member, given a database member. Because these members are generated based on what happens in
      * the `Database` module, this cannot return `null`.
+     *
+     * @psalm-ignore-nullable-return
      */
     public function findMember(DatabaseMemberModel $member): ReportMemberModel
     {

--- a/module/Report/src/Service/Member.php
+++ b/module/Report/src/Service/Member.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service;
 
 use Database\Mapper\Member as MemberMapper;
@@ -28,7 +30,7 @@ class Member
     /**
      * Export members.
      */
-    public function generate()
+    public function generate(): void
     {
         $memberCollection = $this->memberMapper->findAll();
 
@@ -52,7 +54,7 @@ class Member
         $progress->finish();
     }
 
-    public function generateMember(DatabaseMemberModel $member)
+    public function generateMember(DatabaseMemberModel $member): void
     {
         $repo = $this->emReport->getRepository(ReportMemberModel::class);
         // first try to find an existing member
@@ -95,7 +97,7 @@ class Member
     public function generateLists(
         DatabaseMemberModel $member,
         ReportMemberModel $reportMember,
-    ) {
+    ): void {
         $reportListRepo = $this->emReport->getRepository(ReportMailingListModel::class);
 
         $reportLists = array_map(function ($list) {
@@ -113,7 +115,6 @@ class Member
             }
 
             $reportMember->addList($reportList);
-            $this->addToMailmanList($member, $list);
             $this->emReport->persist($reportList);
         }
 
@@ -125,7 +126,6 @@ class Member
             }
 
             $reportMember->removeList($reportList);
-            $this->removeFromMailmanList($member, $list);
             $this->emReport->persist($reportList);
         }
     }
@@ -133,7 +133,7 @@ class Member
     public function generateAddress(
         DatabaseAddressModel $address,
         ?ReportMemberModel $reportMember = null,
-    ) {
+    ): void {
         $addrRepo = $this->emReport->getRepository(ReportAddressModel::class);
 
         if ($reportMember === null) {
@@ -164,7 +164,7 @@ class Member
         $this->emReport->persist($reportAddress);
     }
 
-    public function deleteMember(DatabaseMemberModel $member)
+    public function deleteMember(DatabaseMemberModel $member): void
     {
         $repo = $this->emReport->getRepository(ReportMemberModel::class);
         // first try to find an existing member
@@ -172,7 +172,7 @@ class Member
         $this->emReport->remove($reportMember);
     }
 
-    public function deleteAddress(DatabaseAddressModel $address)
+    public function deleteAddress(DatabaseAddressModel $address): void
     {
         $repo = $this->emReport->getRepository(ReportAddressModel::class);
 
@@ -183,15 +183,5 @@ class Member
         ]);
 
         $this->emReport->remove($reportAddress);
-    }
-
-    public function addToMailmanList($member, $listName)
-    {
-        // TODO
-    }
-
-    public function removeFromMailmanList($member, $listName)
-    {
-        // TODO
     }
 }

--- a/module/Report/src/Service/Misc.php
+++ b/module/Report/src/Service/Misc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service;
 
 use Database\Mapper\MailingList as MailingListMapper;
@@ -18,7 +20,7 @@ class Misc
     /**
      * Export misc info.
      */
-    public function generate()
+    public function generate(): void
     {
         /** @var DatabaseMailingListModel $list */
         foreach ($this->mailingListMapper->findAll() as $list) {
@@ -28,7 +30,7 @@ class Misc
         $this->emReport->flush();
     }
 
-    public function generateList(DatabaseMailingListModel $list)
+    public function generateList(DatabaseMailingListModel $list): void
     {
         $repo = $this->emReport->getRepository(ReportMailingListModel::class);
         $reportList = $repo->find($list->getName());

--- a/module/Report/src/Service/Organ.php
+++ b/module/Report/src/Service/Organ.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Report\Service;
 
 use Doctrine\ORM\EntityManager;

--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User;
 
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;

--- a/module/User/src/Adapter/ApiPrincipalAdapter.php
+++ b/module/User/src/Adapter/ApiPrincipalAdapter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Adapter;
 
 use Laminas\Authentication\Adapter\AdapterInterface;

--- a/module/User/src/Adapter/Factory/ApiPrincipalAdapterFactory.php
+++ b/module/User/src/Adapter/Factory/ApiPrincipalAdapterFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Adapter\Factory;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/User/src/Controller/Factory/SettingsControllerFactory.php
+++ b/module/User/src/Controller/Factory/SettingsControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Controller\Factory;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/User/src/Controller/Factory/UserControllerFactory.php
+++ b/module/User/src/Controller/Factory/UserControllerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Controller\Factory;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/User/src/Controller/SettingsController.php
+++ b/module/User/src/Controller/SettingsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Controller;
 
 use Laminas\Http\Response;

--- a/module/User/src/Controller/UserController.php
+++ b/module/User/src/Controller/UserController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Controller;
 
 use Laminas\Http\Response;

--- a/module/User/src/Factory/PasswordFactory.php
+++ b/module/User/src/Factory/PasswordFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Factory;
 
 use Laminas\Crypt\Password\Bcrypt;

--- a/module/User/src/Form/Login.php
+++ b/module/User/src/Form/Login.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Form;
 
 use Laminas\Form\Element\{

--- a/module/User/src/Form/UserCreate.php
+++ b/module/User/src/Form/UserCreate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Form;
 
 use Laminas\Form\Element\{

--- a/module/User/src/Form/UserEdit.php
+++ b/module/User/src/Form/UserEdit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Form;
 
 use Laminas\Form\Element\{

--- a/module/User/src/Listener/AuthenticationListener.php
+++ b/module/User/src/Listener/AuthenticationListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Listener;
 
 use InvalidArgumentException;

--- a/module/User/src/Listener/AuthorizationListener.php
+++ b/module/User/src/Listener/AuthorizationListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Listener;
 
 use InvalidArgumentException;

--- a/module/User/src/Mapper/ApiPrincipalMapper.php
+++ b/module/User/src/Mapper/ApiPrincipalMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Mapper;
 
 use Doctrine\ORM\{

--- a/module/User/src/Mapper/Factory/ApiPrincipalMapperFactory.php
+++ b/module/User/src/Mapper/Factory/ApiPrincipalMapperFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Mapper\Factory;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/User/src/Mapper/Factory/UserMapperFactory.php
+++ b/module/User/src/Mapper/Factory/UserMapperFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Mapper\Factory;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/User/src/Mapper/UserMapper.php
+++ b/module/User/src/Mapper/UserMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Mapper;
 
 use Doctrine\ORM\{

--- a/module/User/src/Model/ApiPrincipal.php
+++ b/module/User/src/Model/ApiPrincipal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Model;
 
 use Doctrine\ORM\Mapping\{

--- a/module/User/src/Model/Enums/ApiPermissions.php
+++ b/module/User/src/Model/Enums/ApiPermissions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Model\Enums;
 
 use Decision\Model\Member as MemberModel;

--- a/module/User/src/Model/Exception/NotAllowed.php
+++ b/module/User/src/Model/Exception/NotAllowed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Model\Exception;
 
 use RuntimeException;

--- a/module/User/src/Model/User.php
+++ b/module/User/src/Model/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Model;
 
 use Doctrine\ORM\Mapping\{

--- a/module/User/src/Module.php
+++ b/module/User/src/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User;
 
 use Laminas\Authentication\{

--- a/module/User/src/Service/ApiAuthenticationService.php
+++ b/module/User/src/Service/ApiAuthenticationService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Service;
 
 use InvalidArgumentException;

--- a/module/User/src/Service/Factory/ApiAuthenticationServiceFactory.php
+++ b/module/User/src/Service/Factory/ApiAuthenticationServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Service\Factory;
 
 use User\Adapter\ApiPrincipalAdapter;

--- a/module/User/src/Service/Factory/AuthenticationServiceFactory.php
+++ b/module/User/src/Service/Factory/AuthenticationServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Service\Factory;
 
 use Laminas\Authentication\AuthenticationService;

--- a/module/User/src/Service/Factory/UserServiceFactory.php
+++ b/module/User/src/Service/Factory/UserServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Service\Factory;
 
 use Laminas\Authentication\AuthenticationService;

--- a/module/User/src/Service/UserService.php
+++ b/module/User/src/Service/UserService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Service;
 
 use Laminas\Authentication\AuthenticationService;

--- a/module/User/view/user/settings/create.phtml
+++ b/module/User/view/user/settings/create.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $form->prepare();
 $form->setAttribute('action', $this->url('settings/user/default', ['action' => 'create']));
 $form->setAttribute('method', 'post');

--- a/module/User/view/user/settings/create.phtml
+++ b/module/User/view/user/settings/create.phtml
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 $form->prepare();
 $form->setAttribute('action', $this->url('settings/user/default', ['action' => 'create']));
 $form->setAttribute('method', 'post');

--- a/module/User/view/user/settings/edit.phtml
+++ b/module/User/view/user/settings/edit.phtml
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 $form->prepare();
 $form->setAttribute('action', $this->url('settings/user/edit', ['id' => $user->getId()]));
 $form->setAttribute('method', 'post');

--- a/module/User/view/user/settings/edit.phtml
+++ b/module/User/view/user/settings/edit.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $form->prepare();
 $form->setAttribute('action', $this->url('settings/user/edit', ['id' => $user->getId()]));
 $form->setAttribute('method', 'post');

--- a/module/User/view/user/settings/index.phtml
+++ b/module/User/view/user/settings/index.phtml
@@ -1,3 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+?>
 <h1><?= $this->translate('Users') ?></h1>
 
 <?php if ($usesldap): ?>

--- a/module/User/view/user/settings/index.phtml
+++ b/module/User/view/user/settings/index.phtml
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
 ?>
 <h1><?= $this->translate('Users') ?></h1>
 

--- a/module/User/view/user/user/index.phtml
+++ b/module/User/view/user/user/index.phtml
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $form->prepare();
 $form->setAttribute('action', $this->url('user'));
 $form->setAttribute('method', 'post');

--- a/module/User/view/user/user/index.phtml
+++ b/module/User/view/user/user/index.phtml
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\View\HelperTrait;
+use Laminas\View\Renderer\PhpRenderer;
+
+/** @var PhpRenderer|HelperTrait $this */
+
 $form->prepare();
 $form->setAttribute('action', $this->url('user'));
 $form->setAttribute('method', 'post');

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,10 +8,16 @@
 
     <arg name="parallel" value="8"/>
     <arg name="extensions" value="php,dist"/>
-
     <arg name="error-severity" value="1"/>
     <arg name="warning-severity" value="1"/>
+
     <rule ref="PSR1"/>
     <rule ref="PSR12"/>
     <rule ref="./phpcs"/>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="spacesCountAroundEqualsSign" type="int" value="0" />
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
These changes bring a lot to our code base. First and foremost, `declare(strict_type=1)` is now always required in a PHP file (including the `.phtml` view templates). On top of that, I have added correct typing to most of the view templates themselves, this means that auto-complete can now also work in templates. It should be noted that typing in view templates is not automatically available, this still requires manual insertion of type definitions.

Closes GH-225.