### PR TITLE
Add missing concurrency check to unit test action

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,6 +3,7 @@ name: PHP Static Analysis
 # Only run this action on pull requests (creation, synchronisation, and reopening).
 on: [pull_request]
 
+# Cancel running jobs that have become stale through updates to the ref (e.g., pushes to a pull request).
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,11 @@ on:
             - master
     pull_request:
 
+# Cancel running jobs that have become stale through updates to the ref (e.g., pushes to a pull request).
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     phpunit:
         name: PHPUnit


### PR DESCRIPTION
We added it for two of the three actions, this has been fixed.

Closes GH-239.