### PR TITLE
Handle manual approval of prospective members and potential refunds

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -27,7 +27,8 @@ APP_URL=https://database.gewis.nl
 NGINX_REQUIRE_AUTH=off
 
 # Stripe settings to enable auto-magic payment flow in enrolment form
-# The STRIPE_SECRET_KEY should at all times be a restricted key!
+# The STRIPE_SECRET_KEY should at all times be a restricted key with the following permissions:
+# Write on "Core Objects: Charges", rak_charge_write (for refunds) and write on "Checkout"
 STRIPE_API_VERSION=2022-08-01
 STRIPE_PUBLISHABLE_KEY=pk_test_somelongrandomgeneratedtextfromstripe
 STRIPE_SECRET_KEY=rk_test_somelongrandomgeneratedtextfromstripe

--- a/module/Database/src/Controller/Factory/ProspectiveMemberControllerFactory.php
+++ b/module/Database/src/Controller/Factory/ProspectiveMemberControllerFactory.php
@@ -6,6 +6,8 @@ namespace Database\Controller\Factory;
 
 use Database\Controller\ProspectiveMemberController;
 use Database\Service\Member as MemberService;
+use Database\Service\Stripe as StripeService;
+use Laminas\Mvc\I18n\Translator as MvcTranslator;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 
@@ -19,9 +21,17 @@ class ProspectiveMemberControllerFactory implements FactoryInterface
         $requestedName,
         ?array $options = null,
     ): ProspectiveMemberController {
+        /** @var MvcTranslator $translator */
+        $translator = $container->get(MvcTranslator::class);
         /** @var MemberService $memberService */
         $memberService = $container->get(MemberService::class);
+        /** @var StripeService $stripeService */
+        $stripeService = $container->get(StripeService::class);
 
-        return new ProspectiveMemberController($memberService);
+        return new ProspectiveMemberController(
+            $translator,
+            $memberService,
+            $stripeService,
+        );
     }
 }

--- a/module/Database/src/Model/CheckoutSession.php
+++ b/module/Database/src/Model/CheckoutSession.php
@@ -63,6 +63,15 @@ class CheckoutSession
     protected DateTime $expiration;
 
     /**
+     * The identifier of the PaymentIntent associated with this Checkout Session when the state is 'PAID'.
+     */
+    #[Column(
+        type: 'string',
+        nullable: true,
+    )]
+    protected ?string $paymentIntentId = null;
+
+    /**
      * Recovery URL for the Checkout Session when the state is 'EXPIRED'.
      */
     #[Column(
@@ -135,6 +144,16 @@ class CheckoutSession
     public function setExpiration(DateTime $expiration): void
     {
         $this->expiration = $expiration;
+    }
+
+    public function getPaymentIntentId(): ?string
+    {
+        return $this->paymentIntentId;
+    }
+
+    public function setPaymentIntentId(?string $paymentIntentId): void
+    {
+        $this->paymentIntentId = $paymentIntentId;
     }
 
     public function getRecoveryUrl(): ?string

--- a/module/Database/view/database/email/refund-created.mailtemplate.yml
+++ b/module/Database/view/database/email/refund-created.mailtemplate.yml
@@ -1,0 +1,39 @@
+# This is a GEWIS mailings template
+# Registration confirmation
+---
+# All mailings require some settings. These can be set here. Don't forget to set the title ("Algemene mededeling; tekst zelf invoeren")
+version: 1.1
+settings:
+    title: "GEWIS Membership Fee Refund Issued"
+    email: "secr@gewis.nl"
+    lang: en-UK
+    #lang: nl-NL
+    follow: true
+
+# A mailing consists of a series of messageblocks, each with their own type
+# The available types are "header", "topblock", "activities", "activityfooter", "extramessage" and "tinyfooter"
+messageblocks:
+
+    # Each mailing must have a header to make the template shine! It contains the title and the date.
+    - type: "header"
+      title: "Update on your registration"
+      date: 2023-08-13 #Note that this date needs to be updated
+
+    # This is the first block which is shown on top of the message. Recommended for most messages
+    - type: topblock
+      title: "Refund of Membership Fee"
+      contentHTML: "</p>
+
+      <p>Dear {{FIRST_NAME}},</p>
+
+      <p>Your payment of the membership fee is being refunded. It can take anywhere from 5-10 business days to show up on your bank account.</p>
+
+      <br/>
+      With kind regards,<br/>
+      The board of GEWIS
+      "
+
+
+    # You probably want to include this each newsletter
+    - type: tinyfooter
+      contentHTML: 'You received this email because your membership fee is being refunded.'

--- a/module/Database/view/database/email/refund-created.phtml
+++ b/module/Database/view/database/email/refund-created.phtml
@@ -1,0 +1,321 @@
+
+<!DOCTYPE html>
+<html lang="en" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml">
+<head>
+    <title>GEWIS Membership Fee Refund Issued</title>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <!--[if mso]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+            <o:AllowPNG/>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <!--[if !mso]><!-->
+    <!--<![endif]-->
+    <style>
+        :root {
+            --gewisred: #D40000;
+            --black: #000000;
+            --white: #FFFFFF;
+            --gewisdarkred: #C40000;
+            --gewisdarkgray: #333333;
+            --gewislightgray: #F2F2F2;
+            --slightlydarkergray: #DDDDDD;
+            --gewisdarkblue: #293065;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+        th.column {
+            padding: 0
+        }
+        .pleft {
+            text-align: right;
+        }
+        a[x-apple-data-detectors] {
+            color: inherit !important;
+            text-decoration: inherit !important;
+        }
+        #MessageViewBody a {
+            color: inherit;
+            text-decoration: none;
+        }
+        p {
+            line-height: inherit
+        }
+        @media (max-width:720px) {
+            .icons-inner {
+                text-align: center;
+            }
+            .icons-inner td {
+                margin: 0 auto;
+            }
+            .fullMobileWidth,
+            .row-content {
+                width: 100% !important;
+            }
+            .image_block img.big {
+                width: auto !important;
+            }
+            .stack .column {
+                width: 100%;
+                display: block;
+            }
+            .pleft {
+                text-align: left;
+            }
+            .reverse {
+                display: table;
+                width: 100%;
+            }
+            .reverse th.first {
+                display: table-footer-group !important;
+            }
+            .reverse th.last {
+                display: table-header-group !important;
+            }
+            .row-11 th.column.first>table,
+            .row-11 th.column.last>table {
+                padding-left: 25px;
+                padding-right: 25px;
+            }
+            .hiddensmall {
+                display: none;
+            }
+        }
+    </style>
+</head>
+<body style="background-color: #DDDDDD; margin: 0; padding: 0; text-align: center;">
+GEWIS&nbsp;Registration&nbsp;Payment&nbsp;Refunded
+<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #DDDDDD;" width="100%">
+    <tbody>
+    <tr>
+        <td>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-1" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;" width="100%">
+                <tbody style="width: 100%;">
+
+                <tr>
+                    <td style="width: 100%;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-left: 25px; padding-right: 25px; padding-top: 40px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
+                                    <table border="0" cellpadding="0" cellspacing="0" class="image_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;" width="100%">
+                                        <tr>
+                                            <td style="padding-bottom:25px;width:20%;padding-right:0px;padding-left:0px;min-width: 85px;">
+                                                <div align="left" style="line-height:10px;">
+                                                    <img alt="Logo" src="https://static.gewis.nl/mailings/2021/logo-70x70.png" style="display: block; width: auto; border: 0; height: 70px; max-width: 100%;" title="Logo" width="70"/>
+                                                </div>
+                                            </td>
+                                            <td style="padding-bottom:25px;width:50%;padding-right:0px;padding-left:0px;">
+                                                <div align="left" style="font-size: 26px; font-family: 'Roboto Slab', Arial, 'Helvetica Neue', Helvetica, sans-serif; color: #ffffff; line-height: 1.5em;">
+                                                    Update on your registration
+                                                </div>
+                                            </td>
+                                            <td style="padding-bottom:25px;width:50%;padding-right:0px;padding-left:0px;">
+                                                <div align="right" style="font-size: 13px; font-family: 'Roboto Slab', Arial, 'Helvetica Neue', Helvetica, sans-serif; color: #ffffff; line-height: 1.5em;">
+                                                    <?= date('l') ?><br/><?= date('j F Y') ?>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <!-- Important announcements -->
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000;" width="720">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #F2F2F2; margin-top: 10px; " width="660">
+                                        <tbody>
+                                        <tr>
+                                            <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-left: 25px; padding-right: 25px; padding-top: 30px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
+                                                <table border="0" cellpadding="0" cellspacing="0" class="heading_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;" width="100%">
+                                                    <tr>
+                                                        <td style="padding-bottom:10px;text-align:center;width:100%; color: black; font-family: 'Roboto Slab', Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 28px; font-weight: bold; letter-spacing: normal; line-height: 120%; text-align: center; ">
+                                                            Refund of Membership Fee
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #FFFFFF;" width="720">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #F2F2F2; " width="660">
+                                        <tbody>
+                                        <tr>
+                                            <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-left: 25px; padding-right: 25px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="50%">
+                                                <table border="0" cellpadding="0" cellspacing="0" class="text_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; word-break: break-word;" width="100%">
+                                                    <tr>
+                                                        <td style="padding-top:25px;padding-bottom:25px;">
+                                                            <div style="font-family: sans-serif">
+                                                                <div style="font-size: 18px; color: #333333; line-height: 1.4; font-family: Roboto, Tahoma, Verdana, Segoe, sans-serif;">
+                                                                    <p style="margin: 0; font-size: 18px;">
+                                                                    <p>Dear <?= $this->escapeHtml($member->getFirstName()) ?>,</p>
+                                                                    <p>Your payment of the membership fee is being refunded. It can take anywhere from 5-10 business days to show up on your bank account.</p>
+                                                                    <br> With kind regards,<br> The board of GEWIS
+                                                                    </p>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr class="hiddensmall">
+                                <td>
+                                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #FFFFFF;" width="720">
+                                        <tbody>
+                                        <tr style="height: 25px;">
+                                            <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
+                                                &nbsp;
+                                            </th>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <!-- /Important announcements -->
+                <!-- New newsletter announcement -->
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff; width: 720px;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-left: 65px; padding-right: 65px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
+                                    <table border="0" cellpadding="0" cellspacing="0" class="text_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; word-break: break-word; width: 100%;" width="100%">
+                                        <tr>
+                                            <td style="padding-left:0px; padding-top:20px; padding-bottom:0px; padding-right:0px; background-color: #FFFFFF;">
+                                                <div style="font-size: 11.5px; color: black; line-height: 1.2; font-style: italic; font-family: Roboto, Tahoma, Verdana, Segoe, sans-serif;">
+                                                    <p>You received this email because your membership fee is being refunded.</p>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <!-- /New newsletter announcement -->
+
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000; width: 720px;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: bottom; padding-left: 40px; padding-right: 40px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 50%;" width="50%"><table border="0" cellpadding="0" cellspacing="0" class="text_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; word-break: break-word; width: 100%;" width="100%">
+                                        <tr>
+                                            <td style="padding-bottom:10px;padding-top:20px;">
+                                                <div style="font-family: Arial, sans-serif">
+                                                    <div style="font-size: 14px; font-family: 'Roboto Slab', Arial, 'Helvetica Neue', Helvetica, sans-serif; color: #ffffff; line-height: 1.2;">
+                                                        <p style="margin: 0; font-size: 14px; text-align: left; letter-spacing: 2px;"><span style="font-size:18px;">Follow GEWIS</span></p>
+                                                    </div>
+                                                    <table align="left" border="0" cellpadding="0" cellspacing="0" class="social-table" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 168px;" width="168">
+                                                        <tr>
+                                                            <td style="padding:0 10px 0 0;"><a href="https://www.gewis.nl/" target="_blank"><img alt="GEWIS Website" height="32" src="https://static.gewis.nl/mailings/2021/fa-globe-europe-32x32.png" style="display: block; height: auto; border: 0;" title="Globe" width="32"/></a></td>
+                                                            <td style="padding:0 10px 0 0;"><a href="https://www.instagram.com/svgewis" target="_blank"><img alt="Instagram" height="32" src="https://static.gewis.nl/mailings/2021/fa-instagram-32x32.png" style="display: block; height: auto; border: 0;" title="Instagram" width="32"/></a></td>
+                                                            <td style="padding:0 10px 0 0;"><a href="https://www.facebook.com/svgewis" target="_blank"><img alt="Facebook" height="32" src="https://static.gewis.nl/mailings/2021/fa-facebook-square-32x32.png" style="display: block; height: auto; border: 0;" title="Facebook" width="32"/></a></td>
+                                                            <td style="padding:0 10px 0 0;"><a href="https://www.linkedin.com/company/study-association-gewis/" target="_blank"><img alt="LinkedIn" height="32" src="https://static.gewis.nl/mailings/2021/fa-linkedin-32x32.png" style="display: block; height: auto; border: 0;" title="LinkedIn" width="32"/></a></td>
+                                                        </tr>
+                                                    </table>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </th>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: bottom; padding-left: 40px; padding-right: 40px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 50%;" width="50%">
+                                    <table border="0" cellpadding="0" cellspacing="0" class="text_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; word-break: break-word; width: 100%;" width="100%">
+                                        <tr>
+                                            <td style="padding-top:15px;padding-bottom:0px;">
+                                                <div style="font-family: sans-serif">
+                                                    <div style="font-size: 12px; color: #FFFFFF; line-height: 1.2; font-family: Roboto, Tahoma, Verdana, Segoe, sans-serif;">
+                                                        <p class="pleft" style="margin: 0; font-size: 14px;">
+                                                            <a href="mailto:secr@gewis.nl" style="color:white; text-decoration:none;">secr@gewis.nl</a><br/>
+                                                            <a href="tel:+31402472815" style="color:white; text-decoration:none;">+31 40 247 2815</a><br/>
+
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-20" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
+                <tbody>
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000; width: 720px;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/module/Database/view/database/email/refund-problem.mailtemplate.yml
+++ b/module/Database/view/database/email/refund-problem.mailtemplate.yml
@@ -1,0 +1,31 @@
+# This is a GEWIS mailings template
+# Registration confirmation
+---
+# All mailings require some settings. These can be set here. Don't forget to set the title ("Algemene mededeling; tekst zelf invoeren")
+version: 1.1
+settings:
+    title: "Problem with GEWIS membership fee refund"
+    email: "secr@gewis.nl"
+    lang: en-UK
+    #lang: nl-NL
+    follow: false
+
+# A mailing consists of a series of messageblocks, each with their own type
+# The available types are "header", "topblock", "activities", "activityfooter", "extramessage" and "tinyfooter"
+messageblocks:
+
+    # Each mailing must have a header to make the template shine! It contains the title and the date.
+    - type: "header"
+      title: "Membership Refund Status"
+      date: 2023-08-14 #Note that this date needs to be updated
+
+    # This is the first block which is shown on top of the message. Recommended for most messages
+    - type: topblock
+      title: "[AUTOMATED] Problem with refund"
+      contentHTML: "</p>
+
+      <p>An issue was detected with the following refund: <strong>{{REFUND_ID}}</strong>, its status is <em>{{REFUND_STATUS}}</em>.</p>
+
+      <p>Contact the ApplicatieBeheerCommissie and/or the treasurer to determine the underlying issue.</p>
+
+      "

--- a/module/Database/view/database/email/refund-problem.phtml
+++ b/module/Database/view/database/email/refund-problem.phtml
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var string $refundId
+ * @var string $refundStatus
+ */
+?>
+<!DOCTYPE html>
+<html lang="en" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml">
+<head>
+    <title>Problem with GEWIS membership fee refund</title>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <!--[if mso]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+            <o:AllowPNG/>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <!--[if !mso]><!-->
+    <!--<![endif]-->
+    <style>
+        :root {
+            --gewisred: #D40000;
+            --black: #000000;
+            --white: #FFFFFF;
+            --gewisdarkred: #C40000;
+            --gewisdarkgray: #333333;
+            --gewislightgray: #F2F2F2;
+            --slightlydarkergray: #DDDDDD;
+            --gewisdarkblue: #293065;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+        th.column {
+            padding: 0
+        }
+        .pleft {
+            text-align: right;
+        }
+        a[x-apple-data-detectors] {
+            color: inherit !important;
+            text-decoration: inherit !important;
+        }
+        #MessageViewBody a {
+            color: inherit;
+            text-decoration: none;
+        }
+        p {
+            line-height: inherit
+        }
+        @media (max-width:720px) {
+            .icons-inner {
+                text-align: center;
+            }
+            .icons-inner td {
+                margin: 0 auto;
+            }
+            .fullMobileWidth,
+            .row-content {
+                width: 100% !important;
+            }
+            .image_block img.big {
+                width: auto !important;
+            }
+            .stack .column {
+                width: 100%;
+                display: block;
+            }
+            .pleft {
+                text-align: left;
+            }
+            .reverse {
+                display: table;
+                width: 100%;
+            }
+            .reverse th.first {
+                display: table-footer-group !important;
+            }
+            .reverse th.last {
+                display: table-header-group !important;
+            }
+            .row-11 th.column.first>table,
+            .row-11 th.column.last>table {
+                padding-left: 25px;
+                padding-right: 25px;
+            }
+            .hiddensmall {
+                display: none;
+            }
+        }
+    </style>
+</head>
+<body style="background-color: #DDDDDD; margin: 0; padding: 0; text-align: center;">
+Problem&nbsp;with&nbsp;GEWIS&nbsp;membership&nbsp;fee&nbsp;refund
+<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #DDDDDD;" width="100%">
+    <tbody>
+    <tr>
+        <td>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-1" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;" width="100%">
+                <tbody style="width: 100%;">
+
+                <tr>
+                    <td style="width: 100%;">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-left: 25px; padding-right: 25px; padding-top: 40px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
+                                    <table border="0" cellpadding="0" cellspacing="0" class="image_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;" width="100%">
+                                        <tr>
+                                            <td style="padding-bottom:25px;width:20%;padding-right:0px;padding-left:0px;min-width: 85px;">
+                                                <div align="left" style="line-height:10px;">
+                                                    <img alt="Logo" src="https://static.gewis.nl/mailings/2021/logo-70x70.png" style="display: block; width: auto; border: 0; height: 70px; max-width: 100%;" title="Logo" width="70"/>
+                                                </div>
+                                            </td>
+                                            <td style="padding-bottom:25px;width:50%;padding-right:0px;padding-left:0px;">
+                                                <div align="left" style="font-size: 26px; font-family: 'Roboto Slab', Arial, 'Helvetica Neue', Helvetica, sans-serif; color: #ffffff; line-height: 1.5em;">
+                                                    Membership Refund Status
+                                                </div>
+                                            </td>
+                                            <td style="padding-bottom:25px;width:50%;padding-right:0px;padding-left:0px;">
+                                                <div align="right" style="font-size: 13px; font-family: 'Roboto Slab', Arial, 'Helvetica Neue', Helvetica, sans-serif; color: #ffffff; line-height: 1.5em;">
+                                                    <?= date('l') ?><br/><?= date('j F Y') ?>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <!-- Important announcements -->
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000;" width="720">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #F2F2F2; margin-top: 10px; " width="660">
+                                        <tbody>
+                                        <tr>
+                                            <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-left: 25px; padding-right: 25px; padding-top: 30px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
+                                                <table border="0" cellpadding="0" cellspacing="0" class="heading_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;" width="100%">
+                                                    <tr>
+                                                        <td style="padding-bottom:10px;text-align:center;width:100%; color: black; font-family: 'Roboto Slab', Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size: 28px; font-weight: bold; letter-spacing: normal; line-height: 120%; text-align: center; ">
+                                                            [AUTOMATED] Problem with refund
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #FFFFFF;" width="720">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #F2F2F2; " width="660">
+                                        <tbody>
+                                        <tr>
+                                            <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-left: 25px; padding-right: 25px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="50%">
+                                                <table border="0" cellpadding="0" cellspacing="0" class="text_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; word-break: break-word;" width="100%">
+                                                    <tr>
+                                                        <td style="padding-top:25px;padding-bottom:25px;">
+                                                            <div style="font-family: sans-serif">
+                                                                <div style="font-size: 18px; color: #333333; line-height: 1.4; font-family: Roboto, Tahoma, Verdana, Segoe, sans-serif;">
+                                                                    <p style="margin: 0; font-size: 18px;">
+                                                                    <p>An issue was detected with the following refund: <strong><?= $this->escapeHtml($refundId) ?></strong>, its status is <em><?= $this->escapeHtml($refundStatus) ?></em>.</p>
+                                                                    <p>Contact the ApplicatieBeheerCommissie and/or the treasurer to determine the underlying issue.</p>
+                                                                    </p>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr class="hiddensmall">
+                                <td>
+                                    <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #FFFFFF;" width="720">
+                                        <tbody>
+                                        <tr style="height: 25px;">
+                                            <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
+                                                &nbsp;
+                                            </th>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <!-- /Important announcements -->
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
+                                    <div class="spacer_block" style="height:60px;line-height:60px;">&nbsp;</div>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000; width: 720px;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: bottom; padding-left: 40px; padding-right: 40px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 50%;" width="50%">
+                                </th>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: bottom; padding-left: 40px; padding-right: 40px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 50%;" width="50%">
+                                    <table border="0" cellpadding="0" cellspacing="0" class="text_block" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; word-break: break-word; width: 100%;" width="100%">
+                                        <tr>
+                                            <td style="padding-top:15px;padding-bottom:0px;">
+                                                <div style="font-family: sans-serif">
+                                                    <div style="font-size: 12px; color: #FFFFFF; line-height: 1.2; font-family: Roboto, Tahoma, Verdana, Segoe, sans-serif;">
+                                                        <p class="pleft" style="margin: 0; font-size: 14px;">
+                                                            <a href="mailto:secr@gewis.nl" style="color:white; text-decoration:none;">secr@gewis.nl</a><br/>
+                                                            <a href="tel:+31402472815" style="color:white; text-decoration:none;">+31 40 247 2815</a><br/>
+
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-20" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
+                <tbody>
+                <tr>
+                    <td>
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #C40000; width: 720px;" width="720">
+                            <tbody>
+                            <tr>
+                                <th class="column" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; vertical-align: top; padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px; width: 100%;" width="100%">
+                                    <div class="spacer_block" style="height:40px;line-height:40px;">&nbsp;</div>
+                                </th>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/module/Database/view/database/meeting/installform.phtml
+++ b/module/Database/view/database/meeting/installform.phtml
@@ -607,7 +607,7 @@ $submit->setAttribute('disabled', 'disabled');
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title" id="install-model-discharge-label"><?= $this->translate('Make Member Inactive') ?></h4>
+                <h4 class="modal-title" id="install-model-inactive-label"><?= $this->translate('Make Member Inactive') ?></h4>
             </div>
             <div class="modal-body">
                 <?=

--- a/module/Database/view/database/prospective-member/delete.phtml
+++ b/module/Database/view/database/prospective-member/delete.phtml
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var string $title
+ * @var string $description
+ */
+?>
+<div class="row">
+    <div class="col-md-12">
+        <h1><?= $this->translate('Cannot Delete Prospective Member:') ?> <?= $title ?></h1>
+    </div>
+    <div class="col-md-12">
+        <p><?= $description ?></p>
+    </div>
+</div>

--- a/module/Database/view/database/prospective-member/show.phtml
+++ b/module/Database/view/database/prospective-member/show.phtml
@@ -189,6 +189,19 @@ use Laminas\View\Renderer\PhpRenderer;
         <?php endforeach; ?>
 
         <?php if (isset($form)): ?>
+            <?php if (!$member->hasPaid()): ?>
+                <div class="panel-group">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h4 class="panel-title">
+                                <a data-toggle="collapse" href="#not-paid-collapse">
+                                    <?= $this->translate('Click here for approval if membership fee paid with cash.') ?>
+                                </a>
+                            </h4>
+                        </div>
+                        <div id="not-paid-collapse" class="panel-collapse collapse">
+                            <div class="panel-body">
+            <?php endif; ?>
             <?php
             $form->prepare();
 
@@ -227,7 +240,7 @@ use Laminas\View\Renderer\PhpRenderer;
             } else {
                 $element->setChecked(false);
                 $element->setAttributes([
-                    "disabled" => true,
+                    'disabled' => true,
                 ]);
             }
             ?>
@@ -250,16 +263,69 @@ use Laminas\View\Renderer\PhpRenderer;
             $submit->setAttribute('class', 'btn btn-success');
             ?>
             <?= $this->formButton($submit) ?>
+            <?php if (!$canDelete): ?>
+                <?= $this->form()->closeTag() ?>
+            <?php endif; ?>
+            <?php if (!$member->hasPaid()): ?>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <?php endif; ?>
         <?php else: ?>
             <p>
                 <?= $this->translate('This prospective member cannot be approved.') ?>
             </p>
         <?php endif; ?>
         <?php if ($canDelete): ?>
-            <a href="<?= $this->url('prospective-member/show/delete', array(
-                'id' => $member->getLidnr()
-            )) ?>" class="btn btn-danger"><?= $this->translate('Delete Prospective Member') ?></a>
-            <?= $this->form()->closeTag() ?>
+            <button type="button" class="btn btn-danger remove-modal">
+                <?= $this->translate('Delete Prospective Member') ?>
+            </button>
+            <?php if (isset($form)): ?>
+                <?= $this->form()->closeTag() ?>
+            <?php endif; ?>
+            <div id="prospective-removal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="prospective-removal-label" aria-hidden="true">
+                <div class="modal-dialog modal-sm">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                            <h4 class="modal-title" id="prospective-removal-label">
+                                <?= $this->translate('Remove Prospective Member') ?>
+                            </h4>
+                        </div>
+                        <div class="modal-body">
+                            <?php if ($member->hasPaid()): ?>
+                                <?= sprintf(
+                                    // phpcs:ignore -- user-visible strings should not be split
+                                    $this->translate('Are you sure that you want to remove %s? Because they have already paid a refund will be requested. If this fails, the prospective member will NOT be removed.'),
+                                    '<span class="name">' . $this->escapeHtml($member->getFullName()) . '</span>',
+                                ) ?>
+                            <?php else: ?>
+                                <?= sprintf(
+                                    $this->translate('Are you sure that you want to remove %s?'),
+                                    '<span class="name">' . $this->escapeHtml($member->getFullName()) . '</span>',
+                                ) ?>
+                            <?php endif; ?>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-default" data-dismiss="modal">
+                                <?= $this->translate('No') ?>
+                            </button>
+                            <a href="<?= $this->url('prospective-member/show/delete', [
+                                'id' => $member->getLidnr()
+                            ]) ?>" class="btn btn-danger" id="remove-modal-yes">
+                                <?= $this->translate('Delete Prospective Member') ?>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <script>
+                $('button.remove-modal').click(function() {
+                    let modal = $('#prospective-removal');
+                    modal.modal();
+                });
+            </script>
         <?php endif; ?>
     </div>
 </div>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -194,4 +194,9 @@
         <exclude-pattern>module/Checker/src/Model/Error/MemberActiveWithRoleAndInactiveInOrgan.php</exclude-pattern>
         <exclude-pattern>module/Checker/src/Model/Error/MemberInNonExistingOrgan.php</exclude-pattern>
     </rule>
+
+    <!-- PHP_CodeSniffer does not yet understand PHP 8.2 functionality -->
+    <rule ref="PSR12.Functions.NullableTypeDeclaration.UnexpectedCharactersFound">
+        <exclude-pattern>module/Database/src/Service/Stripe.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/psalm/psalm-baseline.xml
+++ b/psalm/psalm-baseline.xml
@@ -72,7 +72,8 @@
     </InvalidReturnType>
   </file>
   <file src="module/Database/src/Service/Stripe.php">
-    <UndefinedMagicPropertyFetch occurrences="2">
+    <UndefinedMagicPropertyFetch occurrences="3">
+      <code>$event-&gt;data-&gt;object</code>
       <code>$event-&gt;data-&gt;object</code>
       <code>$session-&gt;after_expiration-&gt;recovery</code>
     </UndefinedMagicPropertyFetch>


### PR DESCRIPTION
This changes the approval and removal flow for prospective members.

A prospective member can now be approved if their last Checkout Session state is `EXPIRED` or `FAILED`. This requires unfolding the approval form (adding an additional checkmark it too much work).

This closes GH-314.

---

Prospective members can now only be deleted if their last Checkout Session `FAILED`, when they are fully `EXPIRED` or when they have paid (`PAID`).

In the event that they have paid, we will try to create a Refund for the original Charge. If this fails, the prospective member is not removed and the secretary is warned about this.

If the Refund is created successfully Stripe will handle everything else, it may take up to 5-10 business days before the Refund is fully processed by Stripe.

![image](https://github.com/GEWIS/gewisdb/assets/4983571/78f80d0e-c398-461a-9de0-b4741b0017b8)

To make this possible, when we mark a Checkout Session as `PAID` we store the id of the Payment Intent, which means we have to make one API call less when we are trying to create a Refund. Because Refunds work with a specific Charge and not a Checkout Session or Payment Intent.

If Stripe fails to complete the Refund request, we handle the `charge.refund.updated` event for the following states: `failed`, `requires_action` or `canceled`. The secretary will receive an e-mail for this, as the refund should potentially be done in another way.

This closes GH-313.