### PR TITLE
Improved e-mail address filtering

### DIFF
--- a/module/Database/src/Form/Member.php
+++ b/module/Database/src/Form/Member.php
@@ -270,12 +270,12 @@ class Member extends Form implements InputFilterProviderInterface
                         'name' => Callback::class,
                         'options' => [
                             'callback' => static function ($value) {
-                                return !str_ends_with($value, '@student.tue.nl');
+                                return !str_ends_with($value, '.tue.nl');
                             },
                             'messages' => [
                                 Callback::INVALID_VALUE => $this->translator->translate(
                                     // phpcs:ignore -- user-visible strings should not be split
-                                    'You cannot use your student e-mail address because if you stop studying, we can no longer reach you about important announcements.',
+                                    'You cannot use your TU/e (student) e-mail address because if you leave or stop studying, we can no longer reach you about important announcements.',
                                 ),
                             ],
                         ],

--- a/module/Database/src/Form/Member.php
+++ b/module/Database/src/Form/Member.php
@@ -21,6 +21,8 @@ use Laminas\Form\Form;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Mvc\I18n\Translator as MvcTranslator;
 use Laminas\Validator\Callback;
+use Laminas\Validator\EmailAddress;
+use Laminas\Validator\Hostname;
 use Laminas\Validator\Identical;
 use Laminas\Validator\Regex;
 use Laminas\Validator\StringLength;
@@ -276,6 +278,19 @@ class Member extends Form implements InputFilterProviderInterface
                                 Callback::INVALID_VALUE => $this->translator->translate(
                                     // phpcs:ignore -- user-visible strings should not be split
                                     'You cannot use your TU/e (student) e-mail address because if you leave or stop studying, we can no longer reach you about important announcements.',
+                                ),
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => EmailAddress::class,
+                        'options' => [
+                            'allow' => Hostname::ALLOW_DNS,
+                            'useMxCheck' => true,
+                            'messages' => [
+                                EmailAddress::INVALID_MX_RECORD => $this->translator->translate(
+                                    // phpcs:ignore -- user-visible strings should not be split
+                                    'Please check your e-mail address, \'%hostname%\' does not appear to be able to receive e-mails. If you are certain that your e-mail address is correct, please contact the board.'
                                 ),
                             ],
                         ],


### PR DESCRIPTION
Changes the TU/e e-mail address filter to `*.tue.nl` (from `@student.tue.nl`), this will also catch instances like `@alumnus.tue.nl` if the university decides to abandon those.

Additionally, we now query the domain for `MX` records (not their validity). Combined, this will look like this in the event of a typo/incorrect domain:
![image](https://github.com/GEWIS/gewisdb/assets/4983571/54e10ae5-2be8-4c5d-9478-11ad265ed672)

This closes GH-312 and fixes GH-319.

(I will update the translations before deploying tomorrow)