### PR TITLE
Fix sorting of installations on install form

### DIFF
--- a/module/Database/view/database/meeting/installform.phtml
+++ b/module/Database/view/database/meeting/installform.phtml
@@ -67,6 +67,10 @@ $(document).ready(function () {
                 $.each(data.json.members, function (idx, member) {
                     var installationCount = 0;
 
+                    member.installations.sort((a, b) => {
+                        return ('Lid' === b.function) ? 1 : 0;
+                    });
+
                     $.each(member.installations, function (idx, install) {
                         var decNum = install.meeting_type + '-' + install.meeting_number
                             + '-' + install.decision_point + '-' + install.decision_number


### PR DESCRIPTION
This changes the sorting on the install form to always prioritise `Lid`. This ensures that the ordering and thus the names of the members of an organ are always displayed on top.

This fixes ABC-2306-253.