### PR TITLE
Extra guarantees on member approval and database-constraint update

### DIFF
--- a/module/Database/src/Model/CheckoutSession.php
+++ b/module/Database/src/Model/CheckoutSession.php
@@ -88,6 +88,7 @@ class CheckoutSession
     #[JoinColumn(
         name: 'recovered_from_id',
         referencedColumnName: 'id',
+        onDelete: 'SET NULL',
     )]
     protected ?CheckoutSession $recoveredFrom = null;
 

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -285,6 +285,11 @@ class Member
         // Fill in the address in the form again
         $data = $prospectiveMember->toArray();
 
+        if ($this->getMemberMapper()->hasMemberWith($prospectiveMember->getEmail())) {
+            // phpcs:ignore -- user-visible strings should not be split
+            throw new RuntimeException('You cannot approve this member. A member with this email address already exists. Make sure this is not an error in the database. Disapproving will refund the member, so make sure they paid twice before refunding.');
+        }
+
         // add list data to the form
         foreach ($form->getLists() as $list) {
             $result = '0';


### PR DESCRIPTION
Fix for GH-327 

This PR introduces a database-level restriction on the constraint so it will allow checkout sessions to be deleted without throwing an exception in Doctrine. 

Moreover, an extra restriction on approving members who already exist in the database is introduced.