### PR TITLE
Fix not creating third or later `CheckoutSession` after recovery

### DIFF
--- a/module/Database/src/Mapper/CheckoutSession.php
+++ b/module/Database/src/Mapper/CheckoutSession.php
@@ -37,16 +37,6 @@ class CheckoutSession
         return $qb->getQuery()->getOneOrNullResult();
     }
 
-    public function findRecoveredBy(CheckoutSessionModel $checkoutSession): ?CheckoutSessionModel
-    {
-        $qb = $this->getRepository()->createQueryBuilder('cs');
-        $qb->where('cs.recoveredFrom = :checkoutSession');
-
-        $qb->setParameter('checkoutSession', $checkoutSession);
-
-        return $qb->getQuery()->getOneOrNullResult();
-    }
-
     /**
      * Persist a payment state.
      */

--- a/module/Database/src/Service/Stripe.php
+++ b/module/Database/src/Service/Stripe.php
@@ -25,7 +25,6 @@ use Stripe\Webhook;
 use UnexpectedValueException;
 
 use function intval;
-use function sprintf;
 use function time;
 
 class Stripe
@@ -328,20 +327,6 @@ class Stripe
             if (null === $originalCheckoutSession) {
                 // The original Checkout Session does not exist, the only logical explanation is that the prospective
                 // member is removed.
-                return;
-            }
-
-            // Check if we have previously recovered from the original Checkout Session.
-            $recoveredBy = $this->checkoutSessionMapper->findRecoveredBy($originalCheckoutSession);
-
-            if (null !== $recoveredBy) {
-                // We have previously recovered and this is a new Checkout Session. This should not be possible.
-                $this->logger->error(sprintf(
-                    'Trying to recover Checkout Session % for the second time through %s.',
-                    $originalCheckoutSession->getCheckoutId(),
-                    $session->id,
-                ));
-
                 return;
             }
 


### PR DESCRIPTION
Unfortunately, I missed this in GH-334. However, `recoveredFrom` is many-to-one not one-to-one, so it is possible to recover for a third (or later) time.

![image](https://github.com/GEWIS/gewisdb/assets/4983571/a57ff619-4cca-45cd-a747-09efb376642b)