### PR TITLE
Use meeting date for comparisons on key granting and withdrawal

### DIFF
--- a/module/Database/src/Form/Fieldset/Meeting.php
+++ b/module/Database/src/Form/Fieldset/Meeting.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Form\Fieldset;
 
 use Database\Model\Meeting as MeetingModel;
+use DateTimeInterface;
 use Laminas\Form\Element\Hidden;
 use Laminas\Form\Fieldset;
 
@@ -24,6 +25,11 @@ class Meeting extends Fieldset
             'type' => Hidden::class,
         ]);
 
+        $this->add([
+            'name' => 'date',
+            'type' => Hidden::class,
+        ]);
+
         // TODO: filters
     }
 
@@ -34,5 +40,6 @@ class Meeting extends Fieldset
     {
         $this->get('type')->setValue($meeting->getType()->value);
         $this->get('number')->setValue($meeting->getNumber());
+        $this->get('date')->setValue($meeting->getDate()->format(DateTimeInterface::ATOM));
     }
 }

--- a/module/Database/src/Form/Key/Grant.php
+++ b/module/Database/src/Form/Key/Grant.php
@@ -59,8 +59,8 @@ class Grant extends AbstractDecision implements InputFilterProviderInterface
                     [
                         'name' => Callback::class,
                         'options' => [
-                            'callback' => function ($value) {
-                                return $this->isNotInThePast($value);
+                            'callback' => function ($value, $context) {
+                                return $this->isNotInThePast($value, $context);
                             },
                             'messages' => [
                                 Callback::INVALID_VALUE => $this->translator->translate(
@@ -72,8 +72,8 @@ class Grant extends AbstractDecision implements InputFilterProviderInterface
                     [
                         'name' => Callback::class,
                         'options' => [
-                            'callback' => function ($value) {
-                                return $this->isMaxOneYear($value);
+                            'callback' => function ($value, $context) {
+                                return $this->isMaxOneYear($value, $context);
                             },
                             'messages' => [
                                 Callback::INVALID_VALUE => $this->translator->translate(
@@ -85,8 +85,8 @@ class Grant extends AbstractDecision implements InputFilterProviderInterface
                     [
                         'name' => Callback::class,
                         'options' => [
-                            'callback' => function ($value) {
-                                return $this->isNotTooFar($value);
+                            'callback' => function ($value, $context) {
+                                return $this->isNotTooFar($value, $context);
                             },
                             'messages' => [
                                 Callback::INVALID_VALUE => $this->translator->translate(
@@ -100,10 +100,15 @@ class Grant extends AbstractDecision implements InputFilterProviderInterface
         ];
     }
 
-    private function isNotInThePast(string $value): bool
-    {
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
+     */
+    private function isNotInThePast(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
-            $today = new DateTime('today');
+            $today = new DateTime($context['meeting']['date']);
 
             return (new DateTime($value)) >= $today;
         } catch (Throwable) {
@@ -111,10 +116,15 @@ class Grant extends AbstractDecision implements InputFilterProviderInterface
         }
     }
 
-    private function isMaxOneYear(string $value): bool
-    {
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
+     */
+    private function isMaxOneYear(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
-            $future = (new DateTime('today'))->add(new DateInterval('P1Y'));
+            $future = (new DateTime($context['meeting']['date']))->add(new DateInterval('P1Y'));
 
             return (new DateTime($value)) <= $future;
         } catch (Throwable) {
@@ -122,10 +132,15 @@ class Grant extends AbstractDecision implements InputFilterProviderInterface
         }
     }
 
-    private function isNotTooFar(string $value): bool
-    {
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
+     */
+    private function isNotTooFar(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
-            $today = new DateTime('today');
+            $today = new DateTime($context['meeting']['date']);
 
             if ($today->format('m') >= 7) {
                 $year = (int) $today->format('Y') + 1;

--- a/module/Database/src/Form/Key/Withdraw.php
+++ b/module/Database/src/Form/Key/Withdraw.php
@@ -58,8 +58,8 @@ class Withdraw extends AbstractDecision implements InputFilterProviderInterface
                     [
                         'name' => Callback::class,
                         'options' => [
-                            'callback' => function ($value) {
-                                return $this->isNotInThePast($value);
+                            'callback' => function ($value, $context) {
+                                return $this->isNotInThePast($value, $context);
                             },
                             'messages' => [
                                 Callback::INVALID_VALUE => $this->translator->translate(
@@ -86,10 +86,15 @@ class Withdraw extends AbstractDecision implements InputFilterProviderInterface
         ];
     }
 
-    private function isNotInThePast(string $value): bool
-    {
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
+     */
+    private function isNotInThePast(
+        string $value,
+        array $context = [],
+    ): bool {
         try {
-            $today = new DateTime('today');
+            $today = new DateTime($context['meeting']['date']);
 
             return (new DateTime($value)) >= $today;
         } catch (Throwable) {

--- a/module/Database/view/database/meeting/key/grantform.phtml
+++ b/module/Database/view/database/meeting/key/grantform.phtml
@@ -58,6 +58,7 @@ $fs = $form->get('meeting')
 ?>
 <?= $this->formHidden($fs->get('type')) ?>
 <?= $this->formHidden($fs->get('number')) ?>
+<?= $this->formHidden($fs->get('date')) ?>
 <?= $this->formHidden($form->get('point')) ?>
 <?= $this->formHidden($form->get('decision')) ?>
 

--- a/module/Database/view/database/meeting/key/withdrawform.phtml
+++ b/module/Database/view/database/meeting/key/withdrawform.phtml
@@ -55,6 +55,7 @@ $fsgm = $fsg->get('member');
 ?>
 <?= $this->formHidden($fs->get('type')) ?>
 <?= $this->formHidden($fs->get('number')) ?>
+<?= $this->formHidden($fs->get('date')) ?>
 <?= $this->formHidden($form->get('point')) ?>
 <?= $this->formHidden($form->get('decision')) ?>
 


### PR DESCRIPTION
Instead of `new DateTime('now')`, all comparisons for key granting and withdrawal is based on the date of the meeting `$context['meeting']['date']`. Of course this can be manually edited, however, the `Checker` should already catch this:

https://github.com/GEWIS/gewisdb/blob/5ecdb85361843e86786e66f3f13131b470f0d5e8/module/Checker/src/Service/Checker.php#L328-L335

This fixes GH-282 and fixes GH-335.