### PR TITLE
Fix removal query to find fully expired Checkout Sessions

### DIFF
--- a/module/Database/src/Model/CheckoutSession.php
+++ b/module/Database/src/Model/CheckoutSession.php
@@ -60,6 +60,8 @@ class CheckoutSession
 
     /**
      * Expiration of the checkout session.
+     *
+     * If $state == CheckoutSessionStates::Expired, then this is the last date this checkout session can be recovered.
      */
     #[Column(type: 'datetime')]
     protected DateTime $expiration;


### PR DESCRIPTION
Since fixing the processing of the expiration of a restarted Checkout Session, prospective members were deleted too soon. This was the result of the latest Checkout Session always having an expiration of a day (ONLY IF RESTARTED).

This fixes that by adjusting the query to make sure that if we are dealing with an expired and restarted Checkout Session we always check the `recoveredFrom` (i.e. original) Checkout Session to check whether the limit has passed.

There is no doubt about it being _ugly_, however, this prevents us from having to make at least three separate queries to make this work (and it was a good exercise to see how far the Doctrine QueryBuilder can be pushed).

This fixes GH-338.

---

Want to test the query? Use this parsed variant:

```sql
SELECT
    p0_.lidnr AS lidnr_0,
    p0_.email AS email_1,
    p0_.lastName AS lastname_2,
    p0_.middleName AS middlename_3,
    p0_.initials AS initials_4,
    p0_.firstName AS firstname_5,
    p0_.tueUsername AS tueusername_6,
    p0_.study AS study_7,
    p0_.changedOn AS changedon_8,
    p0_.birth AS birth_9,
    p0_.paid AS paid_10,
    p0_.country AS country_11,
    p0_.street AS street_12,
    p0_.number AS number_13,
    p0_.postalCode AS postalcode_14,
    p0_.city AS city_15,
    p0_.phone AS phone_16 
FROM
    ProspectiveMember p0_ 
    LEFT JOIN
        CheckoutSession c1_ 
        ON (c1_.prospective_member = p0_.lidnr) 
WHERE
    (
        c1_.id = 
        (
            SELECT
                MAX(c2_.id) AS sclr_17 
            FROM
                CheckoutSession c2_ 
            WHERE
                c2_.prospective_member = p0_.lidnr
        )
        AND c1_.state = ? -- THIS IS ALWAYS "FAILED": 4
        AND c1_.expiration < ? 
    )
    OR 
    (
        (
            c1_.id = (
                SELECT (
                    CASE
                        WHEN
                            c3_.recovered_from_id IS NOT NULL 
                        THEN
                            c3_.recovered_from_id 
                        ELSE
                            c3_.id 
                    END
                ) 
                FROM
                    CheckoutSession c3_ 
                WHERE
                    c3_.prospective_member = p0_.lidnr 
                    AND c3_.id = (
                        SELECT
                            MAX(c4_.id) AS sclr_18 
                        FROM
                            CheckoutSession c4_ 
                        WHERE
                            c4_.prospective_member = p0_.lidnr
                    )
                    AND c3_.state = ? -- THIS IS ALWAYS "EXPIRED": 2
             )
        ) 
        AND c1_.state = ? -- THIS IS ALWAYS "EXPIRED": 2
        AND c1_.expiration < ? 
    )
```