### PR TITLE
Add `Reappointment` subdecision for installations in bodies

### DIFF
--- a/module/Database/src/Form/Install.php
+++ b/module/Database/src/Form/Install.php
@@ -18,6 +18,7 @@ class Install extends AbstractDecision
         private readonly Translator $translator,
         MeetingFieldset $meeting,
         InstallationFieldset $install,
+        SubDecisionFieldset $reappointment,
         SubDecisionFieldset $discharge,
         SubDecisionFieldset $foundation,
     ) {
@@ -41,6 +42,17 @@ class Install extends AbstractDecision
                 'count' => 1,
                 'should_create_template' => true,
                 'target_element' => $install,
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'reappointments',
+            'type' => Collection::class,
+            'options' => [
+                'label' => $this->translator->translate('Reappointments'),
+                'count' => 1,
+                'should_create_template' => true,
+                'target_element' => $reappointment,
             ],
         ]);
 

--- a/module/Database/src/Hydrator/Install.php
+++ b/module/Database/src/Hydrator/Install.php
@@ -7,6 +7,7 @@ namespace Database\Hydrator;
 use Database\Model\Decision as DecisionModel;
 use Database\Model\SubDecision\Discharge as DischargeModel;
 use Database\Model\SubDecision\Installation as InstallationModel;
+use Database\Model\SubDecision\Reappointment as ReappointmentModel;
 use InvalidArgumentException;
 
 class Install extends AbstractDecision
@@ -34,8 +35,18 @@ class Install extends AbstractDecision
 
         $num = 1;
 
-        // first add discharges
-        if (isset($data['discharges']) && !empty($data['discharges'])) {
+        // first do reappointments
+        if (!empty($data['reappointments'])) {
+            foreach ($data['reappointments'] as $install) {
+                $reappointment = new ReappointmentModel();
+                $reappointment->setInstallation($install);
+                $reappointment->setNumber($num++);
+                $reappointment->setDecision($decision);
+            }
+        }
+
+        // then add discharges
+        if (!empty($data['discharges'])) {
             foreach ($data['discharges'] as $install) {
                 $discharge = new DischargeModel();
                 $discharge->setInstallation($install);
@@ -44,8 +55,8 @@ class Install extends AbstractDecision
             }
         }
 
-        // then add installations
-        if (isset($data['installations']) && !empty($data['installations'])) {
+        // finally add installations
+        if (!empty($data['installations'])) {
             foreach ($data['installations'] as $install) {
                 $installation = new InstallationModel();
                 $installation->setNumber($num++);

--- a/module/Database/src/Model/SubDecision.php
+++ b/module/Database/src/Model/SubDecision.php
@@ -18,6 +18,7 @@ use Database\Model\SubDecision\Installation;
 use Database\Model\SubDecision\Key\Granting as KeyGranting;
 use Database\Model\SubDecision\Key\Withdrawal as KeyWithdrawal;
 use Database\Model\SubDecision\Other;
+use Database\Model\SubDecision\Reappointment;
 use Database\Model\SubDecision\Reckoning;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
@@ -42,6 +43,7 @@ use Doctrine\ORM\Mapping\ManyToOne;
         'foundation' => Foundation::class,
         'abrogation' => Abrogation::class,
         'installation' => Installation::class,
+        'reappointment' => Reappointment::class,
         'discharge' => Discharge::class,
         'budget' => Budget::class,
         'reckoning' => Reckoning::class,

--- a/module/Database/src/Model/SubDecision/Installation.php
+++ b/module/Database/src/Model/SubDecision/Installation.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Database\Model\SubDecision;
 
 use Database\Model\Member;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 
 /**
@@ -37,6 +40,17 @@ class Installation extends FoundationReference
     protected Member $member;
 
     /**
+     * Reappointment subdecisions if this installation was prolonged (can be done multiple times).
+     *
+     * @var Collection<array-key, Reappointment>
+     */
+    #[OneToMany(
+        targetEntity: Reappointment::class,
+        mappedBy: 'installation',
+    )]
+    protected Collection $reappointments;
+
+    /**
      * Discharges.
      */
     #[OneToOne(
@@ -44,6 +58,11 @@ class Installation extends FoundationReference
         mappedBy: 'installation',
     )]
     protected ?Discharge $discharge = null;
+
+    public function __construct()
+    {
+        $this->reappointments = new ArrayCollection();
+    }
 
     /**
      * Get the function.
@@ -78,6 +97,24 @@ class Installation extends FoundationReference
     }
 
     /**
+     * Get the reappointments, if they exist.
+     *
+     * @return Collection<array-key, Reappointment>
+     */
+    public function getReappointments(): Collection
+    {
+        return $this->reappointments;
+    }
+
+    /**
+     * Get the discharge, if it exists
+     */
+    public function getDischarge(): ?Discharge
+    {
+        return $this->discharge;
+    }
+
+    /**
      * Get the content.
      *
      * Fixes Bor's greatest frustration
@@ -89,13 +126,5 @@ class Installation extends FoundationReference
         $text .= ' van ' . $this->getFoundation()->getAbbr() . '.';
 
         return $text;
-    }
-
-    /**
-     * Get the discharge, if it exists
-     */
-    public function getDischarge(): ?Discharge
-    {
-        return $this->discharge;
     }
 }

--- a/module/Database/src/Model/SubDecision/Reappointment.php
+++ b/module/Database/src/Model/SubDecision/Reappointment.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Model\SubDecision;
+
+use Database\Model\SubDecision;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+use function sprintf;
+
+/**
+ * Reappointment of a previous installation.
+ *
+ * To prevent issues with recursive self-references, multiple reappointments can point to the same installation.
+ */
+#[Entity]
+class Reappointment extends SubDecision
+{
+    /**
+     * Reference to the installation of a member.
+     */
+    #[ManyToOne(
+        targetEntity: Installation::class,
+        inversedBy: 'reappointments',
+    )]
+    #[JoinColumn(
+        name: 'r_meeting_type',
+        referencedColumnName: 'meeting_type',
+    )]
+    #[JoinColumn(
+        name: 'r_meeting_number',
+        referencedColumnName: 'meeting_number',
+    )]
+    #[JoinColumn(
+        name: 'r_decision_point',
+        referencedColumnName: 'decision_point',
+    )]
+    #[JoinColumn(
+        name: 'r_decision_number',
+        referencedColumnName: 'decision_number',
+    )]
+    #[JoinColumn(
+        name: 'r_number',
+        referencedColumnName: 'number',
+    )]
+    protected Installation $installation;
+
+    /**
+     * Get the original installation for this reappointment.
+     */
+    public function getInstallation(): Installation
+    {
+        return $this->installation;
+    }
+
+    /**
+     * Set the original installation for this reappointment.
+     */
+    public function setInstallation(Installation $installation): void
+    {
+        $this->installation = $installation;
+    }
+
+    /**
+     * Get the textual content of this subdecision.
+     */
+    public function getContent(): string
+    {
+        $installation = $this->getInstallation();
+        $memberFullName = $installation->getMember()->getFullName();
+
+        return sprintf(
+            '%s wordt herbenoemd als %s van %s.',
+            $memberFullName,
+            $installation->getFunction(),
+            $installation->getFoundation()->getAbbr(),
+        );
+    }
+}

--- a/module/Database/src/Module.php
+++ b/module/Database/src/Module.php
@@ -85,9 +85,10 @@ use Database\Model\Decision as DecisionModel;
 use Database\Model\Meeting as MeetingModel;
 use Database\Model\Member as MemberModel;
 use Database\Model\SubDecision\Board\Installation as BoardInstallationModel;
+use Database\Model\SubDecision\Discharge as DischargeModel;
 use Database\Model\SubDecision\Foundation as FoundationModel;
-use Database\Model\SubDecision\Installation as InstallationModel;
 use Database\Model\SubDecision\Key\Granting as KeyGrantingModel;
+use Database\Model\SubDecision\Reappointment as ReappointmentModel;
 use Database\Service\Api as ApiService;
 use Database\Service\Factory\ApiFactory as ApiServiceFactory;
 use Database\Service\Factory\InstallationFunctionFactory as InstallationFunctionServiceFactory;
@@ -245,6 +246,7 @@ class Module
                         $container->get(MvcTranslator::class),
                         $container->get(MeetingFieldset::class),
                         $container->get(InstallationFieldset::class),
+                        $container->get('database_form_fieldset_subdecision_reappointment'),
                         $container->get('database_form_fieldset_subdecision_discharge'),
                         $container->get('database_form_fieldset_subdecision_foundation'),
                     );
@@ -358,10 +360,17 @@ class Module
 
                     return $fieldset;
                 },
+                'database_form_fieldset_subdecision_reappointment' => static function (ContainerInterface $container) {
+                    $fieldset = new SubDecisionFieldset();
+                    $fieldset->setHydrator($container->get('database_hydrator_subdecision'));
+                    $fieldset->setObject(new ReappointmentModel());
+
+                    return $fieldset;
+                },
                 'database_form_fieldset_subdecision_discharge' => static function (ContainerInterface $container) {
                     $fieldset = new SubDecisionFieldset();
                     $fieldset->setHydrator($container->get('database_hydrator_subdecision'));
-                    $fieldset->setObject(new InstallationModel());
+                    $fieldset->setObject(new DischargeModel());
 
                     return $fieldset;
                 },

--- a/module/Database/view/database/meeting/installform.phtml
+++ b/module/Database/view/database/meeting/installform.phtml
@@ -90,11 +90,14 @@ $(document).ready(function () {
                             + '<span class="glyphicon glyphicon-remove"></span> <?= $this->translate('Discharge') ?></button></td>';
 
                         if ('Lid' === install.function) {
+                            toAdd += '<td><button type="button" class="btn btn-warning btn-xs reappoint">'
+                                + '<span class="glyphicon glyphicon-repeat"></span> <?= $this->translate('Reappoint') ?></button></td>';
                             toAdd += '<td><button type="button" class="btn btn-warning btn-xs inactive">'
                                 + '<span class="glyphicon glyphicon-pencil"></span> <?= $this->translate('Make Inactive') ?></button></td>';
                             toAdd += '<td><button type="button" class="btn btn-warning btn-xs functionchange">'
                                 + '<span class="glyphicon glyphicon-plus"></span> <?= $this->translate('Give Function') ?></button></td>';
                         } else {
+                            toAdd += '<td></td>';
                             toAdd += '<td></td>';
                             toAdd += '<td></td>';
                         }
@@ -105,7 +108,9 @@ $(document).ready(function () {
                 });
                 $('#members-install').html(content);
                 $('#members-result').html(content2);
-                $('#install-changes').html('');
+                $('#reappointment-changes').html('');
+                $('#discharge-changes').html('');
+                $('#installation-changes').html('');
 
                 // set foundation of organ
                 $('#install-foundation-meeting-type').val(data.json.meeting_type);
@@ -120,6 +125,55 @@ $(document).ready(function () {
                 $('#install-organ').prop('disabled', true);
 
                 // enable member change events
+                $('button.reappoint').click(function(e)
+                {
+                    var element = $(e.target).parent().parent();
+                    var name = element.find('.name').html();
+                    $('#install-modal-reappoint div.modal-body span.name').html(name);
+
+                    // Add all special functions to the modal.
+                    var reappointFuctionForm = $('#install-modal-reappoint div.modal-body #reappoint-functions-form');
+                    var functions = 1;
+                    $($('#members-result tr[data-lidnr="' + element.data('lidnr') + '"]').get()).each(function (i) {
+                        var installation = $(this);
+                        var installedFunction = installation.find('.function').text();
+
+                        // We do not need to list the normal membership function, only the extra ones.
+                        if ('Lid' !== installedFunction) {
+                            var meeting_type = installation.data('meeting-type');
+                            var meeting_number = installation.data('meeting-number');
+                            var decision_point = installation.data('decision-point');
+                            var decision_number = installation.data('decision-number');
+                            var subdecision_number = installation.data('subdecision-number');
+
+                            reappointFuctionForm.append(`
+                                <input type="checkbox" id="reappoint-function-${functions}"
+                                    data-function="${installedFunction}"
+                                    data-meeting-type="${meeting_type}"
+                                    data-meeting-number="${meeting_number}"
+                                    data-decision-point="${decision_point}"
+                                    data-decision-number="${decision_number}"
+                                    data-subdecision-number="${subdecision_number}"/>
+                                <label for="reappoint-function-${functions}">
+                                    ${installedFunction} (${meeting_type} ${meeting_number}.${decision_point}.${decision_number})
+                                </label>
+                                <br>
+                            `);
+
+                            functions++;
+                        }
+                    });
+
+                    var modal = $('#install-modal-reappoint');
+                    modal.data('meeting-type', element.data('meeting-type'));
+                    modal.data('meeting-number', element.data('meeting-number'));
+                    modal.data('decision-point', element.data('decision-point'));
+                    modal.data('decision-number', element.data('decision-number'));
+                    modal.data('subdecision-number', element.data('subdecision-number'));
+                    modal.data('lidnr', element.data('lidnr'));
+                    modal.modal();
+                });
+
                 $('button.discharge').click(function(e)
                 {
                     var element = $(e.target).parent().parent();
@@ -230,7 +284,7 @@ $(document).ready(function () {
         template = template.replace(/__function__/g, func);
         template = template.replace(/__lidnr__/g, lidnr);
         template = template.replace(/__name__/g, name);
-        $('#install-changes').append($(template));
+        $('#installation-changes').append($(template));
 
         // add to 'result'
         var toAdd = '<tr data-lidnr="' + lidnr + '">'
@@ -290,6 +344,90 @@ $(document).ready(function () {
         $('#install-modal-function').modal('hide');
     });
 
+    function createReappointment(element, name, func) {
+        var meeting_type = element.data('meeting-type');
+        var meeting_number = element.data('meeting-number');
+        var decision_point = element.data('decision-point');
+        var decision_number = element.data('decision-number');
+        var subdecision_number = element.data('subdecision-number');
+
+        var template = $('#reappointment-template').data('template');
+        template = template.replace(/__index__/g, count++);
+        template = template.replace(/__function__/g, func);
+        template = template.replace(/__name__/g, name);
+
+        template = template.replace(/__meeting_type__/g, meeting_type);
+        template = template.replace(/__meeting_number__/g, meeting_number);
+        template = template.replace(/__decision_point__/g, decision_point);
+        template = template.replace(/__decision_number__/g, decision_number);
+        template = template.replace(/__number__/g, subdecision_number);
+        $('#reappointment-changes').append($(template));
+    }
+
+    // reappointment modal stuff
+    $('#reappoint-modal-yes').click(function(e) {
+        var modal = $('#install-modal-reappoint');
+        var name = $('#install-modal-reappoint div.modal-body span.name').text();
+
+        // Reappoint the 'Lid' function (i.e. normal membership).
+        createReappointment(modal, name, 'Lid');
+
+        // Create the reappointments for all checked functions of member.
+        $($('#reappoint-functions-form input:checked').get()).each(function () {
+            var installation = $(this);
+            var func = installation.data('function');
+
+            if ('Lid' !== func) {
+                createReappointment(installation, name, func);
+            }
+        });
+
+        // Create discharges for all unchecked functions of member.
+        $($('#reappoint-functions-form input:not(:checked)').get()).each(function () {
+            var installation = $(this);
+            var meeting_type = installation.data('meeting-type');
+            var meeting_number = installation.data('meeting-number');
+            var decision_point = installation.data('decision-point');
+            var decision_number = installation.data('decision-number');
+            var subdecision_number = installation.data('subdecision-number');
+
+            var select = '.dec-' + meeting_type + '-' + meeting_number
+                + '-' + decision_point + '-' + decision_number
+                + '-' + subdecision_number;
+
+            dischargeFunction($('#members-result').find(select), name)
+        });
+
+        // dismiss the dialog
+        modal.modal('hide');
+    });
+
+    function dischargeFunction(installationElement, name) {
+        var meeting_type = installationElement.data('meeting-type');
+        var meeting_number = installationElement.data('meeting-number');
+        var decision_point = installationElement.data('decision-point');
+        var decision_number = installationElement.data('decision-number');
+        var subdecision_number = installationElement.data('subdecision-number');
+
+        // create the discharge, and add to all changes
+        var template = $('#discharge-template').data('template');
+        template = template.replace(/__index__/g, count++);
+        template = template.replace(/__function__/g, installationElement.find('.function').html());
+        template = template.replace(/__name__/g, name);
+
+        template = template.replace(/__meeting_type__/g, meeting_type);
+        template = template.replace(/__meeting_number__/g, meeting_number);
+        template = template.replace(/__decision_point__/g, decision_point);
+        template = template.replace(/__decision_number__/g, decision_number);
+        template = template.replace(/__number__/g, subdecision_number);
+        $('#discharge-changes').append($(template));
+
+        var select = '.dec-' + meeting_type + '-' + meeting_number
+            + '-' + decision_point + '-' + decision_number
+            + '-' + subdecision_number;
+        $('#members-result').find(select).remove();
+    }
+
     // discharge modal stuff
     $('#discharge-modal-yes').click(function(e)
     {
@@ -297,34 +435,10 @@ $(document).ready(function () {
         var func = $('#install-modal-discharge div.modal-body span.function').text();
         var name = $('#install-modal-discharge div.modal-body span.name').text();
 
-        // Ensure that is a `Lid` is discharged, all functions are removed too.
+        // Ensure that if a `Lid` is discharged, all functions are removed too.
         if ('Lid' === func) {
-            $($('#members-result tr[data-lidnr="' + modal.data('lidnr') + '"]').get().reverse()).each(function (i) {
-                var installation = $(this);
-
-                var meeting_type = installation.data('meeting-type');
-                var meeting_number = installation.data('meeting-number');
-                var decision_point = installation.data('decision-point');
-                var decision_number = installation.data('decision-number');
-                var subdecision_number = installation.data('subdecision-number');
-
-                // create the discharge, and add to all changes
-                var template = $('#discharge-template').data('template');
-                template = template.replace(/__index__/g, count++);
-                template = template.replace(/__function__/g, installation.find('.function').html());
-                template = template.replace(/__name__/g, name);
-
-                template = template.replace(/__meeting_type__/g, meeting_type);
-                template = template.replace(/__meeting_number__/g, meeting_number);
-                template = template.replace(/__decision_point__/g, decision_point);
-                template = template.replace(/__decision_number__/g, decision_number);
-                template = template.replace(/__number__/g, subdecision_number);
-                $('#install-changes').append($(template));
-
-                var select = '.dec-' + meeting_type + '-' + meeting_number
-                    + '-' + decision_point + '-' + decision_number
-                    + '-' + subdecision_number;
-                $('#members-result').find(select).remove();
+            $($('#members-result tr[data-lidnr="' + modal.data('lidnr') + '"]').get().reverse()).each(function () {
+                dischargeFunction($(this), name);
             });
         } else {
             var meeting_type = modal.data('meeting-type');
@@ -333,23 +447,11 @@ $(document).ready(function () {
             var decision_number = modal.data('decision-number');
             var subdecision_number = modal.data('subdecision-number');
 
-            // create the discharge, and add to all changes
-            var template = $('#discharge-template').data('template');
-            template = template.replace(/__index__/g, count++);
-            template = template.replace(/__function__/g, func);
-            template = template.replace(/__name__/g, name);
-
-            template = template.replace(/__meeting_type__/g, meeting_type);
-            template = template.replace(/__meeting_number__/g, meeting_number);
-            template = template.replace(/__decision_point__/g, decision_point);
-            template = template.replace(/__decision_number__/g, decision_number);
-            template = template.replace(/__number__/g, subdecision_number);
-            $('#install-changes').append($(template));
-
             var select = '.dec-' + meeting_type + '-' + meeting_number
                 + '-' + decision_point + '-' + decision_number
                 + '-' + subdecision_number;
-            $('#members-result').find(select).remove();
+
+            dischargeFunction($('#members-result').find(select), name)
         }
 
         // dismiss the dialog
@@ -363,32 +465,8 @@ $(document).ready(function () {
         var lidnr = modal.data('lidnr');
         var name = $('#install-modal-inactive div.modal-body span.name').text();
 
-        $($('#members-result tr[data-lidnr="' + lidnr + '"]').get().reverse()).each(function (i) {
-            var installation = $(this);
-
-            var meeting_type = installation.data('meeting-type');
-            var meeting_number = installation.data('meeting-number');
-            var decision_point = installation.data('decision-point');
-            var decision_number = installation.data('decision-number');
-            var subdecision_number = installation.data('subdecision-number');
-
-            // create the discharge, and add to all changes
-            var template = $('#discharge-template').data('template');
-            template = template.replace(/__index__/g, count++);
-            template = template.replace(/__function__/g, installation.find('.function').html());
-            template = template.replace(/__name__/g, name);
-
-            template = template.replace(/__meeting_type__/g, meeting_type);
-            template = template.replace(/__meeting_number__/g, meeting_number);
-            template = template.replace(/__decision_point__/g, decision_point);
-            template = template.replace(/__decision_number__/g, decision_number);
-            template = template.replace(/__number__/g, subdecision_number);
-            $('#install-changes').append($(template));
-
-            var select = '.dec-' + meeting_type + '-' + meeting_number
-                + '-' + decision_point + '-' + decision_number
-                + '-' + subdecision_number;
-            $('#members-result').find(select).remove();
+        $($('#members-result tr[data-lidnr="' + lidnr + '"]').get().reverse()).each(function () {
+            dischargeFunction($(this), name)
         });
 
         createInstallation('Inactief Lid', lidnr, name);
@@ -446,7 +524,7 @@ $fs->get('number')->setAttribute('id', 'install-foundation-subdecision-number');
 
 <div id="install-members-hide" style="display: none;">
 <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-4">
         <h2><?= $this->translate('Current Members') ?></h2>
         <table class="table table-striped">
             <thead>
@@ -459,7 +537,7 @@ $fs->get('number')->setAttribute('id', 'install-foundation-subdecision-number');
             </tbody>
         </table>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-8">
         <h2><?= $this->translate('Result') ?></h2>
         <table class="table table-striped">
             <thead>
@@ -467,6 +545,7 @@ $fs->get('number')->setAttribute('id', 'install-foundation-subdecision-number');
                     <th><?= $this->translate('Name') ?></th>
                     <th><?= $this->translate('Function') ?></th>
                     <th><?= $this->translate('Discharge') ?></th>
+                    <th><?= $this->translate('Reappoint') ?></th>
                     <th><?= $this->translate('Make Inactive') ?></th>
                     <th><?= $this->translate('Give Function') ?></th>
                 </tr>
@@ -479,6 +558,45 @@ $fs->get('number')->setAttribute('id', 'install-foundation-subdecision-number');
 <div class="row">
     <div class="col-md-6">
         <h2><?= $this->translate('Mutations') ?></h2>
+<?php
+// reappointment element template
+$element = $form->get('reappointments');
+$fs = $element->getTemplateElement();
+// render template element
+ob_start();
+?>
+<div class="organ-reappointment">
+    __name__ wordt herbenoemd als __function__.
+    <?php
+    $el = $fs->get('meeting_type');
+    $el->setValue('__meeting_type__');
+    ?>
+    <?= $this->formHidden($el) ?>
+    <?php
+    $el = $fs->get('meeting_number');
+    $el->setValue('__meeting_number__');
+    ?>
+    <?= $this->formHidden($el) ?>
+    <?php
+    $el = $fs->get('decision_point');
+    $el->setValue('__decision_point__');
+    ?>
+    <?= $this->formHidden($el) ?>
+    <?php
+    $el = $fs->get('decision_number');
+    $el->setValue('__decision_number__');
+    ?>
+    <?= $this->formHidden($el) ?>
+    <?php
+    $el = $fs->get('number');
+    $el->setValue('__number__');
+    ?>
+    <?= $this->formHidden($el) ?>
+</div>
+<?php
+$tpl = trim(ob_get_clean());
+?>
+<span data-template="<?= $this->escapeHtmlAttr($tpl) ?>" id="reappointment-template"></span>
 <?php
 // installation element template
 $element = $form->get('installations');
@@ -545,7 +663,11 @@ ob_start();
 $tpl = trim(ob_get_clean());
 ?>
 <span data-template="<?= $this->escapeHtmlAttr($tpl) ?>" id="discharge-template"></span>
-        <div id="install-changes">
+        <div id="reappointment-changes">
+        </div>
+        <div id="discharge-changes">
+        </div>
+        <div id="installation-changes">
         </div>
     </div>
     <div class="col-md-6 form-inline">
@@ -601,6 +723,30 @@ $submit->setAttribute('disabled', 'disabled');
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal"><?= $this->translate('No') ?></button>
                 <button type="button" class="btn btn-primary" id="discharge-modal-yes"><?= $this->translate('Yes') ?></button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="install-modal-reappoint" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="install-model-reappoint-label" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="install-model-reappoint-label"><?= $this->translate('Reappoint Member') ?></h4>
+            </div>
+            <div class="modal-body">
+                <?=
+                sprintf(
+                    $this->translate('Do you want to reappoint %s? Check functions you also want reappointed, functions that are not selected will result in a discharge of that function.'),
+                    '<span class="name"></span>',
+                )
+                ?>
+                <form id="reappoint-functions-form"></form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal"><?= $this->translate('No') ?></button>
+                <button type="button" class="btn btn-primary" id="reappoint-modal-yes"><?= $this->translate('Yes') ?></button>
             </div>
         </div>
     </div>

--- a/module/Database/view/database/meeting/installform.phtml
+++ b/module/Database/view/database/meeting/installform.phtml
@@ -133,6 +133,8 @@ $(document).ready(function () {
 
                     // Add all special functions to the modal.
                     var reappointFuctionForm = $('#install-modal-reappoint div.modal-body #reappoint-functions-form');
+                    reappointFuctionForm.empty(); // clear contents before appending functions
+
                     var functions = 1;
                     $($('#members-result tr[data-lidnr="' + element.data('lidnr') + '"]').get()).each(function (i) {
                         var installation = $(this);
@@ -296,6 +298,7 @@ $(document).ready(function () {
             toAdd += '<td><button type="button" class="btn btn-warning btn-xs functionchange">'
                 + '<span class="glyphicon glyphicon-plus"></span> <?= $this->translate('Give Function') ?></button></td>';
         } else {
+            toAdd += '<td></td>';
             toAdd += '<td></td>';
         }
         toAdd += '</tr>';

--- a/module/Report/src/Model/SubDecision.php
+++ b/module/Report/src/Model/SubDecision.php
@@ -26,6 +26,7 @@ use Report\Model\SubDecision\Installation;
 use Report\Model\SubDecision\Key\Granting as KeyGranting;
 use Report\Model\SubDecision\Key\Withdrawal as KeyWithdrawal;
 use Report\Model\SubDecision\Other;
+use Report\Model\SubDecision\Reappointment;
 use Report\Model\SubDecision\Reckoning;
 
 /**
@@ -42,6 +43,7 @@ use Report\Model\SubDecision\Reckoning;
         'foundation' => Foundation::class,
         'abrogation' => Abrogation::class,
         'installation' => Installation::class,
+        'reappointment' => Reappointment::class,
         'discharge' => Discharge::class,
         'budget' => Budget::class,
         'reckoning' => Reckoning::class,

--- a/module/Report/src/Model/SubDecision/Installation.php
+++ b/module/Report/src/Model/SubDecision/Installation.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Report\Model\SubDecision;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Report\Model\Member;
 use Report\Model\OrganMember;
@@ -38,6 +41,17 @@ class Installation extends FoundationReference
     protected Member $member;
 
     /**
+     * Reappointment subdecisions if this installation was prolonged (can be done multiple times).
+     *
+     * @var Collection<array-key, Reappointment>
+     */
+    #[OneToMany(
+        targetEntity: Reappointment::class,
+        mappedBy: 'installation',
+    )]
+    protected Collection $reappointments;
+
+    /**
      * Discharges.
      */
     #[OneToOne(
@@ -54,6 +68,11 @@ class Installation extends FoundationReference
         mappedBy: 'installation',
     )]
     protected OrganMember $organMember;
+
+    public function __construct()
+    {
+        $this->reappointments = new ArrayCollection();
+    }
 
     /**
      * Get the function.
@@ -85,6 +104,28 @@ class Installation extends FoundationReference
     public function setMember(Member $member): void
     {
         $this->member = $member;
+    }
+
+    /**
+     * Get the reappointments, if they exist.
+     *
+     * @return Collection<array-key, Reappointment>
+     */
+    public function getReappointments(): Collection
+    {
+        return $this->reappointments;
+    }
+
+    /**
+     * Removes the reappointments, if they exist.
+     */
+    public function removeReappointment(Reappointment $reappointment): void
+    {
+        if (!$this->reappointments->contains($reappointment)) {
+            return;
+        }
+
+        $this->reappointments->removeElement($reappointment);
     }
 
     /**

--- a/module/Report/src/Model/SubDecision/Reappointment.php
+++ b/module/Report/src/Model/SubDecision/Reappointment.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Report\Model\SubDecision;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Report\Model\SubDecision;
+
+/**
+ * Reappointment of a previous installation.
+ *
+ * To prevent issues with recursive self-references, multiple reappointments can point to the same installation.
+ */
+#[Entity]
+class Reappointment extends SubDecision
+{
+    /**
+     * Reference to the installation of a member.
+     */
+    #[ManyToOne(
+        targetEntity: Installation::class,
+        inversedBy: 'reappointments',
+    )]
+    #[JoinColumn(
+        name: 'r_meeting_type',
+        referencedColumnName: 'meeting_type',
+    )]
+    #[JoinColumn(
+        name: 'r_meeting_number',
+        referencedColumnName: 'meeting_number',
+    )]
+    #[JoinColumn(
+        name: 'r_decision_point',
+        referencedColumnName: 'decision_point',
+    )]
+    #[JoinColumn(
+        name: 'r_decision_number',
+        referencedColumnName: 'decision_number',
+    )]
+    #[JoinColumn(
+        name: 'r_number',
+        referencedColumnName: 'number',
+    )]
+    protected Installation $installation;
+
+    /**
+     * Get the original installation for this reappointment.
+     */
+    public function getInstallation(): Installation
+    {
+        return $this->installation;
+    }
+
+    /**
+     * Set the installation.
+     */
+    public function setInstallation(Installation $installation): void
+    {
+        $this->installation = $installation;
+    }
+}

--- a/module/Report/src/Service/Meeting.php
+++ b/module/Report/src/Service/Meeting.php
@@ -205,8 +205,11 @@ class Meeting
             // installation
             $reportSubDecision->setFunction($subdecision->getFunction());
             $reportSubDecision->setMember($this->findMember($subdecision->getMember()));
-        } elseif ($subdecision instanceof DatabaseSubDecisionModel\Discharge) {
-            // discharge
+        } elseif (
+            $subdecision instanceof DatabaseSubDecisionModel\Reappointment
+            || $subdecision instanceof DatabaseSubDecisionModel\Discharge
+        ) {
+            // reappointment and discharge
             $ref = $subdecision->getInstallation();
             $installation = $subdecRepo->find([
                 'meeting_type' => $ref->getDecision()->getMeeting()->getType(),
@@ -326,6 +329,11 @@ class Meeting
             case $subDecision instanceof ReportSubDecisionModel\Destroy:
                 throw new Exception('Deletion of destroy decisions not implemented');
 
+            case $subDecision instanceof ReportSubDecisionModel\Reappointment:
+                $installation = $subDecision->getInstallation();
+                $installation->removeReappointment($subDecision);
+
+                break;
             case $subDecision instanceof ReportSubDecisionModel\Discharge:
                 $installation = $subDecision->getInstallation();
                 $installation->clearDischarge();

--- a/psalm/psalm-baseline.xml
+++ b/psalm/psalm-baseline.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
+  <file src="module/Database/src/Service/Meeting.php">
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$decision[$subDecisionType]</code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
   <file src="module/Checker/src/Command/CheckAuthenticationKeysCommand.php">
     <NonInvariantDocblockPropertyType occurrences="2">
       <code>$defaultDescription</code>


### PR DESCRIPTION
This adds a new type of organ mutation, a reappointment. This mutation can be used to "prolong" the membership of a member in an organ. The subdecision refers to the original installation, just like a discharge.

While a self-reference would have been nice (for consecutive reappointments), it introduces a lot of compexity due to the added recursion. As such, `Reappointment`s have a many-to-one relationship with `Installation`s.

`Reappointment`s are processed before `Discharge`s and `Installation`s.

In the Organ Mutations UI, only the `Lid` function can be directly reappointed. All other functions can be reappointed by checking the relevant functions in the model. This means that if a function is NOT checked it will not be reappointed, this means that a discharge for this particular function is created.

Some of the JavaScript discharge functionality has been moved into a separate function to reduce code duplication. On top of that, the reappointments, discharges, and installations are now also sorted as such in the UI.

**Before reappointment:**
![image](https://github.com/GEWIS/gewisdb/assets/4983571/fbca3122-7588-4407-b3d4-98a690f02dd0)

**Reappointment modal:**
![image](https://github.com/GEWIS/gewisdb/assets/4983571/4345e71d-4167-4782-bcf0-3c58c2fd0496)

**Reappointment of membership and one additional function:**
![image](https://github.com/GEWIS/gewisdb/assets/4983571/400222c9-4194-44a0-9184-a700ffffbaa6)

**Resulting decision:**
![image](https://github.com/GEWIS/gewisdb/assets/4983571/767dca11-5271-4451-ba0a-bb947f802249)

This closes GH-346 and closes ABC-2309-556 (pending IR changes).