### PR TITLE
Mark API token as sensitive to prevent it from appearing in logs

### DIFF
--- a/module/User/src/Adapter/ApiPrincipalAdapter.php
+++ b/module/User/src/Adapter/ApiPrincipalAdapter.php
@@ -6,6 +6,7 @@ namespace User\Adapter;
 
 use Laminas\Authentication\Adapter\AdapterInterface;
 use Laminas\Authentication\Result;
+use SensitiveParameter;
 use User\Mapper\ApiPrincipalMapper;
 
 class ApiPrincipalAdapter implements AdapterInterface
@@ -36,8 +37,10 @@ class ApiPrincipalAdapter implements AdapterInterface
     /**
      * Sets the credentials used to authenticate.
      */
-    public function setCredentials(string $token): void
-    {
+    public function setCredentials(
+        #[SensitiveParameter]
+        string $token,
+    ): void {
         $this->token = $token;
     }
 

--- a/module/User/src/Mapper/ApiPrincipalMapper.php
+++ b/module/User/src/Mapper/ApiPrincipalMapper.php
@@ -6,6 +6,7 @@ namespace User\Mapper;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
+use SensitiveParameter;
 use User\Model\ApiPrincipal as ApiPrincipalModel;
 
 use function count;
@@ -29,8 +30,10 @@ class ApiPrincipalMapper
         return $this->getRepository()->find($id);
     }
 
-    public function findByToken(string $token): ?ApiPrincipalModel
-    {
+    public function findByToken(
+        #[SensitiveParameter]
+        string $token,
+    ): ?ApiPrincipalModel {
         /** @var ApiPrincipalModel[] $results */
         $results = $this->getRepository()->findBy(['token' => $token], limit: 1);
 


### PR DESCRIPTION
This fixes GH-348 and prevents the tokens from appearing in the logs.