### PR TITLE
Move any `Member` association to `SubDecision` itself

### DIFF
--- a/module/Checker/src/Model/Error/KeyGrantedInThePast.php
+++ b/module/Checker/src/Model/Error/KeyGrantedInThePast.php
@@ -36,7 +36,7 @@ class KeyGrantedInThePast extends Error
     {
         return sprintf(
             'Key code granted to %s has an expiration of %s, this is before %s.',
-            $this->getGranting()->getGrantee()->getFullName(),
+            $this->getGranting()->getMember()->getFullName(),
             $this->getGranting()->getUntil()->format('Y-m-d'),
             $this->getMeeting()->getDate()->format('Y-m-d'),
         );

--- a/module/Checker/src/Model/Error/KeyGrantedLongerThanOneYear.php
+++ b/module/Checker/src/Model/Error/KeyGrantedLongerThanOneYear.php
@@ -36,7 +36,7 @@ class KeyGrantedLongerThanOneYear extends Error
     {
         return sprintf(
             'Key code granted to %s has an expiration of %s, this is longer than the 1 year.',
-            $this->getGranting()->getGrantee()->getFullName(),
+            $this->getGranting()->getMember()->getFullName(),
             $this->getGranting()->getUntil()->format('Y-m-d'),
         );
     }

--- a/module/Checker/src/Model/Error/KeyGrantedPastBoundary.php
+++ b/module/Checker/src/Model/Error/KeyGrantedPastBoundary.php
@@ -36,7 +36,7 @@ class KeyGrantedPastBoundary extends Error
     {
         return sprintf(
             'Key code granted to %s has an expiration of %s, this is after September 1st of the next association year.',
-            $this->getGranting()->getGrantee()->getFullName(),
+            $this->getGranting()->getMember()->getFullName(),
             $this->getGranting()->getUntil()->format('Y-m-d'),
         );
     }

--- a/module/Checker/src/Model/Error/KeyWithdrawnPastOriginalGranting.php
+++ b/module/Checker/src/Model/Error/KeyWithdrawnPastOriginalGranting.php
@@ -36,7 +36,7 @@ class KeyWithdrawnPastOriginalGranting extends Error
     {
         return sprintf(
             'Key code of %s withdrawn per %s, this is after the original expiration %s.',
-            $this->getWithdrawal()->getGranting()->getGrantee()->getFullName(),
+            $this->getWithdrawal()->getGranting()->getMember()->getFullName(),
             $this->getWithdrawal()->getWithdrawnOn()->format('Y-m-d'),
             $this->getWithdrawal()->getGranting()->getUntil()->format('Y-m-d'),
         );

--- a/module/Database/src/Hydrator/Budget.php
+++ b/module/Database/src/Hydrator/Budget.php
@@ -39,7 +39,7 @@ class Budget extends AbstractDecision
         $subdecision->setDate($date);
 
         $subdecision->setName($data['name']);
-        $subdecision->setAuthor($data['author']);
+        $subdecision->setMember($data['author']);
         $subdecision->setVersion($data['version']);
         $subdecision->setApproval(boolval($data['approve']));
         $subdecision->setChanges(boolval($data['changes']));

--- a/module/Database/src/Hydrator/Key/Grant.php
+++ b/module/Database/src/Hydrator/Key/Grant.php
@@ -33,7 +33,7 @@ class Grant extends AbstractDecision
         $install = new KeyGranting();
 
         $install->setNumber(1);
-        $install->setGrantee($data['grantee']);
+        $install->setMember($data['grantee']);
         $install->setUntil(new DateTime($data['until']));
 
         $install->setDecision($decision);

--- a/module/Database/src/Mapper/Meeting.php
+++ b/module/Database/src/Mapper/Meeting.php
@@ -311,7 +311,7 @@ class Meeting
 
         $qb->select('g, m')
             ->from(KeyGrantingModel::class, 'g')
-            ->join('g.grantee', 'm')
+            ->join('g.member', 'm')
             ->where('g.until >= :now');
 
         // remove withdrawals

--- a/module/Database/src/Mapper/Member.php
+++ b/module/Database/src/Mapper/Member.php
@@ -249,7 +249,7 @@ class Member
 
         $qb->select('b')
             ->from(BudgetModel::class, 'b')
-            ->where('b.author = :member');
+            ->where('b.member = :member');
         $qb->setParameter('member', $member);
 
         $results = $qb->getQuery()->getResult();
@@ -262,7 +262,7 @@ class Member
 
         $qb->select('b')
             ->from(ReckoningModel::class, 'b')
-            ->where('b.author = :member');
+            ->where('b.member = :member');
         $qb->setParameter('member', $member);
 
         $results = $qb->getQuery()->getResult();

--- a/module/Database/src/Model/SubDecision.php
+++ b/module/Database/src/Model/SubDecision.php
@@ -131,6 +131,20 @@ abstract class SubDecision
     protected int $number;
 
     /**
+     * The member involved in this sub-decision.
+     *
+     * Not all sub-decisions require this, as such it is nullable. However, sub-decisions that need the guarantee that
+     * this is not null or need to specify an inverse side can do so using an association override.
+     */
+    #[ManyToOne(targetEntity: Member::class)]
+    #[JoinColumn(
+        name: 'lidnr',
+        referencedColumnName: 'lidnr',
+        nullable: true,
+    )]
+    protected ?Member $member = null;
+
+    /**
      * Get the decision.
      */
     public function getDecision(): Decision
@@ -192,11 +206,27 @@ abstract class SubDecision
     }
 
     /**
+     * Get the member.
+     */
+    public function getMember(): ?Member
+    {
+        return $this->member;
+    }
+
+    /**
      * Set the number.
      */
     public function setNumber(int $number): void
     {
         $this->number = $number;
+    }
+
+    /**
+     * Set the member.
+     */
+    public function setMember(Member $member): void
+    {
+        $this->member = $member;
     }
 
     /**

--- a/module/Database/src/Model/SubDecision/Board/Installation.php
+++ b/module/Database/src/Model/SubDecision/Board/Installation.php
@@ -7,10 +7,11 @@ namespace Database\Model\SubDecision\Board;
 use Database\Model\Member;
 use Database\Model\SubDecision;
 use DateTime;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 use IntlDateFormatter;
 
@@ -20,6 +21,16 @@ use function date_default_timezone_get;
  * Installation as board member.
  */
 #[Entity]
+#[AssociationOverrides([
+    new AssociationOverride(
+        name: 'member',
+        joinColumns: new JoinColumn(
+            name: 'lidnr',
+            referencedColumnName: 'lidnr',
+            nullable: false,
+        ),
+    ),
+])]
 class Installation extends SubDecision
 {
     /**
@@ -27,22 +38,6 @@ class Installation extends SubDecision
      */
     #[Column(type: 'string')]
     protected string $function;
-
-    /**
-     * Member.
-     *
-     * Note that only members that are older than 18 years can be board members.
-     * Also, honorary members cannot be board members.
-     * (See the Statuten, Art. 13A Lid 2.
-     *
-     * @todo Inversed relation
-     */
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-    )]
-    protected Member $member;
 
     /**
      * The date at which the installation is in effect.
@@ -86,18 +81,12 @@ class Installation extends SubDecision
 
     /**
      * Get the member.
+     *
+     * @psalm-suppress InvalidNullableReturnType
      */
     public function getMember(): Member
     {
         return $this->member;
-    }
-
-    /**
-     * Set the member.
-     */
-    public function setMember(Member $member): void
-    {
-        $this->member = $member;
     }
 
     /**

--- a/module/Database/src/Model/SubDecision/Budget.php
+++ b/module/Database/src/Model/SubDecision/Budget.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Database\Model\SubDecision;
 
-use Database\Model\Member;
 use Database\Model\SubDecision;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use IntlDateFormatter;
 
 use function date_default_timezone_get;
@@ -19,17 +16,6 @@ use function str_replace;
 #[Entity]
 class Budget extends SubDecision
 {
-    /**
-     * Budget author.
-     */
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-        nullable: true,
-    )]
-    protected ?Member $author = null;
-
     /**
      * Name of the budget.
      */
@@ -62,22 +48,6 @@ class Budget extends SubDecision
      */
     #[Column(type: 'boolean')]
     protected bool $changes;
-
-    /**
-     * Get the author.
-     */
-    public function getAuthor(): ?Member
-    {
-        return $this->author;
-    }
-
-    /**
-     * Set the author.
-     */
-    public function setAuthor(Member $author): void
-    {
-        $this->author = $author;
-    }
 
     /**
      * Get the name.
@@ -166,10 +136,10 @@ class Budget extends SubDecision
     {
         $template = $this->getTemplate();
         $template = str_replace('%NAME%', $this->getName(), $template);
-        if (null === $this->getAuthor()) {
+        if (null === $this->getMember()) {
             $template = str_replace('%AUTHOR%', 'onbekend', $template);
         } else {
-            $template = str_replace('%AUTHOR%', $this->getAuthor()->getFullName(), $template);
+            $template = str_replace('%AUTHOR%', $this->getMember()->getFullName(), $template);
         }
 
         $template = str_replace('%VERSION%', $this->getVersion(), $template);

--- a/module/Database/src/Model/SubDecision/Installation.php
+++ b/module/Database/src/Model/SubDecision/Installation.php
@@ -7,10 +7,11 @@ namespace Database\Model\SubDecision;
 use Database\Model\Member;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 
@@ -18,6 +19,17 @@ use Doctrine\ORM\Mapping\OneToOne;
  * Installation into organ.
  */
 #[Entity]
+#[AssociationOverrides([
+    new AssociationOverride(
+        name: 'member',
+        joinColumns: new JoinColumn(
+            name: 'lidnr',
+            referencedColumnName: 'lidnr',
+            nullable: false,
+        ),
+        inversedBy: 'installations',
+    ),
+])]
 class Installation extends FoundationReference
 {
     /**
@@ -25,19 +37,6 @@ class Installation extends FoundationReference
      */
     #[Column(type: 'string')]
     protected string $function;
-
-    /**
-     * Member.
-     */
-    #[ManyToOne(
-        targetEntity: Member::class,
-        inversedBy: 'installations',
-    )]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-    )]
-    protected Member $member;
 
     /**
      * Reappointment subdecisions if this installation was prolonged (can be done multiple times).
@@ -82,18 +81,12 @@ class Installation extends FoundationReference
 
     /**
      * Get the member.
+     *
+     * @psalm-suppress InvalidNullableReturnType
      */
     public function getMember(): Member
     {
         return $this->member;
-    }
-
-    /**
-     * Set the member.
-     */
-    public function setMember(Member $member): void
-    {
-        $this->member = $member;
     }
 
     /**

--- a/module/Database/src/Model/SubDecision/Key/Granting.php
+++ b/module/Database/src/Model/SubDecision/Key/Granting.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Database\Model\SubDecision\Key;
 
-use Database\Model\Member;
 use Database\Model\SubDecision;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 use IntlDateFormatter;
 
@@ -20,17 +17,6 @@ use function str_replace;
 #[Entity]
 class Granting extends SubDecision
 {
-    /**
-     * The member who is granted a keycode of GEWIS.
-     */
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-        nullable: true,
-    )]
-    protected ?Member $grantee = null;
-
     /**
      * Till when the keycode is granted.
      */
@@ -45,22 +31,6 @@ class Granting extends SubDecision
         mappedBy: 'granting',
     )]
     protected ?Withdrawal $withdrawal = null;
-
-    /**
-     * Get the grantee.
-     */
-    public function getGrantee(): ?Member
-    {
-        return $this->grantee;
-    }
-
-    /**
-     * Set the grantee.
-     */
-    public function setGrantee(Member $grantee): void
-    {
-        $this->grantee = $grantee;
-    }
 
     /**
      * Get the date.
@@ -85,7 +55,7 @@ class Granting extends SubDecision
     {
         $template = $this->getTemplate();
 
-        $template = str_replace('%GRANTEE%', $this->getGrantee()->getFullName(), $template);
+        $template = str_replace('%GRANTEE%', $this->getMember()->getFullName(), $template);
         $template = str_replace('%UNTIL%', $this->formatDate($this->getUntil()), $template);
 
         return $template;

--- a/module/Database/src/Model/SubDecision/Key/Withdrawal.php
+++ b/module/Database/src/Model/SubDecision/Key/Withdrawal.php
@@ -92,7 +92,7 @@ class Withdrawal extends SubDecision
     {
         $template = $this->getTemplate();
 
-        $template = str_replace('%GRANTEE%', $this->getGranting()->getGrantee()->getFullName(), $template);
+        $template = str_replace('%GRANTEE%', $this->getGranting()->getMember()->getFullName(), $template);
         $template = str_replace('%WITHDRAWAL%', $this->formatDate($this->getWithdrawnOn()), $template);
 
         return $template;

--- a/module/Database/view/database/meeting/key/withdrawform.phtml
+++ b/module/Database/view/database/meeting/key/withdrawform.phtml
@@ -17,7 +17,7 @@ foreach ($grants as $key => $grant) {
         'decision_number' => $grant->getDecision()->getNumber(),
         'subdecision_number' => $grant->getNumber(),
         'granting_until' => $grant->getUntil()->format('Y-m-d'),
-        'granting_member_lidnr' => $grant->getGrantee()->getLidnr(),
+        'granting_member_lidnr' => $grant->getMember()->getLidnr(),
     );
 }
 ?>
@@ -85,7 +85,7 @@ $fsgm = $fsg->get('member');
             <div class="radio">
                 <label>
                     <input type="radio" name="key-withdraw-slot" class="key-withdraw-slot" value="<?= $key ?>">
-                    <?= $grant->getGrantee()->getFullName() ?> (<?= $grant->getUntil()->format('Y-m-d') ?>)<br>
+                    <?= $grant->getMember()->getFullName() ?> (<?= $grant->getUntil()->format('Y-m-d') ?>)<br>
                 </label>
             </div>
         <?php endforeach ?>

--- a/module/Report/src/Model/SubDecision.php
+++ b/module/Report/src/Model/SubDecision.php
@@ -137,6 +137,20 @@ abstract class SubDecision
     protected string $content;
 
     /**
+     * The member involved in this sub-decision.
+     *
+     * Not all sub-decisions require this, as such it is nullable. However, sub-decisions that need the guarantee that
+     * this is not null or need to specify an inverse side can do so using an association override.
+     */
+    #[ManyToOne(targetEntity: Member::class)]
+    #[JoinColumn(
+        name: 'lidnr',
+        referencedColumnName: 'lidnr',
+        nullable: true,
+    )]
+    protected ?Member $member = null;
+
+    /**
      * Get the decision.
      */
     public function getDecision(): Decision
@@ -203,6 +217,22 @@ abstract class SubDecision
     public function setNumber(int $number): void
     {
         $this->number = $number;
+    }
+
+    /**
+     * Get the member.
+     */
+    public function getMember(): ?Member
+    {
+        return $this->member;
+    }
+
+    /**
+     * Set the member.
+     */
+    public function setMember(Member $member): void
+    {
+        $this->member = $member;
     }
 
     /**

--- a/module/Report/src/Model/SubDecision/Board/Installation.php
+++ b/module/Report/src/Model/SubDecision/Board/Installation.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Report\Model\SubDecision\Board;
 
 use DateTime;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 use Report\Model\BoardMember;
 use Report\Model\Member;
@@ -18,6 +19,16 @@ use Report\Model\SubDecision;
  * Installation as board member.
  */
 #[Entity]
+#[AssociationOverrides([
+    new AssociationOverride(
+        name: 'member',
+        joinColumns: new JoinColumn(
+            name: 'lidnr',
+            referencedColumnName: 'lidnr',
+            nullable: false,
+        ),
+    ),
+])]
 class Installation extends SubDecision
 {
     /**
@@ -25,21 +36,6 @@ class Installation extends SubDecision
      */
     #[Column(type: 'string')]
     protected string $function;
-
-    /**
-     * Member.
-     *
-     * Note that only members that are older than 18 years can be board members.
-     * Also, honorary, external and extraordinary members cannot be board members.
-     * (See the Statuten, Art. 13 Lid 2.
-     */
-    // TODO: Inversed relation
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-    )]
-    protected Member $member;
 
     /**
      * The date at which the installation is in effect.
@@ -92,18 +88,12 @@ class Installation extends SubDecision
 
     /**
      * Get the member.
+     *
+     * @psalm-suppress InvalidNullableReturnType
      */
     public function getMember(): Member
     {
         return $this->member;
-    }
-
-    /**
-     * Set the member.
-     */
-    public function setMember(Member $member): void
-    {
-        $this->member = $member;
     }
 
     /**

--- a/module/Report/src/Model/SubDecision/Budget.php
+++ b/module/Report/src/Model/SubDecision/Budget.php
@@ -7,9 +7,6 @@ namespace Report\Model\SubDecision;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
-use Report\Model\Member;
 use Report\Model\SubDecision;
 
 /**
@@ -18,17 +15,6 @@ use Report\Model\SubDecision;
 #[Entity]
 class Budget extends SubDecision
 {
-    /**
-     * Budget author.
-     */
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-        nullable: true,
-    )]
-    protected ?Member $author = null;
-
     /**
      * Name of the budget.
      */
@@ -61,22 +47,6 @@ class Budget extends SubDecision
      */
     #[Column(type: 'boolean')]
     protected bool $changes;
-
-    /**
-     * Get the author.
-     */
-    public function getAuthor(): ?Member
-    {
-        return $this->author;
-    }
-
-    /**
-     * Set the author.
-     */
-    public function setAuthor(Member $author): void
-    {
-        $this->author = $author;
-    }
 
     /**
      * Get the name.

--- a/module/Report/src/Model/SubDecision/Installation.php
+++ b/module/Report/src/Model/SubDecision/Installation.php
@@ -6,10 +6,11 @@ namespace Report\Model\SubDecision;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Report\Model\Member;
@@ -19,6 +20,17 @@ use Report\Model\OrganMember;
  * Installation into organ.
  */
 #[Entity]
+#[AssociationOverrides([
+    new AssociationOverride(
+        name: 'member',
+        joinColumns: new JoinColumn(
+            name: 'lidnr',
+            referencedColumnName: 'lidnr',
+            nullable: false,
+        ),
+        inversedBy: 'installations',
+    ),
+])]
 class Installation extends FoundationReference
 {
     /**
@@ -26,19 +38,6 @@ class Installation extends FoundationReference
      */
     #[Column(type: 'string')]
     protected string $function;
-
-    /**
-     * Member.
-     */
-    #[ManyToOne(
-        targetEntity: Member::class,
-        inversedBy: 'installations',
-    )]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-    )]
-    protected Member $member;
 
     /**
      * Reappointment subdecisions if this installation was prolonged (can be done multiple times).
@@ -92,6 +91,8 @@ class Installation extends FoundationReference
 
     /**
      * Get the member.
+     *
+     * @psalm-suppress InvalidNullableReturnType
      */
     public function getMember(): Member
     {

--- a/module/Report/src/Model/SubDecision/Key/Granting.php
+++ b/module/Report/src/Model/SubDecision/Key/Granting.php
@@ -7,27 +7,13 @@ namespace Report\Model\SubDecision\Key;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 use Report\Model\Keyholder;
-use Report\Model\Member;
 use Report\Model\SubDecision;
 
 #[Entity]
 class Granting extends SubDecision
 {
-    /**
-     * The member who is granted a keycode of GEWIS.
-     */
-    #[ManyToOne(targetEntity: Member::class)]
-    #[JoinColumn(
-        name: 'lidnr',
-        referencedColumnName: 'lidnr',
-        nullable: true,
-    )]
-    protected ?Member $grantee = null;
-
     /**
      * Till when the keycode is granted.
      */
@@ -51,22 +37,6 @@ class Granting extends SubDecision
         mappedBy: 'grantingDec',
     )]
     protected Keyholder $keyholder;
-
-    /**
-     * Get the grantee.
-     */
-    public function getGrantee(): ?Member
-    {
-        return $this->grantee;
-    }
-
-    /**
-     * Set the grantee.
-     */
-    public function setGrantee(Member $grantee): void
-    {
-        $this->grantee = $grantee;
-    }
 
     /**
      * Get the date.

--- a/module/Report/src/Service/Keyholder.php
+++ b/module/Report/src/Service/Keyholder.php
@@ -70,7 +70,7 @@ class Keyholder
             $keyholder->setGrantingDec($granting);
         }
 
-        $keyholder->setMember($granting->getGrantee());
+        $keyholder->setMember($granting->getMember());
         $keyholder->setExpirationDate($granting->getUntil());
 
         $this->emReport->persist($keyholder);

--- a/module/Report/src/Service/Meeting.php
+++ b/module/Report/src/Service/Meeting.php
@@ -230,8 +230,8 @@ class Meeting
             || $subdecision instanceof DatabaseSubDecisionModel\Budget
         ) {
             // budget and reckoning
-            if (null !== $subdecision->getAuthor()) {
-                $reportSubDecision->setAuthor($this->findMember($subdecision->getAuthor()));
+            if (null !== $subdecision->getMember()) {
+                $reportSubDecision->setMember($this->findMember($subdecision->getMember()));
             }
 
             $reportSubDecision->setName($subdecision->getName());
@@ -270,7 +270,7 @@ class Meeting
             $reportSubDecision->setInstallation($installation);
         } elseif ($subdecision instanceof DatabaseSubDecisionModel\Key\Granting) {
             // key code granting
-            $reportSubDecision->setGrantee($this->findMember($subdecision->getGrantee()));
+            $reportSubDecision->setMember($this->findMember($subdecision->getMember()));
             $reportSubDecision->setUntil($subdecision->getUntil());
         } elseif ($subdecision instanceof DatabaseSubDecisionModel\Key\Withdrawal) {
             // key code withdrawal


### PR DESCRIPTION
Instead of allowing specific types of sub-decisions to specify an association with `Member` this is now done "globally". If there are specific needs (e.g. not nullable) this can be achieved using `AssociationOverride`s. Note: in the `JoinColumn` override it is necessary to (re)specify `name` and `referencedColumnName`.

This change is necessary to allow easier extraction of sub- decisions related to specific members (i.e. for GDPR requests).

Functionally nothing changes as all the different associations already super-mapped to the same column.