### PR TITLE
Add birth date API functionality & email permissions

### DIFF
--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-06 23:12+0100\n"
+"POT-Creation-Date: 2024-02-17 15:21+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Rink Pieters <rinkp@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -345,9 +345,6 @@ msgstr "Change Subscriptions"
 msgid "Change password for %s"
 msgstr "Change password for %s"
 
-msgid "Check if a member is a keyholder"
-msgstr "Check if a member is a keyholder"
-
 #, php-format
 msgid ""
 "Check out the website of Ada Alumni <a href=\"//%s\" target=\"_blank\">here</"
@@ -585,17 +582,15 @@ msgstr "Functions"
 msgid "GEWIS Registration - Checkout"
 msgstr "GEWIS Registration - Checkout"
 
-#, fuzzy, php-format
+#, php-format
 msgid ""
-"GEWIS currently has <a href=\"%s\">%d members</a> (+%d expired) and <a "
-"href=\"%s\">%d prospective members (%d paid, %d unpaid)</a>. <a "
-"href=\"%s\">Click here</a> to create a meeting or <a href=\"%s\">perform a "
-"query</a>."
+"GEWIS currently has <a href=\"%s\">%d members</a> (+%d expired) and <a href="
+"\"%s\">%d prospective members (%d paid, %d unpaid)</a>. <a href=\"%s\">Click "
+"here</a> to create a meeting or <a href=\"%s\">perform a query</a>."
 msgstr ""
-"GEWIS currently has <a href=\"%s\">%d members</a> (+%d expired) and <a "
-"href=\"%s\">%d prospective members (%d paid, %d unpaid)</a>. <a "
-"href=\"%s\">Click here</a> to create a meeting or <a href=\"%s\">perform a "
-"query</a>."
+"GEWIS currently has <a href=\"%s\">%d members</a> (+%d expired) and <a href="
+"\"%s\">%d prospective members (%d paid, %d unpaid)</a>. <a href=\"%s\">Click "
+"here</a> to create a meeting or <a href=\"%s\">perform a query</a>."
 
 msgid "GMM (General Members Meeting)"
 msgstr "GMM (General Members Meeting)"
@@ -862,6 +857,27 @@ msgstr "Membership Type"
 
 msgid "Membership of Committees and Fraternities"
 msgstr "Membership of Committees and Fraternities"
+
+msgid "Member¹ - Check if has reached age 16"
+msgstr "Member¹ - Check if has reached age 16"
+
+msgid "Member¹ - Check if has reached age 18"
+msgstr "Member¹ - Check if has reached age 18"
+
+msgid "Member¹ - Check if has reached age 21"
+msgstr "Member¹ - Check if has reached age 21"
+
+msgid "Member¹ - Check if keyholder"
+msgstr "Member¹ - Check if keyholder"
+
+msgid "Member¹ - Check membership type"
+msgstr "Member¹ - Check membership type"
+
+msgid "Member¹ - Get birthdate"
+msgstr "Member¹ - Get birthdate"
+
+msgid "Member¹ - Get email address"
+msgstr "Member¹ - Get email address"
 
 msgid "Message"
 msgstr "Message"
@@ -1235,6 +1251,13 @@ msgstr ""
 "This payment link could not be found. Perhaps it has been used before or has "
 "expired."
 
+msgid ""
+"This permission will add more properties to existing entities that can "
+"already be requested."
+msgstr ""
+"This permission will add more properties to existing entities that can "
+"already be requested."
+
 msgid "This prospective member cannot be approved."
 msgstr "This prospective member cannot be approved."
 
@@ -1299,9 +1322,6 @@ msgstr "View"
 
 msgid "View Update Requests"
 msgstr "View Update Requests"
-
-msgid "View the membership type for a member"
-msgstr "View the membership type for a member"
 
 msgid "Virt (Virtual Meeting)"
 msgstr "Virt (Virtual Meeting)"

--- a/module/Application/language/gewisdb.pot
+++ b/module/Application/language/gewisdb.pot
@@ -6,15 +6,15 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GEWISdb 5957641f-dirty\n"
+"Project-Id-Version: GEWISdb 6d2132f5-dirty\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-06 23:12+0100\n"
+"POT-Creation-Date: 2024-02-17 15:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
@@ -227,8 +227,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"As a GEWIS member, you will be automatically registered on the \"GEWIS-lijst"
-"\" list. This list is for announcements and activities of the study "
+"As a GEWIS member, you will be automatically registered on the \"GEWIS-"
+"lijst\" list. This list is for announcements and activities of the study "
 "association. In addition, there are several optional mailing lists. You can "
 "subscribe to the following mailing lists. These subscriptions can be changed "
 "at a later date."
@@ -319,9 +319,6 @@ msgstr ""
 
 #, php-format
 msgid "Change password for %s"
-msgstr ""
-
-msgid "Check if a member is a keyholder"
 msgstr ""
 
 #, php-format
@@ -805,6 +802,27 @@ msgstr ""
 msgid "Membership of Committees and Fraternities"
 msgstr ""
 
+msgid "Member¹ - Check if has reached age 16"
+msgstr ""
+
+msgid "Member¹ - Check if has reached age 18"
+msgstr ""
+
+msgid "Member¹ - Check if has reached age 21"
+msgstr ""
+
+msgid "Member¹ - Check if keyholder"
+msgstr ""
+
+msgid "Member¹ - Check membership type"
+msgstr ""
+
+msgid "Member¹ - Get birthdate"
+msgstr ""
+
+msgid "Member¹ - Get email address"
+msgstr ""
+
 msgid "Message"
 msgstr ""
 
@@ -1155,6 +1173,11 @@ msgid ""
 "expired."
 msgstr ""
 
+msgid ""
+"This permission will add more properties to existing entities that can "
+"already be requested."
+msgstr ""
+
 msgid "This prospective member cannot be approved."
 msgstr ""
 
@@ -1216,9 +1239,6 @@ msgid "View"
 msgstr ""
 
 msgid "View Update Requests"
-msgstr ""
-
-msgid "View the membership type for a member"
 msgstr ""
 
 msgid "Virt (Virtual Meeting)"

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -2,13 +2,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-06 23:12+0100\n"
+"POT-Creation-Date: 2024-02-17 15:21+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Rink Pieters <rinkp@users.noreply.github.com>\n"
 "Language-Team: \n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=iso-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2.4\n"
@@ -345,9 +345,6 @@ msgstr "Abonnementen wijzigen"
 msgid "Change password for %s"
 msgstr "Wachtwoord voor %s wijzigen"
 
-msgid "Check if a member is a keyholder"
-msgstr "Ophalen of een lid een sleutelcode heeft"
-
 #, php-format
 msgid ""
 "Check out the website of Ada Alumni <a href=\"//%s\" target=\"_blank\">here</"
@@ -380,7 +377,7 @@ msgid "Controller"
 msgstr "Controller"
 
 msgid "Copy Decision"
-msgstr "Besluit kopiëren"
+msgstr "Besluit kopiÃ«ren"
 
 msgid "Create API principal"
 msgstr "Maak API-gebruiker aan"
@@ -588,17 +585,16 @@ msgstr "Functies"
 msgid "GEWIS Registration - Checkout"
 msgstr "GEWIS Inschrijven - Afrekenen"
 
-#, fuzzy, php-format
+#, php-format
 msgid ""
-"GEWIS currently has <a href=\"%s\">%d members</a> (+%d expired) and <a "
-"href=\"%s\">%d prospective members (%d paid, %d unpaid)</a>. <a "
-"href=\"%s\">Click here</a> to create a meeting or <a href=\"%s\">perform a "
-"query</a>."
+"GEWIS currently has <a href=\"%s\">%d members</a> (+%d expired) and <a href="
+"\"%s\">%d prospective members (%d paid, %d unpaid)</a>. <a href=\"%s\">Click "
+"here</a> to create a meeting or <a href=\"%s\">perform a query</a>."
 msgstr ""
-"GEWIS heeft momenteel <a href=\"%s\">%d leden</a> (+%d verlopen) en <a "
-"href=\"%s\">%d toekomstige leden (%d betaald, %d onbetaald)</a>. <a "
-"href=\"%s\">Klik hier</a> om een vergadering te maken of om een <a "
-"href=\"%s\">query uit te voeren</a>."
+"GEWIS heeft momenteel <a href=\"%s\">%d leden</a> (+%d verlopen) en <a href="
+"\"%s\">%d toekomstige leden (%d betaald, %d onbetaald)</a>. <a href=\"%s"
+"\">Klik hier</a> om een vergadering te maken of om een <a href=\"%s\">query "
+"uit te voeren</a>."
 
 msgid "GMM (General Members Meeting)"
 msgstr "ALV (algemene ledenvergadering)"
@@ -734,7 +730,7 @@ msgstr ""
 "bijvoorbeeld %s0001. Je hebt je gebruikersnaam ontvangen in een e-mail toen "
 "je je ingeschreven hebt aan de TU/e. Op <a href=\"%s\">deze pagina</a> staat "
 "hoe je je gebruikersnaam kunt vinden. We gebruiken je gebruikersnaam om te "
-"verifi�ren dat je aan de faculteit van M&CS studeert."
+"verifiï¿½ren dat je aan de faculteit van M&CS studeert."
 
 #, php-format
 msgid ""
@@ -868,6 +864,27 @@ msgstr "Lidmaatschapstype"
 
 msgid "Membership of Committees and Fraternities"
 msgstr "Lidmaatschap van commissies en disputen"
+
+msgid "Member¹ - Check if has reached age 16"
+msgstr "Lid¹ - Controleer of lid ten minste 16 jaar is"
+
+msgid "Member¹ - Check if has reached age 18"
+msgstr "Lid¹ - Controleer of lid ten minste 18 jaar is"
+
+msgid "Member¹ - Check if has reached age 21"
+msgstr "Lid¹ - Controleer of lid ten minste 21 jaar is"
+
+msgid "Member¹ - Check if keyholder"
+msgstr "Lid¹ - Controleer of lid sleutelhouder is"
+
+msgid "Member¹ - Check membership type"
+msgstr "Lid¹ - Lidmaatschapstype inzien"
+
+msgid "Member¹ - Get birthdate"
+msgstr "Lid¹ - Geboortedatum inzien"
+
+msgid "Member¹ - Get email address"
+msgstr "Lid¹ - E-mailadres inzien"
 
 msgid "Message"
 msgstr "Bericht"
@@ -1248,6 +1265,13 @@ msgstr ""
 "Deze betaallink kon niet worden gevonden. Misschien is deze al eerder "
 "gebruikt of is deze verlopen."
 
+msgid ""
+"This permission will add more properties to existing entities that can "
+"already be requested."
+msgstr ""
+"Dit API-recht voegt meer attributen toe aan objecten die al opgehaald kunnen "
+"worden."
+
 msgid "This prospective member cannot be approved."
 msgstr "Dit toekomstig lid kan niet worden goedgekeurd."
 
@@ -1314,9 +1338,6 @@ msgstr "Toon"
 
 msgid "View Update Requests"
 msgstr "Update-aanvragen bekijken"
-
-msgid "View the membership type for a member"
-msgstr "Het lidmaatschapstype voor een lid bekijken"
 
 msgid "Virt (Virtual Meeting)"
 msgstr "Virt (virtuele vergadering)"

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -113,6 +113,26 @@ class ApiController extends AbstractActionController
             $additionalProperties[] = 'type';
         }
 
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersEmail)) {
+            $additionalProperties[] = 'email';
+        }
+
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersBirth)) {
+            $additionalProperties[] = 'birthdate';
+        }
+
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersAge16)) {
+            $additionalProperties[] = 'is_16_plus';
+        }
+
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersAge18)) {
+            $additionalProperties[] = 'is_18_plus';
+        }
+
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersAge21)) {
+            $additionalProperties[] = 'is_21_plus';
+        }
+
         return $additionalProperties;
     }
 }

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -113,23 +113,23 @@ class ApiController extends AbstractActionController
             $additionalProperties[] = 'type';
         }
 
-        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersEmail)) {
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersPropertyEmail)) {
             $additionalProperties[] = 'email';
         }
 
-        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersBirth)) {
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersPropertyBirthDate)) {
             $additionalProperties[] = 'birthdate';
         }
 
-        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersAge16)) {
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersPropertyAge16)) {
             $additionalProperties[] = 'is_16_plus';
         }
 
-        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersAge18)) {
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersPropertyAge18)) {
             $additionalProperties[] = 'is_18_plus';
         }
 
-        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersAge21)) {
+        if ($this->apiAuthService->currentUserCan(ApiPermissions::MembersPropertyAge21)) {
             $additionalProperties[] = 'is_21_plus';
         }
 

--- a/module/Report/src/Model/Member.php
+++ b/module/Report/src/Model/Member.php
@@ -554,6 +554,37 @@ class Member
     }
 
     /**
+     * Member is at least 16 years old on the given date.
+     */
+    public function hasReached16(DateTime $onDate = new DateTime()): bool
+    {
+        return $this->isOlderThan($onDate, 16);
+    }
+
+    /**
+     * Member is at least 18 years old on the given date.
+     */
+    public function hasReached18(DateTime $onDate = new DateTime()): bool
+    {
+        return $this->isOlderThan($onDate, 18);
+    }
+
+    /**
+     * Member is at least 21 years old on the given date.
+     */
+    public function hasReached21(DateTime $onDate = new DateTime()): bool
+    {
+        return $this->isOlderThan($onDate, 21);
+    }
+
+    private function isOlderThan(
+        DateTime $onDate,
+        int $years,
+    ): bool {
+        return $onDate->diff($this->getBirth())->y >= $years;
+    }
+
+    /**
      * Get if the member is deleted.
      */
     public function getDeleted(): bool
@@ -583,6 +614,10 @@ class Member
      *     generation: int,
      *     hidden: bool,
      *     deleted: bool,
+     *     birthdate: string,
+     *     is_16_plus: bool,
+     *     is_18_plus: bool,
+     *     is_21_plus: bool,
      *     membershipEndsOn: ?string,
      *     expiration: string,
      *     authenticationKey: ?string,
@@ -601,6 +636,10 @@ class Member
             'generation' => $this->getGeneration(),
             'hidden' => $this->getHidden(),
             'deleted' => $this->getDeleted(),
+            'birthdate' => $this->getBirth()->format(DateTimeInterface::ATOM),
+            'is_16_plus' => $this->hasReached16(),
+            'is_18_plus' => $this->hasReached18(),
+            'is_21_plus' => $this->hasReached21(),
             'membershipEndsOn' => $this->getMembershipEndsOn()?->format(DateTimeInterface::ATOM) ?? null,
             'expiration' => $this->getExpiration()->format(DateTimeInterface::ATOM),
             'authenticationKey' => $this->getAuthenticationKey(),
@@ -615,7 +654,7 @@ class Member
      *
      * @return array{
      *     lidnr: int,
-     *     email: ?string,
+     *     email?: ?string,
      *     fullName: string,
      *     lastName: string,
      *     middleName: string,
@@ -624,6 +663,10 @@ class Member
      *     generation: int,
      *     hidden: bool,
      *     deleted: bool,
+     *     birthdate?: string,
+     *     is_16_plus?: bool,
+     *     is_18_plus?: bool,
+     *     is_21_plus?: bool,
      *     expiration: string,
      *     organs?: array<array-key, array{
      *         organ: array{
@@ -643,7 +686,6 @@ class Member
     {
         $result = [
             'lidnr' => $this->getLidnr(),
-            'email' => $this->getEmail(),
             'fullName' => $this->getFullName(),
             'lastName' => $this->getLastName(),
             'middleName' => $this->getMiddleName(),
@@ -669,6 +711,26 @@ class Member
                     ),
                 ),
             );
+        }
+
+        if (in_array('email', $include)) {
+            $result['email'] = $this->getEmail();
+        }
+
+        if (in_array('birthdate', $include)) {
+            $result['birthdate'] = $this->getBirth()->format(DateTimeInterface::ATOM);
+        }
+
+        if (in_array('is_16_plus', $include)) {
+            $result['is_16_plus'] = $this->hasReached16();
+        }
+
+        if (in_array('is_18_plus', $include)) {
+            $result['is_18_plus'] = $this->hasReached18();
+        }
+
+        if (in_array('is_21_plus', $include)) {
+            $result['is_21_plus'] = $this->hasReached21();
         }
 
         if (in_array('keyholder', $include)) {

--- a/module/Report/src/Model/Member.php
+++ b/module/Report/src/Model/Member.php
@@ -655,11 +655,11 @@ class Member
      * @return array{
      *     lidnr: int,
      *     email?: ?string,
-     *     fullName: string,
-     *     lastName: string,
-     *     middleName: string,
+     *     full_name: string,
+     *     family_name: string,
+     *     middle_name: string,
      *     initials: string,
-     *     firstName: string,
+     *     given_name: string,
      *     generation: int,
      *     hidden: bool,
      *     deleted: bool,
@@ -679,18 +679,18 @@ class Member
      *         current: bool,
      *      }>,
      *      keyholder?: bool,
-     *      type?: string,
+     *      membership_type?: string,
      * }
      */
     public function toArrayApi(array $include = []): array
     {
         $result = [
             'lidnr' => $this->getLidnr(),
-            'fullName' => $this->getFullName(),
-            'lastName' => $this->getLastName(),
-            'middleName' => $this->getMiddleName(),
+            'full_name' => $this->getFullName(),
+            'family_name' => $this->getLastName(),
+            'middle_name' => $this->getMiddleName(),
             'initials' => $this->getInitials(),
-            'firstName' => $this->getFirstName(),
+            'given_name' => $this->getFirstName(),
             'generation' => $this->getGeneration(),
             'hidden' => $this->getHidden(),
             'deleted' => $this->getDeleted(),
@@ -738,7 +738,7 @@ class Member
         }
 
         if (in_array('type', $include)) {
-            $result['type'] = $this->getType()->value;
+            $result['membership_type'] = $this->getType()->value;
         }
 
         return $result;

--- a/module/User/src/Model/Enums/ApiPermissions.php
+++ b/module/User/src/Model/Enums/ApiPermissions.php
@@ -13,14 +13,14 @@ enum ApiPermissions: string
 {
     case HealthR = 'health_read';
     case MembersR = 'members_read';
+    case MembersActiveR = 'members_active_read';
     case MembersPropertyKeyholder = 'members_read_keyholder';
     case MembersPropertyType = 'members_read_type';
-    case MembersActiveR = 'members_active_read';
-    case MembersEmail = 'members_read_email';
-    case MembersBirth = 'members_read_birthdate';
-    case MembersAge16 = 'members_read_is16';
-    case MembersAge18 = 'members_read_is18';
-    case MembersAge21 = 'members_read_is21';
+    case MembersPropertyEmail = 'members_read_email';
+    case MembersPropertyBirthDate = 'members_read_birthdate';
+    case MembersPropertyAge16 = 'members_read_is16';
+    case MembersPropertyAge18 = 'members_read_is18';
+    case MembersPropertyAge21 = 'members_read_is21';
     case OrgansMembershipR = 'organs_members_read';
     case All = '*';
 
@@ -29,20 +29,20 @@ enum ApiPermissions: string
         return match ($this) {
             self::HealthR => $translator->translate('Get API Health'),
             self::MembersR => $translator->translate('Get all Members'),
-            self::MembersPropertyKeyholder => $translator->translate(
-                'Check if a member is a keyholder',
-            ),
-            self::MembersPropertyType => $translator->translate(
-                'View the membership type for a member',
-            ),
             self::MembersActiveR => $translator->translate(
                 'Get active Members (members that are in one or more organs)',
             ),
-            self::MembersEmail => $translator->translate('Get member email address'),
-            self::MembersBirth => $translator->translate('Get member birthdate'),
-            self::MembersAge16 => $translator->translate('Check if a member has reached age 16'),
-            self::MembersAge18 => $translator->translate('Check if a member has reached age 18'),
-            self::MembersAge21 => $translator->translate('Check if a member has reached age 21'),
+            self::MembersPropertyKeyholder => $translator->translate(
+                'Member¹ - Check if keyholder',
+            ),
+            self::MembersPropertyType => $translator->translate(
+                'Member¹ - Check membership type',
+            ),
+            self::MembersPropertyEmail => $translator->translate('Member¹ - Get email address'),
+            self::MembersPropertyBirthDate => $translator->translate('Member¹ - Get birthdate'),
+            self::MembersPropertyAge16 => $translator->translate('Member¹ - Check if has reached age 16'),
+            self::MembersPropertyAge18 => $translator->translate('Member¹ - Check if has reached age 18'),
+            self::MembersPropertyAge21 => $translator->translate('Member¹ - Check if has reached age 21'),
             self::OrgansMembershipR => $translator->translate('Read organ membership (per user/organ)'),
             self::All => $translator->translate('All API permissions'),
         };

--- a/module/User/src/Model/Enums/ApiPermissions.php
+++ b/module/User/src/Model/Enums/ApiPermissions.php
@@ -16,6 +16,11 @@ enum ApiPermissions: string
     case MembersPropertyKeyholder = 'members_read_keyholder';
     case MembersPropertyType = 'members_read_type';
     case MembersActiveR = 'members_active_read';
+    case MembersEmail = 'members_read_email';
+    case MembersBirth = 'members_read_birthdate';
+    case MembersAge16 = 'members_read_is16';
+    case MembersAge18 = 'members_read_is18';
+    case MembersAge21 = 'members_read_is21';
     case OrgansMembershipR = 'organs_members_read';
     case All = '*';
 
@@ -33,6 +38,11 @@ enum ApiPermissions: string
             self::MembersActiveR => $translator->translate(
                 'Get active Members (members that are in one or more organs)',
             ),
+            self::MembersEmail => $translator->translate('Get member email address'),
+            self::MembersBirth => $translator->translate('Get member birthdate'),
+            self::MembersAge16 => $translator->translate('Check if a member has reached age 16'),
+            self::MembersAge18 => $translator->translate('Check if a member has reached age 18'),
+            self::MembersAge21 => $translator->translate('Check if a member has reached age 21'),
             self::OrgansMembershipR => $translator->translate('Read organ membership (per user/organ)'),
             self::All => $translator->translate('All API permissions'),
         };

--- a/module/User/view/user/api-settings/create-principal.phtml
+++ b/module/User/view/user/api-settings/create-principal.phtml
@@ -47,6 +47,7 @@ $form->setAttribute('class', 'form-horizontal');
             <?= $this->formMultiCheckbox()->setSeparator('<br/>')->render($element, 'prepend') ?>
             </div>
             <?= $this->formElementErrors($element) ?>
+            <p>¹ <?= $this->translate('This permission will add more properties to existing entities that can already be requested.') ?></p>
         </div>
     </div>
 

--- a/module/User/view/user/api-settings/edit-principal.phtml
+++ b/module/User/view/user/api-settings/edit-principal.phtml
@@ -62,6 +62,7 @@ $form->setAttribute('class', 'form-horizontal');
             <?= $this->formMultiCheckbox()->setSeparator('<br/>')->render($element, 'prepend') ?>
             </div>
             <?= $this->formElementErrors($element) ?>
+            <p>¹ <?= $this->translate('This permission will add more properties to existing entities that can already be requested.') ?></p>
         </div>
     </div>
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,7 +9,7 @@ info:
   license:
     name: GNU GENERAL PUBLIC LICENSE Version 3
     url: https://github.com/GEWIS/gewisdb/blob/main/LICENSE.txt
-  version: b54649b155402dca833e5b1e5d9d1737f7caccd2
+  version: 86c08a87afe939cbb9a515f7063965f7bdb30bce
 externalDocs:
   description: Contribute to this API
   url: https://github.com/GEWIS/gewisdb
@@ -18,6 +18,8 @@ servers:
     description: Production environment
   - url: https://database.test.gewis.nl/api
     description: Test environment
+  - url: http://localhost/api
+    description: Local environment    
 tags:
   - name: basic
   - name: members
@@ -158,19 +160,19 @@ components:
           format: int32
           example: 8000
           minimum: 0
-        fullName:
+        full_name:
           type: string
           example: Timo de Teststudent
         initials:
           type: string
           example: T.
-        firstName:
+        given_name:
           type: string
           example: Timo
-        middleName:
+        middle_name:
           type: string
           example: de
-        lastName:
+        family_name:
           type: string
           example: Teststudent
         generation:
@@ -214,6 +216,14 @@ components:
               format: email
               nullable: true
               example: example@gewis.nl
+    MemberExtendedType:
+      allOf:
+        - $ref: '#/components/schemas/MemberSimple'
+        - type: object
+          properties:
+            membership_type:
+              type: string
+              enum: [ordinary, external, graduate, honorary]
     MemberExtendedBirthDate:
       allOf:
         - $ref: '#/components/schemas/MemberSimple'
@@ -240,6 +250,7 @@ components:
         - $ref: '#/components/schemas/MemberExtendedEmail'
         - $ref: '#/components/schemas/MemberExtendedOrgan'
         - $ref: '#/components/schemas/MemberExtendedKeyholder'
+        - $ref: '#/components/schemas/MemberExtendedType'
         - $ref: '#/components/schemas/MemberSimple'
     OrganMembership:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -244,7 +244,7 @@ components:
               type: boolean
               description: Whether the member is at least 21 years old
     Member:
-      description: "If the client holds the `OrgansMembershipR` permission, a (combination of) MemberExtended object(s), else MemberSimple"
+      description: "If the client holds the `OrgansMembershipR` or `MemberProperty*` permissions, a (combination of) MemberExtended object(s), else MemberSimple"
       oneOf:
         - $ref: '#/components/schemas/MemberExtendedBirthDate'
         - $ref: '#/components/schemas/MemberExtendedEmail'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -158,11 +158,6 @@ components:
           format: int32
           example: 8000
           minimum: 0
-        email:
-          type: string
-          format: email
-          nullable: true
-          example: example@gewis.nl
         fullName:
           type: string
           example: Timo de Teststudent
@@ -209,9 +204,40 @@ components:
           properties:
             keyholder:
               type: boolean
+    MemberExtendedEmail:
+      allOf:
+        - $ref: '#/components/schemas/MemberSimple'
+        - type: object
+          properties:
+            email:
+              type: string
+              format: email
+              nullable: true
+              example: example@gewis.nl
+    MemberExtendedBirthDate:
+      allOf:
+        - $ref: '#/components/schemas/MemberSimple'
+        - type: object
+          properties:
+            birthdate:
+              type: string
+              format: date
+              description: Date in the Y-m-d\TH:i:sP format
+              example: "2023-07-01T00:00:00+02:00"
+            is_16_plus:
+              type: boolean
+              description: Whether the member is at least 16 years old
+            is_18_plus:
+              type: boolean
+              description: Whether the member is at least 18 years old
+            is_21_plus:
+              type: boolean
+              description: Whether the member is at least 21 years old
     Member:
       description: "If the client holds the `OrgansMembershipR` permission, a (combination of) MemberExtended object(s), else MemberSimple"
       oneOf:
+        - $ref: '#/components/schemas/MemberExtendedBirthDate'
+        - $ref: '#/components/schemas/MemberExtendedEmail'
         - $ref: '#/components/schemas/MemberExtendedOrgan'
         - $ref: '#/components/schemas/MemberExtendedKeyholder'
         - $ref: '#/components/schemas/MemberSimple'

--- a/psalm.xml
+++ b/psalm.xml
@@ -60,6 +60,7 @@
         <ImplementedReturnTypeMismatch errorLevel="info" />
         <UndefinedInterfaceMethod errorLevel="info" />
         <NullableReturnStatement errorLevel="info" />
+        <Trace errorLevel="error"/>
     </issueHandlers>
     <plugins>
         <pluginClass class="Lctrs\PsalmPsrContainerPlugin\Plugin"/>

--- a/translate-helper
+++ b/translate-helper
@@ -5,6 +5,7 @@ cd `dirname $0`
 # parse php files
 find ./module -iname "*.phtml" -print0 | sort -z | xargs -r0 xgettext \
     --language=PHP \
+    --from-code=UTF-8 \
     --keyword=translate \
     --keyword=translatePlural:1,2 \
     --output=./module/Application/language/gewisdb.pot \
@@ -17,6 +18,7 @@ find ./module -iname "*.phtml" -print0 | sort -z | xargs -r0 xgettext \
 
 find ./module -iname "*.php" -print0 | sort -z | xargs -r0 xgettext \
     --language=PHP \
+    --from-code=UTF-8 \
     --keyword=translate \
     --keyword=translatePlural:1,2 \
     --output=./module/Application/language/gewisdb.pot \


### PR DESCRIPTION
Fixes GH-372, introducing `is_16_plus`, `is_18_plus`, `is_21_plus` and `birthdate` endpoints
Fixes GH-373, introducing email address permissions

**NOTE: The latter is a breaking change and requires update of existing API principals by the secretary in production**