### PR TITLE
Remove audit entires when clearing member and improve flash messenger messages

### DIFF
--- a/docker/web/development/Dockerfile
+++ b/docker/web/development/Dockerfile
@@ -59,6 +59,8 @@ RUN apk add --no-cache --virtual .build-deps \
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 COPY ./composer.json ./composer.lock ./
 
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
 RUN composer install
 
 # Create the final image.

--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-17 15:21+0100\n"
+"POT-Creation-Date: 2024-02-17 17:34+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Rink Pieters <rinkp@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -15,6 +15,10 @@ msgstr ""
 
 msgid "# Decisions"
 msgstr "# Decisions"
+
+#, php-format
+msgid "%s has been added to %s"
+msgstr "%s has been added to %s"
 
 #, php-format
 msgid "%s: %s (started in %s)"
@@ -40,11 +44,14 @@ msgstr "A 404 error occurred"
 msgid "A TU/e-username should look like sYYxxxx or YYYYxxxx."
 msgstr "A TU/e-username should look like sYYxxxx or YYYYxxxx."
 
-msgid "API Principals"
-msgstr "API Principals"
-
 msgid "API Tokens"
 msgstr "API Tokens"
+
+msgid "API principal"
+msgstr "API principal"
+
+msgid "API principals"
+msgstr "API principals"
 
 msgid "Abbreviation"
 msgstr "Abbreviation"
@@ -151,12 +158,6 @@ msgstr "All API permissions"
 
 msgid "An error occurred"
 msgstr "An error occurred"
-
-msgid "An error occurred while trying to reject the changes."
-msgstr "An error occurred while trying to reject the changes."
-
-msgid "An error occurred while trying to save the changes."
-msgstr "An error occurred while trying to save the changes."
 
 msgid ""
 "An error occurred while we were trying to prepare the checkout page. Please "
@@ -346,6 +347,18 @@ msgid "Change password for %s"
 msgstr "Change password for %s"
 
 #, php-format
+msgid "Change(s) of %s have been approved and saved!"
+msgstr "Change(s) of %s have been approved and saved!"
+
+#, php-format
+msgid "Change(s) of %s have been rejected!"
+msgstr "Change(s) of %s have been rejected!"
+
+#, php-format
+msgid "Change(s) of %s have been saved!"
+msgstr "Change(s) of %s have been saved!"
+
+#, php-format
 msgid ""
 "Check out the website of Ada Alumni <a href=\"//%s\" target=\"_blank\">here</"
 "a>."
@@ -376,6 +389,26 @@ msgstr "Controller"
 
 msgid "Copy Decision"
 msgstr "Copy Decision"
+
+#, php-format
+msgid "Could not add new %s!"
+msgstr "Could not add new %s!"
+
+#, php-format
+msgid "Could not delete %s!"
+msgstr "Could not delete %s!"
+
+#, php-format
+msgid "Could not find %s!"
+msgstr "Could not find %s!"
+
+#, php-format
+msgid "Could not reject change(s) of %s!"
+msgstr "Could not reject change(s) of %s!"
+
+#, php-format
+msgid "Could not save change(s) of %s!"
+msgstr "Could not save change(s) of %s!"
 
 msgid "Create API principal"
 msgstr "Create API principal"
@@ -1143,6 +1176,14 @@ msgstr "Study"
 msgid "Subscribe"
 msgstr "Subscribe"
 
+#, php-format
+msgid "Succesfully created %s!"
+msgstr "Succesfully created %s!"
+
+#, php-format
+msgid "Succesfully deleted %s!"
+msgstr "Succesfully deleted %s!"
+
 msgid "Supremum"
 msgstr "Supremum"
 
@@ -1162,12 +1203,6 @@ msgstr "TU/e username"
 #, php-format
 msgid "Thank you %s!"
 msgstr "Thank you %s!"
-
-msgid "The changes have been applied!"
-msgstr "The changes have been applied!"
-
-msgid "The changes have not been applied."
-msgstr "The changes have not been applied."
 
 msgid "The database currently only accepts logins using your GEWIS m-account."
 msgstr "The database currently only accepts logins using your GEWIS m-account."
@@ -1462,11 +1497,30 @@ msgstr ""
 msgid "You have to consent to processing your data"
 msgstr "You have to consent to processing your data"
 
+#, php-format
+msgid "Your API token is \"%s\". This value will NOT be shown again!"
+msgstr "Your API token is \"%s\". This value will NOT be shown again!"
+
 msgid "Your TU/e-username should look like sYYxxxx or YYYYxxxx."
 msgstr "Your TU/e-username should look like sYYxxxx or YYYYxxxx."
 
 msgid "as"
 msgstr "as"
+
+msgid "mailing list subscriptions"
+msgstr "mailing list subscriptions"
+
+msgid "member"
+msgstr "member"
+
+msgid "member address"
+msgstr "member address"
+
+msgid "membership expiration date"
+msgstr "membership expiration date"
+
+msgid "membership type"
+msgstr "membership type"
 
 msgid "our payment provider"
 msgstr "our payment provider"

--- a/module/Application/language/gewisdb.pot
+++ b/module/Application/language/gewisdb.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GEWISdb 6d2132f5-dirty\n"
+"Project-Id-Version: GEWISdb 609d7fdb-dirty\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-17 15:34+0100\n"
+"POT-Creation-Date: 2024-02-17 17:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,10 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 msgid "# Decisions"
+msgstr ""
+
+#, php-format
+msgid "%s has been added to %s"
 msgstr ""
 
 #, php-format
@@ -42,10 +46,13 @@ msgstr ""
 msgid "A TU/e-username should look like sYYxxxx or YYYYxxxx."
 msgstr ""
 
-msgid "API Principals"
+msgid "API Tokens"
 msgstr ""
 
-msgid "API Tokens"
+msgid "API principal"
+msgstr ""
+
+msgid "API principals"
 msgstr ""
 
 msgid "Abbreviation"
@@ -146,12 +153,6 @@ msgid "All API permissions"
 msgstr ""
 
 msgid "An error occurred"
-msgstr ""
-
-msgid "An error occurred while trying to reject the changes."
-msgstr ""
-
-msgid "An error occurred while trying to save the changes."
 msgstr ""
 
 msgid ""
@@ -322,6 +323,18 @@ msgid "Change password for %s"
 msgstr ""
 
 #, php-format
+msgid "Change(s) of %s have been approved and saved!"
+msgstr ""
+
+#, php-format
+msgid "Change(s) of %s have been rejected!"
+msgstr ""
+
+#, php-format
+msgid "Change(s) of %s have been saved!"
+msgstr ""
+
+#, php-format
 msgid ""
 "Check out the website of Ada Alumni <a href=\"//%s\" target=\"_blank\">here</"
 "a>."
@@ -349,6 +362,26 @@ msgid "Controller"
 msgstr ""
 
 msgid "Copy Decision"
+msgstr ""
+
+#, php-format
+msgid "Could not add new %s!"
+msgstr ""
+
+#, php-format
+msgid "Could not delete %s!"
+msgstr ""
+
+#, php-format
+msgid "Could not find %s!"
+msgstr ""
+
+#, php-format
+msgid "Could not reject change(s) of %s!"
+msgstr ""
+
+#, php-format
+msgid "Could not save change(s) of %s!"
 msgstr ""
 
 msgid "Create API principal"
@@ -1075,6 +1108,14 @@ msgstr ""
 msgid "Subscribe"
 msgstr ""
 
+#, php-format
+msgid "Succesfully created %s!"
+msgstr ""
+
+#, php-format
+msgid "Succesfully deleted %s!"
+msgstr ""
+
 msgid "Supremum"
 msgstr ""
 
@@ -1093,12 +1134,6 @@ msgstr ""
 
 #, php-format
 msgid "Thank you %s!"
-msgstr ""
-
-msgid "The changes have been applied!"
-msgstr ""
-
-msgid "The changes have not been applied."
 msgstr ""
 
 msgid "The database currently only accepts logins using your GEWIS m-account."
@@ -1349,10 +1384,29 @@ msgstr ""
 msgid "You have to consent to processing your data"
 msgstr ""
 
+#, php-format
+msgid "Your API token is \"%s\". This value will NOT be shown again!"
+msgstr ""
+
 msgid "Your TU/e-username should look like sYYxxxx or YYYYxxxx."
 msgstr ""
 
 msgid "as"
+msgstr ""
+
+msgid "mailing list subscriptions"
+msgstr ""
+
+msgid "member"
+msgstr ""
+
+msgid "member address"
+msgstr ""
+
+msgid "membership expiration date"
+msgstr ""
+
+msgid "membership type"
 msgstr ""
 
 msgid "our payment provider"

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-17 15:21+0100\n"
+"POT-Creation-Date: 2024-02-17 17:34+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Rink Pieters <rinkp@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -15,6 +15,10 @@ msgstr ""
 
 msgid "# Decisions"
 msgstr "# besluiten"
+
+#, php-format
+msgid "%s has been added to %s"
+msgstr "%s toegevoegd aan %s"
 
 #, php-format
 msgid "%s: %s (started in %s)"
@@ -41,11 +45,14 @@ msgstr "Er is een 404-fout opgetreden"
 msgid "A TU/e-username should look like sYYxxxx or YYYYxxxx."
 msgstr "Een TU/e-gebruikersnaam ziet er uit als sYYxxxx of als YYYYxxxx."
 
-msgid "API Principals"
-msgstr "API-gebruiker"
-
 msgid "API Tokens"
 msgstr "API-token"
+
+msgid "API principal"
+msgstr "API-gebruiker"
+
+msgid "API principals"
+msgstr "API-gebruikers"
 
 msgid "Abbreviation"
 msgstr "Afkorting"
@@ -152,12 +159,6 @@ msgstr "Alle API-rechten"
 
 msgid "An error occurred"
 msgstr "Er is een fout opgetreden"
-
-msgid "An error occurred while trying to reject the changes."
-msgstr "Er is een fout opgetreden tijdens het afwijzen van de wijzigingen."
-
-msgid "An error occurred while trying to save the changes."
-msgstr "Er is een fout opgetreden tijdens het opslaan van de wijzigingen."
 
 msgid ""
 "An error occurred while we were trying to prepare the checkout page. Please "
@@ -346,6 +347,18 @@ msgid "Change password for %s"
 msgstr "Wachtwoord voor %s wijzigen"
 
 #, php-format
+msgid "Change(s) of %s have been approved and saved!"
+msgstr "Wijzigingen van %s zijn goedgekeurd en opgeslagen!"
+
+#, php-format
+msgid "Change(s) of %s have been rejected!"
+msgstr "Wijzigingen van %s zijn afgekeurd!"
+
+#, php-format
+msgid "Change(s) of %s have been saved!"
+msgstr "Wijzigingen van %s zijn opgeslagen!"
+
+#, php-format
 msgid ""
 "Check out the website of Ada Alumni <a href=\"//%s\" target=\"_blank\">here</"
 "a>."
@@ -378,6 +391,26 @@ msgstr "Controller"
 
 msgid "Copy Decision"
 msgstr "Besluit kopiÃ«ren"
+
+#, php-format
+msgid "Could not add new %s!"
+msgstr "Kan nieuw %s niet toevoegen!"
+
+#, php-format
+msgid "Could not delete %s!"
+msgstr "Kon %s niet verwijderen!"
+
+#, php-format
+msgid "Could not find %s!"
+msgstr "Kan %s niet vinden!"
+
+#, php-format
+msgid "Could not reject change(s) of %s!"
+msgstr "Kon wijzigingen van %s niet afkeuren!"
+
+#, php-format
+msgid "Could not save change(s) of %s!"
+msgstr "Kon wijzigingen van %s niet opslaan!"
 
 msgid "Create API principal"
 msgstr "Maak API-gebruiker aan"
@@ -1151,6 +1184,14 @@ msgstr "Studie"
 msgid "Subscribe"
 msgstr "Inschrijven"
 
+#, php-format
+msgid "Succesfully created %s!"
+msgstr "Succesvol %s gemaakt!"
+
+#, php-format
+msgid "Succesfully deleted %s!"
+msgstr "%s succesvol verwijderd!"
+
 msgid "Supremum"
 msgstr "Supremum"
 
@@ -1170,12 +1211,6 @@ msgstr "TU/e-gebruikersnaam"
 #, php-format
 msgid "Thank you %s!"
 msgstr "Bedankt %s!"
-
-msgid "The changes have been applied!"
-msgstr "De wijzigingen zijn toegepast!"
-
-msgid "The changes have not been applied."
-msgstr "De wijzigingen zijn niet toegepast."
 
 msgid "The database currently only accepts logins using your GEWIS m-account."
 msgstr ""
@@ -1483,11 +1518,31 @@ msgstr "Je moet akkoord gaan met de statuten en het huishoudelijk reglement"
 msgid "You have to consent to processing your data"
 msgstr "Je moet akkoord gaan met het verwerken van je persoonlijke data"
 
+#, php-format
+msgid "Your API token is \"%s\". This value will NOT be shown again!"
+msgstr ""
+"Jouw API-sleutel is \"%s\". Deze sleutel wordt NIET opnieuw weergegeven!"
+
 msgid "Your TU/e-username should look like sYYxxxx or YYYYxxxx."
 msgstr "Jouw TU/e-gebruikersnaam moet lijken op sYYxxxx of YYYYxxxx."
 
 msgid "as"
 msgstr "als"
+
+msgid "mailing list subscriptions"
+msgstr "mailinglijst-registraties"
+
+msgid "member"
+msgstr "lid"
+
+msgid "member address"
+msgstr "lid-adres"
+
+msgid "membership expiration date"
+msgstr "einddatum lidmaatschap"
+
+msgid "membership type"
+msgstr "lidmaatschapstype"
 
 msgid "our payment provider"
 msgstr "onze betalingsprovider"

--- a/module/Database/src/Controller/MemberController.php
+++ b/module/Database/src/Controller/MemberController.php
@@ -20,6 +20,7 @@ use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 
 use function array_map;
+use function sprintf;
 
 /**
  * @method FlashMessenger flashMessenger()
@@ -264,7 +265,13 @@ class MemberController extends AbstractActionController
 
             if ($noteForm->isValid()) {
                 $this->memberService->addAuditNote($member, $noteForm);
-                $this->flashMessenger()->addSuccessMessage('Note has been added to member');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('%s has been added to %s'),
+                        $this->translator->translate('Note'),
+                        $this->translator->translate('member'),
+                    ),
+                );
 
                 return $this->redirect()->toRoute('member/show', [
                     'id' => $lidnr,
@@ -330,12 +337,22 @@ class MemberController extends AbstractActionController
             );
 
             if (null !== $updatedMember) {
-                $this->flashMessenger()->addSuccessMessage('Wijzigingen zijn opgeslagen!');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Change(s) of %s have been saved!'),
+                        $this->translator->translate('member'),
+                    ),
+                );
 
                 return $this->redirect()->toRoute('member/show', ['id' => $updatedMember->getLidnr()]);
             }
 
-            $this->flashMessenger()->addSuccessMessage('Wijzigingen kunnen niet worden opgeslagen.');
+            $this->flashMessenger()->addErrorMessage(
+                sprintf(
+                    $this->translator->translate('Could not save change(s) of %s!'),
+                    $this->translator->translate('member'),
+                ),
+            );
         }
 
         return new ViewModel($this->memberService->getMemberEditForm($member));
@@ -361,7 +378,12 @@ class MemberController extends AbstractActionController
         if ($this->getRequest()->isPost()) {
             $this->memberService->remove($member);
 
-            $this->flashMessenger()->addSuccessMessage('Het lid is succesvol verwijderd.');
+            $this->flashMessenger()->addSuccessMessage(
+                sprintf(
+                    $this->translator->translate('Succesfully deleted %s!'),
+                    $this->translator->translate('member'),
+                ),
+            );
 
             return $this->redirect()->toRoute('member');
         }
@@ -397,12 +419,22 @@ class MemberController extends AbstractActionController
             );
 
             if (null !== $member) {
-                $this->flashMessenger()->addSuccessMessage('Aanmeldingen mailinglijsten zijn opgeslagen!');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Change(s) of %s have been saved!'),
+                        $this->translator->translate('mailing list subscriptions'),
+                    ),
+                );
 
                 return $this->redirect()->toRoute('member/show', ['id' => $member->getLidnr()]);
             }
 
-            $this->flashMessenger()->addSuccessMessage('Aanmeldingen mailinglijsten kunnen niet worden opgeslagen.');
+            $this->flashMessenger()->addErrorMessage(
+                sprintf(
+                    $this->translator->translate('Could not save change(s) of %s!'),
+                    $this->translator->translate('mailing list subscriptions'),
+                ),
+            );
         }
 
         return new ViewModel($this->memberService->getListForm($member));
@@ -440,12 +472,22 @@ class MemberController extends AbstractActionController
                     $this->memberService->getActionLinkMapper()->persist($renewalLink);
                 }
 
-                $this->flashMessenger()->addSuccessMessage('Wijziging lidmaatschapstype is opgeslagen!');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Change(s) of %s have been saved!'),
+                        $this->translator->translate('membership type'),
+                    ),
+                );
 
                 return $this->redirect()->toRoute('member/show', ['id' => $member->getLidnr()]);
             }
 
-            $this->flashMessenger()->addSuccessMessage('Wijziging lidmaatschapstype kan niet worden opgeslagen.');
+            $this->flashMessenger()->addErrorMessage(
+                sprintf(
+                    $this->translator->translate('Could not save change(s) of %s!'),
+                    $this->translator->translate('membership type'),
+                ),
+            );
         }
 
         return new ViewModel([
@@ -478,12 +520,22 @@ class MemberController extends AbstractActionController
             );
 
             if (null !== $member) {
-                $this->flashMessenger()->addSuccessMessage('Nieuwe verloopdatum lidmaatschap is opgeslagen!');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Change(s) of %s have been saved!'),
+                        $this->translator->translate('membership expiration date'),
+                    ),
+                );
 
                 return $this->redirect()->toRoute('member/show', ['id' => $member->getLidnr()]);
             }
 
-            $this->flashMessenger()->addSuccessMessage('Nieuwe verloopdatum lidmaatschap kan niet worden opgeslagen.');
+            $this->flashMessenger()->addErrorMessage(
+                sprintf(
+                    $this->translator->translate('Could not save change(s) of %s!'),
+                    $this->translator->translate('membership expiration date'),
+                ),
+            );
         }
 
         return new ViewModel([
@@ -523,12 +575,22 @@ class MemberController extends AbstractActionController
             );
 
             if (null !== $address) {
-                $this->flashMessenger()->addSuccessMessage('Wijzigingen adres zijn opgeslagen!');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Change(s) of %s have been saved!'),
+                        $this->translator->translate('member address'),
+                    ),
+                );
 
                 return $this->redirect()->toRoute('member/show', ['id' => $address->getMember()->getLidnr()]);
             }
 
-            $this->flashMessenger()->addSuccessMessage('Wijzigingen adress kunnen niet worden opgeslagen.');
+            $this->flashMessenger()->addErrorMessage(
+                sprintf(
+                    $this->translator->translate('Could not save change(s) of %s!'),
+                    $this->translator->translate('member address'),
+                ),
+            );
         }
 
         $form = $this->memberService->getAddressForm($member, $type);
@@ -570,12 +632,23 @@ class MemberController extends AbstractActionController
             );
 
             if (null !== $address) {
-                $this->flashMessenger()->addSuccessMessage('Nieuw adres is opgeslagen!');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('%s has been added to %s'),
+                        $this->translator->translate('Address'),
+                        $this->translator->translate('member'),
+                    ),
+                );
 
                 return $this->redirect()->toRoute('member/show', ['id' => $address->getMember()->getLidnr()]);
             }
 
-            $this->flashMessenger()->addSuccessMessage('Nieuw address kan niet worden opgeslagen.');
+            $this->flashMessenger()->addErrorMessage(
+                sprintf(
+                    $this->translator->translate('Could not add new %s!'),
+                    $this->translator->translate('member address'),
+                ),
+            );
         }
 
         $form = $this->memberService->getAddressForm($member, $type, true);
@@ -621,12 +694,22 @@ class MemberController extends AbstractActionController
             );
 
             if (null !== $updatedMember) {
-                $this->flashMessenger()->addSuccessMessage('Adres is succesvol verwijderd!');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Succesfully deleted %s!'),
+                        $this->translator->translate('member address'),
+                    ),
+                );
 
                 return $this->redirect()->toRoute('member/show', ['id' => $updatedMember->getLidnr()]);
             }
 
-            $this->flashMessenger()->addSuccessMessage('Address kan niet worden verwijderd.');
+            $this->flashMessenger()->addErrorMessage(
+                sprintf(
+                    $this->translator->translate('Could not delete %s!'),
+                    $this->translator->translate('member address'),
+                ),
+            );
         }
 
         return new ViewModel([
@@ -725,14 +808,20 @@ class MemberController extends AbstractActionController
 
             if (null !== $member) {
                 $this->flashMessenger()->addSuccessMessage(
-                    $this->translator->translate('The changes have been applied!'),
+                    sprintf(
+                        $this->translator->translate('Change(s) of %s have been approved and saved!'),
+                        $this->translator->translate('member'),
+                    ),
                 );
 
                 return $this->redirect()->toRoute('member/updates');
             }
 
             $this->flashMessenger()->addErrorMessage(
-                $this->translator->translate('An error occurred while trying to save the changes.'),
+                sprintf(
+                    $this->translator->translate('Could not save change(s) of %s!'),
+                    $this->translator->translate('member'),
+                ),
             );
         }
 
@@ -765,14 +854,20 @@ class MemberController extends AbstractActionController
 
             if (null !== $result) {
                 $this->flashMessenger()->addInfoMessage(
-                    $this->translator->translate('The changes have not been applied.'),
+                    sprintf(
+                        $this->translator->translate('Change(s) of %s have been rejected!'),
+                        $this->translator->translate('member'),
+                    ),
                 );
 
                 return $this->redirect()->toRoute('member/updates');
             }
 
-            $this->flashMessenger()->addInfoMessage(
-                $this->translator->translate('An error occurred while trying to reject the changes.'),
+            $this->flashMessenger()->addErrorMessage(
+                sprintf(
+                    $this->translator->translate('Could not reject change(s) of %s!'),
+                    $this->translator->translate('member'),
+                ),
             );
         }
 

--- a/module/Database/src/Mapper/Audit.php
+++ b/module/Database/src/Mapper/Audit.php
@@ -25,9 +25,9 @@ class Audit
     }
 
     /**
-     * Remove a member.
+     * Remove an audit entry.
      */
-    private function remove(AuditEntryModel $entry): void
+    public function remove(AuditEntryModel $entry): void
     {
         $this->em->remove($entry);
         $this->em->flush();

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -650,6 +650,10 @@ class Member
             $this->getMemberMapper()->removeAddress($address);
         }
 
+        foreach ($member->getAuditEntries() as $auditEntry) {
+            $this->getAuditMapper()->remove($auditEntry);
+        }
+
         $date = new DateTime('0001-01-01 00:00:00');
 
         $member->setEmail(null);

--- a/module/User/src/Controller/ApiSettingsController.php
+++ b/module/User/src/Controller/ApiSettingsController.php
@@ -6,9 +6,12 @@ namespace User\Controller;
 
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\Mvc\I18n\Translator as MvcTranslator;
 use Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger;
 use Laminas\View\Model\ViewModel;
 use User\Service\ApiPrincipalService;
+
+use function sprintf;
 
 /**
  * @method FlashMessenger flashMessenger()
@@ -19,6 +22,7 @@ class ApiSettingsController extends AbstractActionController
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
      */
     public function __construct(
+        protected readonly MvcTranslator $translator,
         protected readonly ApiPrincipalService $apiPrincipalService,
         protected readonly array $config,
     ) {
@@ -45,9 +49,17 @@ class ApiSettingsController extends AbstractActionController
             $result = $this->apiPrincipalService->create($this->getRequest()->getPost()->toArray());
 
             if (false !== $result) {
-                $this->flashMessenger()->addSuccessMessage('Succesfully created API principal');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Succesfully created %s!'),
+                        $this->translator->translate('API principal'),
+                    ),
+                );
                 $this->flashMessenger()->addInfoMessage(
-                    'Your API token is "' . $result->getFullToken() . '". This value will NOT be shown again',
+                    sprintf(
+                        $this->translator->translate('Your API token is "%s". This value will NOT be shown again!'),
+                        $result->getFullToken(),
+                    ),
                 );
 
                 return $this->redirectList();
@@ -75,7 +87,12 @@ class ApiSettingsController extends AbstractActionController
             $result = $this->apiPrincipalService->edit($principal, $this->getRequest()->getPost()->toArray());
 
             if ($result) {
-                $this->flashMessenger()->addSuccessMessage('Succesfully updated API principal');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Change(s) of %s have been saved!'),
+                        $this->translator->translate('API principal'),
+                    ),
+                );
 
                 return $this->redirectList();
             }
@@ -93,7 +110,12 @@ class ApiSettingsController extends AbstractActionController
             $result = $this->apiPrincipalService->remove((int) $this->params()->fromRoute('id'));
 
             if ($result) {
-                $this->flashMessenger()->addSuccessMessage('Succesfully removed API principal');
+                $this->flashMessenger()->addSuccessMessage(
+                    sprintf(
+                        $this->translator->translate('Succesfully deleted %s!'),
+                        $this->translator->translate('API principal'),
+                    ),
+                );
             }
         }
 
@@ -107,7 +129,12 @@ class ApiSettingsController extends AbstractActionController
 
     public function notFoundAction(): Response
     {
-        $this->flashMessenger()->addWarningMessage('Could not find requested API principal');
+        $this->flashMessenger()->addWarningMessage(
+            sprintf(
+                $this->translator->translate('Could not find %s!'),
+                $this->translator->translate('API principal'),
+            ),
+        );
 
         return $this->redirectList();
     }

--- a/module/User/src/Controller/Factory/ApiSettingsControllerFactory.php
+++ b/module/User/src/Controller/Factory/ApiSettingsControllerFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace User\Controller\Factory;
 
+use Laminas\Mvc\I18n\Translator as MvcTranslator;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 use User\Controller\ApiSettingsController;
@@ -20,6 +21,7 @@ class ApiSettingsControllerFactory implements FactoryInterface
         ?array $options = null,
     ): ApiSettingsController {
         return new ApiSettingsController(
+            $container->get(MvcTranslator::class),
             $container->get(ApiPrincipalService::class),
             $container->get('config'),
         );

--- a/module/User/view/user/api-settings/list-principals.phtml
+++ b/module/User/view/user/api-settings/list-principals.phtml
@@ -9,7 +9,7 @@ $translator = $this->plugin('translate')->getTranslator();
 
 /** @var PhpRenderer|HelperTrait $this */
 ?>
-<h1><?= $this->translate('API Principals') ?></h1>
+<h1><?= $this->translate('API principals') ?></h1>
 
 <table class="table">
     <thead>


### PR DESCRIPTION
Fixes GH-369, deleting audit entries upon clear of member
Fixes GH-377, now translates flash messenger messages while keeping the number of translation strings low