### PR TITLE
Implement audit logs for renewal

### DIFF
--- a/module/Database/src/Controller/Factory/MemberControllerFactory.php
+++ b/module/Database/src/Controller/Factory/MemberControllerFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Database\Controller\Factory;
 
 use Checker\Service\Checker as CheckerService;
-use Checker\Service\Renewal as RenewalService;
 use Database\Controller\MemberController;
 use Database\Service\Member as MemberService;
 use Database\Service\Stripe as StripeService;
@@ -31,15 +30,12 @@ class MemberControllerFactory implements FactoryInterface
         $memberService = $container->get(MemberService::class);
         /** @var StripeService $stripeService */
         $stripeService = $container->get(StripeService::class);
-        /** @var RenewalService $renewalService */
-        $renewalService = $container->get(RenewalService::class);
 
         return new MemberController(
             $translator,
             $checkerService,
             $memberService,
             $stripeService,
-            $renewalService,
         );
     }
 }

--- a/module/Database/src/Controller/MemberController.php
+++ b/module/Database/src/Controller/MemberController.php
@@ -6,11 +6,9 @@ namespace Database\Controller;
 
 use Application\Model\Enums\AddressTypes;
 use Checker\Service\Checker as CheckerService;
-use Checker\Service\Renewal as RenewalService;
 use Database\Model\Member as MemberModel;
 use Database\Service\Member as MemberService;
 use Database\Service\Stripe as StripeService;
-use DateTime;
 use Laminas\Http\Header\HeaderInterface;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
@@ -32,7 +30,6 @@ class MemberController extends AbstractActionController
         private readonly CheckerService $checkerService,
         private readonly MemberService $memberService,
         private readonly StripeService $stripeService,
-        private readonly RenewalService $renewalService,
     ) {
     }
 
@@ -188,11 +185,8 @@ class MemberController extends AbstractActionController
             } elseif ($form->isValid()) {
                 /** @var MemberModel $updatedMember */
                 $updatedMember = $form->getData();
-                $updatedMember->setChangedOn(new DateTime());
-                $this->memberService->getMemberMapper()->persist($updatedMember);
-                $form->getRenewalLink()->setUsed(true);
-                $this->memberService->getActionLinkMapper()->persist($form->getRenewalLink());
-                $this->renewalService->sendRenewalSuccessEmail($form->getRenewalLink());
+                $renewalLink = $form->getRenewalLink();
+                $this->memberService->renewMember($updatedMember, $renewalLink);
 
                 return new ViewModel([
                     'updatedMember' => $updatedMember,

--- a/module/Database/src/Model/AuditEntry.php
+++ b/module/Database/src/Model/AuditEntry.php
@@ -36,6 +36,7 @@ use function strip_tags;
 #[DiscriminatorMap(
     value: [
         'note' => AuditNote::class,
+        'renewal' => AuditRenewal::class,
     ],
 )]
 abstract class AuditEntry
@@ -119,7 +120,7 @@ abstract class AuditEntry
 
     public function setMember(Member $member): void
     {
-        if (null !== $this->member) {
+        if (null !== $this->member && $this->member !== $member) {
             throw new LogicException('Must not link an audit entry to another object after creation');
         }
 

--- a/module/Database/src/Model/AuditRenewal.php
+++ b/module/Database/src/Model/AuditRenewal.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Model;
+
+use DateTime;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\JoinColumn;
+
+/**
+ * Class for registering renewals by the member or another user
+ */
+#[Entity]
+#[AssociationOverrides([
+    new AssociationOverride(
+        name: 'member',
+        joinColumns: new JoinColumn(
+            name: 'member',
+            referencedColumnName: 'lidnr',
+            onDelete: 'cascade',
+            nullable: false,
+        ),
+    ),
+])]
+class AuditRenewal extends AuditEntry
+{
+    /** @psalm-suppress InvalidClassConstantType */
+    protected bool $IMMUTABLE = true;
+
+    /**
+     * Expiration value before this renewal took place
+     */
+    #[Column(type: 'datetime')]
+    protected DateTime $oldExpiration;
+
+    /**
+     * Expiration value after the renewal
+     */
+    #[Column(type: 'datetime')]
+    protected DateTime $newExpiration;
+
+    final public static function fromRenewalLink(RenewalLink $renewalLink): AuditRenewal
+    {
+        $auditRenewal = new AuditRenewal();
+        $auditRenewal->setOldExpiration($renewalLink->getCurrentExpiration());
+        $auditRenewal->setNewExpiration($renewalLink->getNewExpiration());
+        $auditRenewal->setMember($renewalLink->getMember());
+
+        return $auditRenewal;
+    }
+
+    /**
+     * Get the old expiration date.
+     */
+    public function getOldExpiration(): DateTime
+    {
+        return $this->oldExpiration;
+    }
+
+    /**
+     * Set the old expiration date.
+     */
+    public function setOldExpiration(DateTime $oldExpiration): void
+    {
+        $this->newExpiration = $oldExpiration;
+    }
+
+    /**
+     * Get the new expiration date.
+     */
+    public function getNewExpiration(): DateTime
+    {
+        return $this->newExpiration;
+    }
+
+    /**
+     * Set the new expiration date.
+     */
+    public function setNewExpiration(DateTime $newExpiration): void
+    {
+        $this->newExpiration = $newExpiration;
+    }
+
+    /**
+     * Check if the renewal was done by the member
+     */
+    protected function isSelfRenewal(): bool
+    {
+        return null === $this->user;
+    }
+
+    protected function getStringRenewalType(): string
+    {
+        return $this->isSelfRenewal() ? 'Self-renewal' : 'Renewal';
+    }
+
+    /**
+     * Get a textual representation of this audit entry
+     */
+    protected function getStringBodyFormatted(): string
+    {
+        return '<strong>%s</strong> of <emph>%s</emph> until <br/>%s';
+    }
+
+    /**
+     * @return array<?string>
+     */
+    protected function getStringArguments(): array
+    {
+        return [
+            $this->getStringRenewalType(),
+            $this->getMember()->getFullName(),
+            $this->getNewExpiration()->format('l j F Y'),
+        ];
+    }
+}

--- a/module/Database/src/Service/Factory/MemberFactory.php
+++ b/module/Database/src/Service/Factory/MemberFactory.php
@@ -6,6 +6,7 @@ namespace Database\Service\Factory;
 
 use Application\Service\FileStorage as FileStorageService;
 use Checker\Service\Checker as CheckerService;
+use Checker\Service\Renewal as RenewalService;
 use Database\Form\Address as AddressForm;
 use Database\Form\AuditEntry\AuditNote as AuditNoteForm;
 use Database\Form\DeleteAddress as DeleteAddressForm;
@@ -78,6 +79,8 @@ class MemberFactory implements FactoryInterface
         $fileStorageService = $container->get(FileStorageService::class);
         /** @var MailingListService $mailingListService */
         $mailingListService = $container->get(MailingListService::class);
+        /** @var RenewalService $renewalService */
+        $renewalService = $container->get(RenewalService::class);
         /** @var UserService $userService */
         $userService = $container->get(UserService::class);
         /** @var PhpRenderer $viewRenderer */
@@ -107,6 +110,7 @@ class MemberFactory implements FactoryInterface
             $checkerService,
             $fileStorageService,
             $mailingListService,
+            $renewalService,
             $userService,
             $viewRenderer,
             $mailTransport,

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -10,6 +10,7 @@ use Application\Service\FileStorage as FileStorageService;
 use Checker\Model\Exception\LookupException;
 use Checker\Model\TueData;
 use Checker\Service\Checker as CheckerService;
+use Checker\Service\Renewal as RenewalService;
 use Database\Form\Address as AddressForm;
 use Database\Form\AuditEntry\AuditNote as AuditNoteForm;
 use Database\Form\DeleteAddress as DeleteAddressForm;
@@ -27,12 +28,15 @@ use Database\Mapper\Member as MemberMapper;
 use Database\Mapper\MemberUpdate as MemberUpdateMapper;
 use Database\Mapper\ProspectiveMember as ProspectiveMemberMapper;
 use Database\Model\Address as AddressModel;
+use Database\Model\AuditEntry as AuditEntryModel;
 use Database\Model\AuditNote as AuditNoteModel;
+use Database\Model\AuditRenewal as AuditRenewalModel;
 use Database\Model\MailingList as MailingListModel;
 use Database\Model\Member as MemberModel;
 use Database\Model\MemberUpdate as MemberUpdateModel;
 use Database\Model\PaymentLink;
 use Database\Model\ProspectiveMember as ProspectiveMemberModel;
+use Database\Model\RenewalLink as RenewalLinkModel;
 use Database\Service\MailingList as MailingListService;
 use DateTime;
 use InvalidArgumentException;
@@ -79,6 +83,7 @@ class Member
         private readonly CheckerService $checkerService,
         private readonly FileStorageService $fileStorageService,
         private readonly MailingListService $mailingListService,
+        private readonly RenewalService $renewalService,
         private readonly UserService $userService,
         private readonly PhpRenderer $viewRenderer,
         private readonly TransportInterface $mailTransport,
@@ -163,12 +168,6 @@ class Member
         if (!in_array($type, ['registration', 'welcome', 'checkout-expired', 'checkout-failed', 'refund-created'])) {
             throw new InvalidArgumentException('Unknown email type for prospective member.');
         }
-
-        // Define here to appease the checkers for "possibly undefined variables". Because of the `!in_array()` these
-        // are guaranteed to be changed.
-        $template = '';
-        $subjectProspectiveMember = '';
-        $subjectSecretary = '';
 
         switch ($type) {
             case 'registration':
@@ -936,12 +935,21 @@ class Member
 
         /** @var AuditNoteModel $auditNote */
         $auditNote = $form->getData();
-        $auditNote->setMember($member);
         $auditNote->setUser($this->userService->getIdentity());
 
-        $this->getAuditMapper()->persist($auditNote);
+        $this->addAuditEntry($member, $auditNote);
 
         return $auditNote;
+    }
+
+    private function addAuditEntry(
+        MemberModel $member,
+        AuditEntryModel $auditEntry,
+    ): AuditEntryModel {
+        $auditEntry->setMember($member);
+        $this->getAuditMapper()->persist($auditEntry);
+
+        return $auditEntry;
     }
 
     /**
@@ -1202,6 +1210,26 @@ class Member
         $form->setRenewalLink($renewalLink);
 
         return $form;
+    }
+
+    /**
+     * Renew a member, assumes that the expiry date has already been set
+     */
+    public function renewMember(
+        MemberModel $member,
+        RenewalLinkModel $renewalLink,
+    ): MemberModel {
+        $member->setChangedOn(new DateTime());
+        $this->getMemberMapper()->persist($member);
+        $renewalLink->setUsed(true);
+        $this->getActionLinkMapper()->persist($renewalLink);
+        $this->renewalService->sendRenewalSuccessEmail($renewalLink);
+
+        // Record a renewal audit entry
+        $renewalAudit = AuditRenewalModel::fromRenewalLink($renewalLink);
+        $this->addAuditEntry($member, $renewalAudit);
+
+        return $member;
     }
 
     /**

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -733,6 +733,10 @@ class Member
         $date->setTime(0, 0);
         $member->setChangedOn($date);
 
+        // Record a renewal audit entry
+        $renewalAudit = new AuditRenewalModel();
+        $renewalAudit->setOldExpiration($member->getExpiration());
+
         // update expiration and 'membership ends on' date (should become effective at the end of the previous
         // association year).
         $expiration = clone $date;
@@ -776,6 +780,10 @@ class Member
         // At the end of the current association year.
         $expiration->setDate($year, 7, 1);
         $member->setExpiration($expiration);
+
+        $renewalAudit->setNewExpiration($member->getExpiration());
+        $renewalAudit->setUser($this->userService->getIdentity());
+        $this->addAuditEntry($member, $renewalAudit);
 
         $this->getMemberMapper()->persist($member);
 


### PR DESCRIPTION
Fixes GH-381

Tested cases:
- Set expiry date of member to April 1st, generate renewal link
Renew member through form. A self-renewal is logged
- Change membership type of member by the secretary
A renewal is logged