### PR TITLE
Clarify what will happen to existing organ membership during graduate renewal

### DIFF
--- a/module/Checker/src/Service/Factory/RenewalFactory.php
+++ b/module/Checker/src/Service/Factory/RenewalFactory.php
@@ -11,6 +11,7 @@ use Database\Mapper\ActionLink as ActionLinkMapper;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Renderer\PhpRenderer;
 use Psr\Container\ContainerInterface;
+use Report\Mapper\Member as ReportMemberMapper;
 
 class RenewalFactory implements FactoryInterface
 {
@@ -27,6 +28,7 @@ class RenewalFactory implements FactoryInterface
         return new RenewalService(
             $container->get(ActionLinkMapper::class),
             $container->get(MemberMapper::class),
+            $container->get(ReportMemberMapper::class),
             $container->get(EmailService::class),
             $container->get(PhpRenderer::class),
             $config,

--- a/module/Checker/view/email/graduate-renewal.phtml
+++ b/module/Checker/view/email/graduate-renewal.phtml
@@ -7,8 +7,14 @@
     Please click <a href="<?= $url ?>" style="color: #C40000; text-decoration: none;" target="_blank" rel="noopener nofollow">here</a> to review your personal details and renew your status as graduate of GEWIS until <b><?= $newExpiration->format('F jS, Y') ?></b>.
     If you do not click this link, your status will automatically expire and we will delete your data in the way described in our <a href="https://gewis.nl/association/regulations/privacy-statement" style="color: #C40000; text-decoration: none;" target="_blank" rel="noopener nofollow">privacy statement</a>.
 </p>
+<? if ($isInstalled): ?>
 <p>
-    If you prefer this, you can also renew your membership by replying to this email.
+    <span style="font-weight: bold;">Please note:</span> you are currently an (in)active member of one or more committees/fraternities.
+    If you do not renew your status, those memberships will end on <?= $currentExpiration->format('F jS, Y') ?>. 
+</p>
+<? endif; ?>
+<p>
+    If you prefer this, you can also renew your graduate status by replying to this email.
     Please keep the subject intact so we can process it more efficiently.
 </p>
 <p>


### PR DESCRIPTION
I thought about recreating the functionality that we have in `Report`. I decided against it to make sure we have a consistent definition. The alternative is to use the `getActiveMembers` function from https://github.com/GEWIS/gewisdb/blob/4d43d794fe36d3d9abfc6ef5f697d48254295aa4/module/Checker/src/Service/Installation.php#L76 but that would require either passing this information through OR obtaining the whole list for each email.

@tomudding, could you do a review

@SvenMokveldje, please approve the textual changes

![example active](https://github.com/GEWIS/gewisdb/assets/17340320/ce07cff1-5814-423e-be47-29030c59479e)

![example inactive](https://github.com/GEWIS/gewisdb/assets/17340320/5419775f-49f2-48b3-8d7b-fab83725c0e2)
