### PR TITLE
API changes to health endpoint

### DIFF
--- a/module/Database/config/module.config.php
+++ b/module/Database/config/module.config.php
@@ -650,6 +650,16 @@ return [
                 ],
                 'may_terminate' => true,
                 'child_routes' => [
+                    'health' => [
+                        'type' => Literal::class,
+                        'options' => [
+                            'route' => '/health',
+                            'defaults' => [
+                                'controller' => ApiController::class,
+                                'action' => 'healthy',
+                            ],
+                        ],
+                    ],
                     'members' => [
                         'type' => Literal::class,
                         'options' => [

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -28,7 +28,7 @@ class ApiController extends AbstractActionController
     {
         $this->apiAuthService->assertCan(ApiPermissions::HealthR);
 
-        return new JsonModel(['healthy' => true]);
+        return new JsonModel(['healthy' => true, 'sync_paused' => false]);
     }
 
     /**

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,6 +33,26 @@ paths:
     get:
       summary: Health endpoint
       description: This endpoint will return the health status of the API
+      deprecated: true
+      tags:
+        - basic
+      responses:
+        200:
+          description: Successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/health'
+        403:
+          $ref: '#/components/responses/no_permission'
+      security:
+        - api_auth:
+            - HealthR
+            
+  /health:
+    get:
+      summary: Health endpoint
+      description: This endpoint will return the health status of the API and whether client applications are requested to temporarily pause their synchronisation.
       tags:
         - basic
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -170,6 +170,10 @@ components:
       properties:
         healthy:
           type: boolean
+        sync_paused:
+          type: boolean
+          default: false
+          description: Attribute to indicate that data is currently being modified and that client applications that perform syncs in the background are requested to temporarily suspend this sync.
     MemberSimple:
       type: object
       required:


### PR DESCRIPTION
* Add sync paused stub to health endpoint<br/>This allows us to later request external applications to temporarily suspend syncing when the secretary is making changes
* Change `/api` to `/api/health` for automatic route generation based on the openapi specification. Deprecate the previous endpoint but keep it working for now. Requested by @JustSamuel