### PR TITLE
Implement dynamic configuration service

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Application;
+
 use Application\Controller\IndexController;
 use Application\View\Helper\BootstrapElementError;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Laminas\I18n\Translator\Resources;
 use Laminas\Router\Http\Segment;
 use User\Listener\AuthenticationListener;
@@ -76,6 +79,21 @@ return [
     'view_helpers' => [
         'invokables' => [
             'bootstrapElementError' => BootstrapElementError::class,
+        ],
+    ],
+    'doctrine' => [
+        'driver' => [
+            __NAMESPACE__ . '_driver' => [
+                'class' => AttributeDriver::class,
+                'paths' => [
+                    __DIR__ . '/../src/Model/',
+                ],
+            ],
+            'orm_default' => [
+                'drivers' => [
+                    __NAMESPACE__ . '\Model' => __NAMESPACE__ . '_driver',
+                ],
+            ],
         ],
     ],
 ];

--- a/module/Application/src/Mapper/ConfigItem.php
+++ b/module/Application/src/Mapper/ConfigItem.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Mapper;
+
+use Application\Model\ConfigItem as ConfigItemModel;
+use Application\Model\Enums\ConfigNamespaces;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+
+class ConfigItem
+{
+    public function __construct(protected readonly EntityManager $em)
+    {
+    }
+
+    public function findByKey(
+        ConfigNamespaces $namespace,
+        string $key,
+    ): ?ConfigItemModel {
+        $qb = $this->getRepository()->createQueryBuilder('ci');
+        $qb->where('ci.namespace = :namespace')
+            ->andWhere('ci.key = :key');
+
+        $qb->setParameter('namespace', $namespace);
+        $qb->setParameter('key', $key);
+
+        return $qb->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * Persist configuration.
+     */
+    public function persist(ConfigItemModel $item): void
+    {
+        $this->em->persist($item);
+        $this->em->flush();
+    }
+
+    /**
+     * Remove configuration.
+     */
+    public function remove(ConfigItemModel $item): void
+    {
+        $this->em->remove($item);
+        $this->em->flush();
+    }
+
+    /**
+     * Get the repository for this mapper.
+     */
+    private function getRepository(): EntityRepository
+    {
+        return $this->em->getRepository(ConfigItemModel::class);
+    }
+}

--- a/module/Application/src/Mapper/Factory/ConfigItemFactory.php
+++ b/module/Application/src/Mapper/Factory/ConfigItemFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Mapper\Factory;
+
+use Application\Mapper\ConfigItem as ConfigItemMapper;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class ConfigItemFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): ConfigItemMapper {
+        return new ConfigItemMapper($container->get('database_doctrine_em'));
+    }
+}

--- a/module/Application/src/Model/ConfigItem.php
+++ b/module/Application/src/Model/ConfigItem.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model;
+
+use Application\Model\Enums\ConfigNamespaces;
+use Database\Model\Trait\CreatedTrait;
+use Database\Model\Trait\UpdatedTrait;
+use DateTime;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\HasLifecycleCallbacks;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\PrePersist;
+use Doctrine\ORM\Mapping\PreUpdate;
+use Doctrine\ORM\Mapping\UniqueConstraint;
+use LogicException;
+use TypeError;
+
+use function is_string;
+
+/**
+ * Runtime configuration items model.
+ */
+#[Entity]
+#[HasLifecycleCallbacks]
+#[UniqueConstraint(
+    name: 'configitem_unique_idx',
+    columns: ['namespace', 'key'],
+)]
+class ConfigItem
+{
+    use CreatedTrait;
+    use UpdatedTrait;
+
+    /**
+     * Primary key item ID (to avoid reference issues).
+     */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
+    protected ?int $id = null;
+
+    /**
+     * Namespace
+     */
+    #[Column(
+        type: 'string',
+        enumType: ConfigNamespaces::class,
+    )]
+    protected ConfigNamespaces $namespace;
+
+    /**
+     * Configuration item key.
+     * Configuration item keys are in snake_case.
+     */
+    #[Column(type: 'string')]
+    protected string $key;
+
+    /**
+     * If the item is a string, its value.
+     */
+    #[Column(
+        type: 'string',
+        nullable: true,
+    )]
+    protected ?string $valueString = null;
+
+    /**
+     * If the item is a DateTime, its value.
+     */
+    #[Column(
+        type: 'datetime',
+        nullable: true,
+    )]
+    protected ?DateTime $valueDate = null;
+
+    #[PrePersist]
+    #[PreUpdate]
+    public function assertValid(): void
+    {
+        if (null !== $this->valueDate xor null !== $this->valueString) {
+            return;
+        }
+
+        throw new LogicException();
+    }
+
+    /**
+     * Set the namespace and key of the configuration item.
+     */
+    public function setKey(
+        ConfigNamespaces $namespace,
+        string $key,
+    ): void {
+        $this->namespace = $namespace;
+        $this->key = $key;
+    }
+
+    /**
+     * Set the value of the configuration item.
+     */
+    public function setValue(string|DateTime $value): void
+    {
+        if ($value instanceof DateTime) {
+            $this->valueString = null;
+            $this->valueDate = $value;
+        } elseif (is_string($value)) {
+            $this->valueString = $value;
+            $this->valueDate = null;
+        } else {
+            throw new TypeError();
+        }
+    }
+
+    public function getValue(): string|DateTime|null
+    {
+        if (null !== $this->valueDate) {
+            return $this->valueDate;
+        }
+
+        if (null !== $this->valueString) {
+            return $this->valueString;
+        }
+
+        return null;
+    }
+}

--- a/module/Application/src/Model/Enums/ConfigNamespaces.php
+++ b/module/Application/src/Model/Enums/ConfigNamespaces.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model\Enums;
+
+/**
+ * The different namespaces in which configuration items can be created.
+ * As a rule of thumb, a namespace should be restricted to one service or a welldefined set of a few services.
+ *
+ * Ideally these namespaces are defined inside the respective modules, but defining them as an enum allows for
+ * verification in IDEs.
+ */
+enum ConfigNamespaces: string
+{
+    /* Database module */
+    case DatabaseApi = 'database_api';
+}

--- a/module/Application/src/Module.php
+++ b/module/Application/src/Module.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Application;
 
+use Application\Mapper\ConfigItem as ConfigItemMapper;
+use Application\Mapper\Factory\ConfigItemFactory as ConfigItemMapperFactory;
+use Application\Service\Config as ConfigService;
 use Application\Service\Email as EmailService;
+use Application\Service\Factory\ConfigFactory as ConfigServiceFactory;
 use Application\Service\Factory\EmailFactory as EmailServiceFactory;
 use Application\Service\Factory\FileStorageFactory as FileStorageServiceFactory;
 use Application\Service\FileStorage as FileStorageService;
@@ -46,7 +50,6 @@ class Module
 
         $locale = $this->determineLocale($e);
 
-        /** @var MvcTranslator $mvcTranslator */
         $mvcTranslator = $e->getApplication()->getServiceManager()->get(MvcTranslator::class);
         $translator = $mvcTranslator->getTranslator();
         if ($translator instanceof I18nTranslator) {
@@ -119,6 +122,8 @@ class Module
     {
         return [
             'factories' => [
+                ConfigItemMapper::class => ConfigItemMapperFactory::class,
+                ConfigService::class => ConfigServiceFactory::class,
                 EmailService::class => EmailServiceFactory::class,
                 FileStorageService::class => FileStorageServiceFactory::class,
                 'application_mail_transport' => static function (ContainerInterface $container) {

--- a/module/Application/src/Service/Config.php
+++ b/module/Application/src/Service/Config.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service;
+
+use Application\Mapper\ConfigItem as ConfigItemMapper;
+use Application\Model\ConfigItem as ConfigItemModel;
+use Application\Model\Enums\ConfigNamespaces;
+use DateTime;
+
+class Config
+{
+    public function __construct(private readonly ConfigItemMapper $configItemMapper)
+    {
+    }
+
+    public function getConfig(
+        ConfigNamespaces $namespace,
+        string $key,
+        string|DateTime|null $default = null,
+    ): string|DateTime|null {
+        $configItem = $this->getConfigItemMapper()->findByKey($namespace, $key);
+
+        if (null === $configItem || null === $configItem->getValue()) {
+            return $default;
+        }
+
+        return $configItem->getValue();
+    }
+
+    public function setConfig(
+        ConfigNamespaces $namespace,
+        string $key,
+        string|DateTime $value,
+    ): void {
+        $configItem = $this->getConfigItemMapper()->findByKey($namespace, $key);
+
+        if (null === $configItem) {
+            $configItem = new ConfigItemModel();
+            $configItem->setKey($namespace, $key);
+        }
+
+        $configItem->setValue($value);
+        $this->getConfigItemMapper()->persist($configItem);
+    }
+
+    public function unsetConfig(
+        ConfigNamespaces $namespace,
+        string $key,
+    ): void {
+        $configItem = $this->getConfigItemMapper()->findByKey($namespace, $key);
+
+        if (null === $configItem) {
+            return;
+        }
+
+        $this->getConfigItemMapper()->remove($configItem);
+    }
+
+    /**
+     * Get the member mapper.
+     */
+    private function getConfigItemMapper(): ConfigItemMapper
+    {
+        return $this->configItemMapper;
+    }
+}

--- a/module/Application/src/Service/Factory/ConfigFactory.php
+++ b/module/Application/src/Service/Factory/ConfigFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Service\Factory;
+
+use Application\Mapper\ConfigItem as ConfigItemMapper;
+use Application\Service\Config as ConfigService;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class ConfigFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): ConfigService {
+        $configItemMapper = $container->get(ConfigItemMapper::class);
+
+        return new ConfigService($configItemMapper);
+    }
+}

--- a/module/Checker/config/module.config.php
+++ b/module/Checker/config/module.config.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Checker;
+
 use Checker\Command\CheckAuthenticationKeysCommand;
 use Checker\Command\CheckDatabaseCommand;
 use Checker\Command\CheckDischargesCommand;

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Database\Controller;
 
+use Application\Model\Enums\ConfigNamespaces;
+use Application\Service\Config as ConfigService;
 use Database\Service\Api as ApiService;
+use DateTime;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
@@ -18,6 +21,7 @@ class ApiController extends AbstractActionController
     public function __construct(
         private readonly ApiService $apiService,
         private readonly ApiAuthenticationService $apiAuthService,
+        private readonly ConfigService $configService,
     ) {
     }
 
@@ -28,7 +32,10 @@ class ApiController extends AbstractActionController
     {
         $this->apiAuthService->assertCan(ApiPermissions::HealthR);
 
-        return new JsonModel(['healthy' => true, 'sync_paused' => false]);
+        $syncPausedUntil = $this->configService->getConfig(ConfigNamespaces::DatabaseApi, 'sync_paused');
+        $syncPaused = $syncPausedUntil > new DateTime();
+
+        return new JsonModel(['healthy' => true, 'sync_paused' => $syncPaused]);
     }
 
     /**

--- a/module/Database/src/Controller/Factory/ApiControllerFactory.php
+++ b/module/Database/src/Controller/Factory/ApiControllerFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Controller\Factory;
 
+use Application\Service\Config as ConfigService;
 use Database\Controller\ApiController;
 use Database\Service\Api as ApiService;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -20,13 +21,14 @@ class ApiControllerFactory implements FactoryInterface
         $requestedName,
         ?array $options = null,
     ): ApiController {
-        /** @var ApiService $apiService */
         $apiService = $container->get(ApiService::class);
         $apiAuthService = $container->get(ApiAuthenticationService::class);
+        $configService = $container->get(ConfigService::class);
 
         return new ApiController(
             $apiService,
             $apiAuthService,
+            $configService,
         );
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,6 +30,8 @@
     <!-- Type hints that cannot converted to native types due to signature of parent -->
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
         <!-- Factories -->
+        <exclude-pattern>module/Application/src/Mapper/Factory/ConfigItemFactory.php</exclude-pattern>
+        <exclude-pattern>module/Application/src/Service/Factory/ConfigFactory.php</exclude-pattern>
         <exclude-pattern>module/Application/src/Service/Factory/EmailFactory.php</exclude-pattern>
         <exclude-pattern>module/Application/src/Service/Factory/FileStorageFactory.php</exclude-pattern>
         <exclude-pattern>module/Checker/src/Command/Factory/AbstractCheckerCommandFactory.php</exclude-pattern>


### PR DESCRIPTION
For some features, such as the one requested in GH-389, it is preferable if we can store a dynamic configuration through the database engine. This PR introduces a configuration service.

Reading config and default values has been implemented in the API health endpoint. Setting and unsetting is never used, but useful for testing: 
```php
$this->configService->setConfig(ConfigNamespaces::DatabaseApi, 'sync_paused', new DateTime());

$this->configService->unsetConfig(ConfigNamespaces::DatabaseApi, 'sync_paused');
```