### PR TITLE
Add non-official translations for all decisions

### DIFF
--- a/module/Application/src/Model/Enums/OrganTypes.php
+++ b/module/Application/src/Model/Enums/OrganTypes.php
@@ -27,4 +27,16 @@ enum OrganTypes: string
             self::RvA => 'RvA',
         };
     }
+
+    public function getAlternativeName(): string
+    {
+        return match ($this) {
+            self::Committee => 'Committee',
+            self::AVC => 'GMM Committee',
+            self::Fraternity => 'Fraternity',
+            self::KCC => 'Financial Audit Committee',
+            self::AVW => 'GMM Taskforce',
+            self::RvA => 'Advisory Board',
+        };
+    }
 }

--- a/module/Database/src/Model/Decision.php
+++ b/module/Database/src/Model/Decision.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 
 use function implode;
+use function sprintf;
 
 /**
  * Decision model.
@@ -218,6 +219,26 @@ class Decision
         return null !== $this->destroyedby;
     }
 
+    /**
+     * Get the string ("hash") that uniquely identifies this decision.
+     *
+     * Referencing a decision should always happen through this and only this identifier (or a variation thereof). No
+     * alternative version is provided (in contrast to the contents of this decision).
+     */
+    public function getHash(): string
+    {
+        return sprintf(
+            '%s %d.%d.%d',
+            $this->getMeetingType()->value,
+            $this->getMeetingNumber(),
+            $this->getPoint(),
+            $this->getNumber(),
+        );
+    }
+
+    /**
+     * Get the statutory content of the decision (in Dutch) by going over all subdecisions.
+     */
     public function getContent(): string
     {
         $content = [];
@@ -225,9 +246,20 @@ class Decision
             $content[] = $subdecision->getContent();
         }
 
-        $content = implode(' ', $content);
+        return implode(' ', $content);
+    }
 
-        return $content;
+    /**
+     * Get the alternative content of the subdecision (in English) by going over all subdecisions.
+     */
+    public function getAlternativeContent(): string
+    {
+        $alternativeContent = [];
+        foreach ($this->getSubdecisions() as $subdecision) {
+            $alternativeContent[] = $subdecision->getAlternativeContent();
+        }
+
+        return implode(' ', $alternativeContent);
     }
 
     /**

--- a/module/Database/src/Model/SubDecision.php
+++ b/module/Database/src/Model/SubDecision.php
@@ -30,6 +30,9 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 
+use function array_keys;
+use function str_replace;
+
 /**
  * SubDecision model.
  */
@@ -232,7 +235,44 @@ abstract class SubDecision
     }
 
     /**
-     * Get the content.
+     * Get the template string for the statutory content of the subdecision (in Dutch).
+     *
+     * Any changes to this method should also be reflected in {@see SubDecision::getAlternativeTemplate()}.
+     */
+    abstract protected function getTemplate(): string;
+
+    /**
+     * Get the template string for the alternative content of the subdecision (in English).
+     *
+     * Any changes to this method should also be reflected in {@see SubDecision::getTemplate()}.
+     */
+    abstract protected function getAlternativeTemplate(): string;
+
+    /**
+     * Perform string replacements on a template.
+     *
+     * Used in the implementations of {@see SubDecision::getContent()} and {@see SubDecision::getAlternativeContent()}.
+     *
+     * @param array<string, string> $replacements
+     */
+    protected function replaceContentPlaceholders(
+        string $template,
+        array $replacements,
+    ): string {
+        return str_replace(array_keys($replacements), $replacements, $template);
+    }
+
+    /**
+     * Get the statutory content of the subdecision (in Dutch).
+     *
+     * Any changes to this method should also be reflected in {@see SubDecision::getAlternativeContent()}.
      */
     abstract public function getContent(): string;
+
+    /**
+     * Get the alternative content of the subdecision (in English).
+     *
+     * Any changes to this method should also be reflected in {@see SubDecision::getContent()}.
+     */
+    abstract public function getAlternativeContent(): string;
 }

--- a/module/Database/src/Model/SubDecision/Abrogation.php
+++ b/module/Database/src/Model/SubDecision/Abrogation.php
@@ -12,15 +12,33 @@ use Doctrine\ORM\Mapping\Entity;
 #[Entity]
 class Abrogation extends FoundationReference
 {
-    /**
-     * Get the content.
-     *
-     * @todo implement this
-     */
+    protected function getTemplate(): string
+    {
+        return '%ORGAN_TYPE% %ORGAN_ABBR% wordt opgeheven.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return '%ORGAN_TYPE% %ORGAN_ABBR% is abrogated.';
+    }
+
     public function getContent(): string
     {
-        // <type> <abbr> wordt opgeheven.
-        return $this->getFoundation()->getOrganType()->getName() . ' '
-            . $this->getFoundation()->getAbbr() . ' wordt opgeheven.';
+        $replacements = [
+            '%ORGAN_TYPE%' => $this->getFoundation()->getOrganType()->getName(),
+            '%ORGAN_ABBR%' => $this->getFoundation()->getAbbr(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
+
+    public function getAlternativeContent(): string
+    {
+        $replacements = [
+            '%ORGAN_TYPE%' => $this->getFoundation()->getOrganType()->getAlternativeName(),
+            '%ORGAN_ABBR%' => $this->getFoundation()->getAbbr(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 }

--- a/module/Database/src/Model/SubDecision/Board/Discharge.php
+++ b/module/Database/src/Model/SubDecision/Board/Discharge.php
@@ -63,15 +63,33 @@ class Discharge extends SubDecision
         $this->installation = $installation;
     }
 
-    /**
-     * Get the content.
-     */
+    protected function getTemplate(): string
+    {
+        return '%MEMBER% wordt gedechargeerd als %FUNCTION% der s.v. GEWIS.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return '%MEMBER% is discharged as %FUNCTION% of s.v. GEWIS.';
+    }
+
     public function getContent(): string
     {
-        $member = $this->getInstallation()->getMember()->getFullName();
-        $function = $this->getInstallation()->getFunction();
+        $replacements = [
+            '%MEMBER%' => $this->getInstallation()->getMember()->getFullName(),
+            '%FUNCTION%' => $this->getInstallation()->getFunction(),
+        ];
 
-        return $member . ' wordt gedechargeerd als ' . $function
-              . ' der s.v. GEWIS.';
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
+
+    public function getAlternativeContent(): string
+    {
+        $replacements = [
+            '%MEMBER%' => $this->getInstallation()->getMember()->getFullName(),
+            '%FUNCTION%' => $this->getInstallation()->getFunction(), // Has no alternative (like the decision hash).
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 }

--- a/module/Database/src/Model/SubDecision/Board/Installation.php
+++ b/module/Database/src/Model/SubDecision/Board/Installation.php
@@ -6,6 +6,7 @@ namespace Database\Model\SubDecision\Board;
 
 use Database\Model\Member;
 use Database\Model\SubDecision;
+use Database\Model\Trait\FormattableDateTrait;
 use DateTime;
 use Doctrine\ORM\Mapping\AssociationOverride;
 use Doctrine\ORM\Mapping\AssociationOverrides;
@@ -13,10 +14,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
-use IntlDateFormatter;
 use Override;
-
-use function date_default_timezone_get;
 
 /**
  * Installation as board member.
@@ -34,6 +32,8 @@ use function date_default_timezone_get;
 ])]
 class Installation extends SubDecision
 {
+    use FormattableDateTrait;
+
     /**
      * Function in the board.
      */
@@ -105,29 +105,6 @@ class Installation extends SubDecision
     public function setDate(DateTime $date): void
     {
         $this->date = $date;
-    }
-
-    /**
-     * Format the date.
-     *
-     * returns the localized version of $date->format('d F Y')
-     *
-     * @return string Formatted date
-     */
-    protected function formatDate(
-        DateTime $date,
-        string $locale = 'nl_NL',
-    ): string {
-        $formatter = new IntlDateFormatter(
-            $locale,
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            date_default_timezone_get(),
-            null,
-            'd MMMM y',
-        );
-
-        return $formatter->format($date);
     }
 
     protected function getTemplate(): string

--- a/module/Database/src/Model/SubDecision/Board/Installation.php
+++ b/module/Database/src/Model/SubDecision/Board/Installation.php
@@ -108,29 +108,18 @@ class Installation extends SubDecision
     }
 
     /**
-     * Get the content.
-     *
-     * Fixes Bor's greatest frustration
-     */
-    public function getContent(): string
-    {
-        $member = $this->getMember()->getFullName();
-
-        return $member . ' wordt per ' . $this->formatDate($this->getDate())
-              . ' geïnstalleerd als ' . $this->getFunction() . ' der s.v. GEWIS.';
-    }
-
-    /**
      * Format the date.
      *
      * returns the localized version of $date->format('d F Y')
      *
      * @return string Formatted date
      */
-    protected function formatDate(DateTime $date): string
-    {
+    protected function formatDate(
+        DateTime $date,
+        string $locale = 'nl_NL',
+    ): string {
         $formatter = new IntlDateFormatter(
-            'nl_NL', // yes, hardcoded :D
+            $locale,
             IntlDateFormatter::NONE,
             IntlDateFormatter::NONE,
             date_default_timezone_get(),
@@ -139,5 +128,37 @@ class Installation extends SubDecision
         );
 
         return $formatter->format($date);
+    }
+
+    protected function getTemplate(): string
+    {
+        return '%MEMBER% wordt per %DATE% geïnstalleerd als %FUNCTION% der s.v. GEWIS.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return '%MEMBER% is installed as %FUNCTION% of s.v. GEWIS effective from %DATE%.';
+    }
+
+    public function getContent(): string
+    {
+        $replacements = [
+            '%MEMBER%' => $this->getMember()->getFullName(),
+            '%DATE%' => $this->formatDate($this->getDate()),
+            '%FUNCTION%' => $this->getFunction(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
+
+    public function getAlternativeContent(): string
+    {
+        $replacements = [
+            '%MEMBER%' => $this->getMember()->getFullName(),
+            '%DATE%' => $this->formatDate($this->getDate(), 'en_GB'),
+            '%FUNCTION%' => $this->getFunction(), // Has no alternative (like the decision hash).
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 }

--- a/module/Database/src/Model/SubDecision/Board/Release.php
+++ b/module/Database/src/Model/SubDecision/Board/Release.php
@@ -91,29 +91,18 @@ class Release extends SubDecision
     }
 
     /**
-     * Get the content.
-     */
-    public function getContent(): string
-    {
-        $member = $this->getInstallation()->getMember()->getFullName();
-        $function = $this->getInstallation()->getFunction();
-
-        return $member . ' wordt per ' . $this->formatDate($this->getDate())
-              . ' ontheven uit de functie van ' . $function
-              . ' der s.v. GEWIS.';
-    }
-
-    /**
      * Format the date.
      *
      * returns the localized version of $date->format('d F Y')
      *
      * @return string Formatted date
      */
-    protected function formatDate(DateTime $date): string
-    {
+    protected function formatDate(
+        DateTime $date,
+        string $locale = 'nl_NL',
+    ): string {
         $formatter = new IntlDateFormatter(
-            'nl_NL', // yes, hardcoded :D
+            $locale,
             IntlDateFormatter::NONE,
             IntlDateFormatter::NONE,
             date_default_timezone_get(),
@@ -122,5 +111,37 @@ class Release extends SubDecision
         );
 
         return $formatter->format($date);
+    }
+
+    protected function getTemplate(): string
+    {
+        return '%MEMBER% wordt per %DATE% ontheven uit de functie van %FUNCTION% der s.v. GEWIS.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return '%MEMBER% is relieved from the position of %FUNCTION% of s.v. GEWIS effective from %DATE%.';
+    }
+
+    public function getContent(): string
+    {
+        $replacements = [
+            '%MEMBER%' => $this->getInstallation()->getMember()->getFullName(),
+            '%DATE%' => $this->formatDate($this->date),
+            '%FUNCTION%' => $this->getInstallation()->getFunction(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
+
+    public function getAlternativeContent(): string
+    {
+        $replacements = [
+            '%MEMBER%' => $this->getInstallation()->getMember()->getFullName(),
+            '%DATE%' => $this->formatDate($this->date, 'en_GB'),
+            '%FUNCTION%' => $this->getInstallation()->getFunction(), // Has no alternative (like the decision hash).
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 }

--- a/module/Database/src/Model/SubDecision/Board/Release.php
+++ b/module/Database/src/Model/SubDecision/Board/Release.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Database\Model\SubDecision\Board;
 
 use Database\Model\SubDecision;
+use Database\Model\Trait\FormattableDateTrait;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
-use IntlDateFormatter;
-
-use function date_default_timezone_get;
 
 /**
  * Release from board duties.
@@ -23,6 +21,8 @@ use function date_default_timezone_get;
 #[Entity]
 class Release extends SubDecision
 {
+    use FormattableDateTrait;
+
     /**
      * Reference to the installation of a member.
      */
@@ -88,29 +88,6 @@ class Release extends SubDecision
     public function setDate(DateTime $date): void
     {
         $this->date = $date;
-    }
-
-    /**
-     * Format the date.
-     *
-     * returns the localized version of $date->format('d F Y')
-     *
-     * @return string Formatted date
-     */
-    protected function formatDate(
-        DateTime $date,
-        string $locale = 'nl_NL',
-    ): string {
-        $formatter = new IntlDateFormatter(
-            $locale,
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            date_default_timezone_get(),
-            null,
-            'd MMMM y',
-        );
-
-        return $formatter->format($date);
     }
 
     protected function getTemplate(): string

--- a/module/Database/src/Model/SubDecision/Budget.php
+++ b/module/Database/src/Model/SubDecision/Budget.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Database\Model\SubDecision;
 
 use Database\Model\SubDecision;
+use Database\Model\Trait\FormattableDateTrait;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use IntlDateFormatter;
-
-use function date_default_timezone_get;
 
 #[Entity]
 class Budget extends SubDecision
 {
+    use FormattableDateTrait;
+
     /**
      * Name of the budget.
      */
@@ -126,29 +126,6 @@ class Budget extends SubDecision
     public function setChanges(bool $changes): void
     {
         $this->changes = $changes;
-    }
-
-    /**
-     * Format the date.
-     *
-     * returns the localized version of $date->format('d F Y')
-     *
-     * @return string Formatted date
-     */
-    protected function formatDate(
-        DateTime $date,
-        string $locale = 'nl_NL',
-    ): string {
-        $formatter = new IntlDateFormatter(
-            $locale,
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            date_default_timezone_get(),
-            null,
-            'd MMMM y',
-        );
-
-        return $formatter->format($date);
     }
 
     protected function getTemplate(): string

--- a/module/Database/src/Model/SubDecision/Destroy.php
+++ b/module/Database/src/Model/SubDecision/Destroy.php
@@ -10,8 +10,6 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
 
-use function implode;
-
 /**
  * Destroying a decision.
  *
@@ -68,20 +66,33 @@ class Destroy extends SubDecision
         $this->target = $target;
     }
 
-    /**
-     * Get the content.
-     */
+    protected function getTemplate(): string
+    {
+        return 'Besluit %DECISION_HASH% wordt nietig verklaard. Het besluit luidde: "%DECISION_CONTENT%"';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return 'Decision %DECISION_HASH% is annulled. The decision read: "%DECISION_CONTENT%"';
+    }
+
     public function getContent(): string
     {
-        $target = $this->getTarget();
-        $meet = $this->getTarget()->getMeeting();
-        $content = [];
-        foreach ($target->getSubdecisions() as $sub) {
-            $content[] = $sub->getContent();
-        }
+        $replacements = [
+            '%DECISION_HASH%' => $this->getTarget()->getHash(),
+            '%DECISION_CONTENT%' => $this->getTarget()->getContent(),
+        ];
 
-        return 'Besluit ' . $meet->getType()->value . ' ' . $meet->getNumber()
-            . '.' . $target->getPoint() . '.' . $target->getNumber()
-            . ' wordt nietig verklaard. Het besluit luidde: "' . implode(' ', $content) . '"';
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
+
+    public function getAlternativeContent(): string
+    {
+        $replacements = [
+            '%DECISION_HASH%' => $this->getTarget()->getHash(), // We do not provide an alternative to the hash.
+            '%DECISION_CONTENT%' => $this->getTarget()->getAlternativeContent(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 }

--- a/module/Database/src/Model/SubDecision/Discharge.php
+++ b/module/Database/src/Model/SubDecision/Discharge.php
@@ -63,18 +63,35 @@ class Discharge extends SubDecision
         $this->installation = $installation;
     }
 
-    /**
-     * Get the content.
-     */
+    protected function getTemplate(): string
+    {
+        return '%MEMBER% wordt gedechargeerd als %FUNCTION% van %ORGAN_ABBR%.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return '%MEMBER% is discharged as %FUNCTION% of %ORGAN_ABBR%.';
+    }
+
     public function getContent(): string
     {
-        $member = $this->getInstallation()->getMember()->getFullName();
-        $function = $this->getInstallation()->getFunction();
-        $organ = $this->getInstallation()->getFoundation()->getAbbr();
+        $replacements = [
+            '%MEMBER%' => $this->getInstallation()->getMember()->getFullName(),
+            '%FUNCTION%' => $this->getInstallation()->getFunction(),
+            '%ORGAN_ABBR%' => $this->getInstallation()->getFoundation()->getAbbr(),
+        ];
 
-        $text = $member . ' wordt gedechargeerd als ' . $function;
-        $text .= ' van ' . $organ . '.';
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
 
-        return $text;
+    public function getAlternativeContent(): string
+    {
+        $replacements = [
+            '%MEMBER%' => $this->getInstallation()->getMember()->getFullName(),
+            '%FUNCTION%' => $this->getInstallation()->getFunction(), // Has no alternative (like the decision hash).
+            '%ORGAN_ABBR%' => $this->getInstallation()->getFoundation()->getAbbr(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 }

--- a/module/Database/src/Model/SubDecision/Foundation.php
+++ b/module/Database/src/Model/SubDecision/Foundation.php
@@ -114,18 +114,36 @@ class Foundation extends SubDecision
         return $this->references;
     }
 
-    /**
-     * Get the content.
-     */
+    protected function getTemplate(): string
+    {
+        return '%ORGAN_TYPE% %ORGAN_NAME% met afkorting %ORGAN_ABBR% wordt opgericht.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return '%ORGAN_TYPE% %ORGAN_NAME% with abbreviation %ORGAN_ABBR% is established.';
+    }
+
     public function getContent(): string
     {
-        $text = $this->getOrganType()->getName() . ' ';
-        $text .= $this->getName();
-        $text .= ' met afkorting ';
-        $text .= $this->getAbbr();
-        $text .= ' wordt opgericht.';
+        $replacements = [
+            '%ORGAN_TYPE%' => $this->getOrganType()->getName(),
+            '%ORGAN_NAME%' => $this->getName(),
+            '%ORGAN_ABBR%' => $this->getAbbr(),
+        ];
 
-        return $text;
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
+
+    public function getAlternativeContent(): string
+    {
+        $replacements = [
+            '%ORGAN_TYPE%' => $this->getOrganType()->getAlternativeName(),
+            '%ORGAN_NAME%' => $this->getName(),
+            '%ORGAN_ABBR%' => $this->getAbbr(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 
     /**

--- a/module/Database/src/Model/SubDecision/Installation.php
+++ b/module/Database/src/Model/SubDecision/Installation.php
@@ -109,17 +109,35 @@ class Installation extends FoundationReference
         return $this->discharge;
     }
 
-    /**
-     * Get the content.
-     *
-     * Fixes Bor's greatest frustration
-     */
+    protected function getTemplate(): string
+    {
+        return '%MEMBER% wordt geïnstalleerd als %FUNCTION% van %ORGAN_ABBR%.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return '%MEMBER% is installed as %FUNCTION% of %ORGAN_ABBR%.';
+    }
+
     public function getContent(): string
     {
-        $member = $this->getMember()->getFullName();
-        $text = $member . ' wordt geïnstalleerd als ' . $this->getFunction();
-        $text .= ' van ' . $this->getFoundation()->getAbbr() . '.';
+        $replacements = [
+            '%MEMBER%' => $this->getMember()->getFullName(),
+            '%FUNCTION%' => $this->getFunction(),
+            '%ORGAN_ABBR%' => $this->getFoundation()->getAbbr(),
+        ];
 
-        return $text;
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
+
+    public function getAlternativeContent(): string
+    {
+        $replacements = [
+            '%MEMBER%' => $this->getMember()->getFullName(),
+            '%FUNCTION%' => $this->getFunction(), // Has no alternative (like the decision hash).
+            '%ORGAN_ABBR%' => $this->getFoundation()->getAbbr(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 }

--- a/module/Database/src/Model/SubDecision/Key/Granting.php
+++ b/module/Database/src/Model/SubDecision/Key/Granting.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Database\Model\SubDecision\Key;
 
 use Database\Model\SubDecision;
+use Database\Model\Trait\FormattableDateTrait;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\OneToOne;
-use IntlDateFormatter;
-
-use function date_default_timezone_get;
 
 #[Entity]
 class Granting extends SubDecision
 {
+    use FormattableDateTrait;
+
     /**
      * Till when the keycode is granted.
      */
@@ -45,29 +45,6 @@ class Granting extends SubDecision
     public function setUntil(DateTime $until): void
     {
         $this->until = $until;
-    }
-
-    /**
-     * Format the date.
-     *
-     * returns the localized version of $date->format('d F Y')
-     *
-     * @return string Formatted date
-     */
-    protected function formatDate(
-        DateTime $date,
-        string $locale = 'nl_NL',
-    ): string {
-        $formatter = new IntlDateFormatter(
-            $locale,
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            date_default_timezone_get(),
-            null,
-            'd MMMM y',
-        );
-
-        return $formatter->format($date);
     }
 
     protected function getTemplate(): string

--- a/module/Database/src/Model/SubDecision/Key/Withdrawal.php
+++ b/module/Database/src/Model/SubDecision/Key/Withdrawal.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Database\Model\SubDecision\Key;
 
 use Database\Model\SubDecision;
+use Database\Model\Trait\FormattableDateTrait;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
-use IntlDateFormatter;
-
-use function date_default_timezone_get;
 
 #[Entity]
 class Withdrawal extends SubDecision
 {
+    use FormattableDateTrait;
+
     /**
      * Reference to the granting of a keycode.
      */
@@ -82,29 +82,6 @@ class Withdrawal extends SubDecision
     public function setWithdrawnOn(DateTime $withdrawnOn): void
     {
         $this->withdrawnOn = $withdrawnOn;
-    }
-
-    /**
-     * Format the date.
-     *
-     * returns the localized version of $date->format('d F Y')
-     *
-     * @return string Formatted date
-     */
-    protected function formatDate(
-        DateTime $date,
-        string $locale = 'nl_NL',
-    ): string {
-        $formatter = new IntlDateFormatter(
-            $locale,
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            date_default_timezone_get(),
-            null,
-            'd MMMM y',
-        );
-
-        return $formatter->format($date);
     }
 
     protected function getTemplate(): string

--- a/module/Database/src/Model/SubDecision/OrganRegulation.php
+++ b/module/Database/src/Model/SubDecision/OrganRegulation.php
@@ -6,17 +6,17 @@ namespace Database\Model\SubDecision;
 
 use Application\Model\Enums\OrganTypes;
 use Database\Model\SubDecision;
+use Database\Model\Trait\FormattableDateTrait;
 use DateTime;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use IntlDateFormatter;
 use ValueError;
-
-use function date_default_timezone_get;
 
 #[Entity]
 class OrganRegulation extends SubDecision
 {
+    use FormattableDateTrait;
+
     /**
      * Name of the organ.
      */
@@ -153,29 +153,6 @@ class OrganRegulation extends SubDecision
     public function setChanges(bool $changes): void
     {
         $this->changes = $changes;
-    }
-
-    /**
-     * Format the date.
-     *
-     * returns the localized version of $date->format('d F Y')
-     *
-     * @return string Formatted date
-     */
-    protected function formatDate(
-        DateTime $date,
-        string $locale = 'nl_NL',
-    ): string {
-        $formatter = new IntlDateFormatter(
-            $locale,
-            IntlDateFormatter::NONE,
-            IntlDateFormatter::NONE,
-            date_default_timezone_get(),
-            null,
-            'd MMMM y',
-        );
-
-        return $formatter->format($date);
     }
 
     protected function getTemplate(): string

--- a/module/Database/src/Model/SubDecision/Other.php
+++ b/module/Database/src/Model/SubDecision/Other.php
@@ -7,6 +7,7 @@ namespace Database\Model\SubDecision;
 use Database\Model\SubDecision;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
+use RuntimeException;
 
 /**
  * Entity for undefined decisions.
@@ -34,5 +35,20 @@ class Other extends SubDecision
     public function setContent(string $content): void
     {
         $this->content = $content;
+    }
+
+    protected function getTemplate(): string
+    {
+        throw new RuntimeException('Not implemented');
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        throw new RuntimeException('Not implemented');
+    }
+
+    public function getAlternativeContent(): string
+    {
+        return $this->getContent(); // No alternative content exists for a custom decision.
     }
 }

--- a/module/Database/src/Model/SubDecision/Reappointment.php
+++ b/module/Database/src/Model/SubDecision/Reappointment.php
@@ -9,8 +9,6 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 
-use function sprintf;
-
 /**
  * Reappointment of a previous installation.
  *
@@ -64,19 +62,39 @@ class Reappointment extends SubDecision
         $this->installation = $installation;
     }
 
-    /**
-     * Get the textual content of this subdecision.
-     */
+    protected function getTemplate(): string
+    {
+        return '%MEMBER% wordt herbenoemd als %FUNCTION% van %ORGAN_ABBR%.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return '%MEMBER% is reappointed as %FUNCTION% of %ORGAN_ABBR%.';
+    }
+
     public function getContent(): string
     {
         $installation = $this->getInstallation();
-        $memberFullName = $installation->getMember()->getFullName();
 
-        return sprintf(
-            '%s wordt herbenoemd als %s van %s.',
-            $memberFullName,
-            $installation->getFunction(),
-            $installation->getFoundation()->getAbbr(),
-        );
+        $replacements = [
+            '%MEMBER%' => $installation->getMember()->getFullName(),
+            '%FUNCTION%' => $installation->getFunction(),
+            '%ORGAN_ABBR%' => $installation->getFoundation()->getAbbr(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getTemplate(), $replacements);
+    }
+
+    public function getAlternativeContent(): string
+    {
+        $installation = $this->getInstallation();
+
+        $replacements = [
+            '%MEMBER%' => $installation->getMember()->getFullName(),
+            '%FUNCTION%' => $installation->getFunction(), // Has no alternative (like the decision hash).
+            '%ORGAN_ABBR%' => $installation->getFoundation()->getAbbr(),
+        ];
+
+        return $this->replaceContentPlaceholders($this->getAlternativeTemplate(), $replacements);
     }
 }

--- a/module/Database/src/Model/SubDecision/Reckoning.php
+++ b/module/Database/src/Model/SubDecision/Reckoning.php
@@ -9,11 +9,13 @@ use Doctrine\ORM\Mapping\Entity;
 #[Entity]
 class Reckoning extends Budget
 {
-    /**
-     * Decision template
-     */
     protected function getTemplate(): string
     {
         return 'De afrekening %NAME% van %AUTHOR%, versie %VERSION% van %DATE% wordt %APPROVAL%%CHANGES%.';
+    }
+
+    protected function getAlternativeTemplate(): string
+    {
+        return 'The financial statement %NAME% by %AUTHOR%, version %VERSION% dated %DATE% is %APPROVAL%%CHANGES%.';
     }
 }

--- a/module/Database/src/Model/Trait/FormattableDateTrait.php
+++ b/module/Database/src/Model/Trait/FormattableDateTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Model\Trait;
+
+use DateTime;
+use IntlDateFormatter;
+
+use function date_default_timezone_get;
+
+trait FormattableDateTrait
+{
+    /**
+     * Format a `DateTime` in a specified locale.
+     *
+     * With {@see IntlDateFormatter::LONG} the date will be formatted using the day of the month, full month, and
+     * 4-digit year. For example, for
+     */
+    protected function formatDate(
+        DateTime $date,
+        string $locale = 'nl_NL',
+    ): string {
+        $formatter = new IntlDateFormatter(
+            $locale,
+            IntlDateFormatter::LONG,
+            IntlDateFormatter::NONE,
+            date_default_timezone_get(),
+        );
+
+        return $formatter->format($date);
+    }
+}

--- a/module/Database/view/database/meeting/decisionform.phtml
+++ b/module/Database/view/database/meeting/decisionform.phtml
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Application\View\HelperTrait;
+use Database\Model\Decision as DecisionModel;
 use Database\Model\Meeting;
 use Laminas\View\Renderer\PhpRenderer;
 
@@ -68,10 +69,9 @@ case 'other':
 ?>
 <?php else: ?>
 <?php
-$meeting = $decision->getMeeting();
-$decisionNum = $meeting->getType()->value . ' ' . $meeting->getNumber() . '.' . $decision->getPoint() . '.' . $decision->getNumber();
+/** @var DecisionModel $decision */
 ?>
-<h1><?= $this->translate('Decision') ?> <?= $decisionNum ?> <?= $this->translate('reads as follows:') ?></h1>
+<h1><?= $this->translate('Decision') ?> <?= $decision->getHash() ?> <?= $this->translate('reads as follows:') ?></h1>
 <?php foreach ($decision->getSubdecisions() as $subdecision): ?>
     <?= $this->escapeHtml($subdecision->getContent()) ?>
 <?php endforeach; ?>
@@ -83,20 +83,25 @@ $decisionNum = $meeting->getType()->value . ' ' . $meeting->getNumber() . '.' . 
     <a href="<?= $this->url(
         'meeting/view',
         [
-            'type' => $meeting->getType()->value,
-            'number' => $meeting->getNumber(),
+            'type' => $decision->getMeetingType()->value,
+            'number' => $decision->getMeetingNumber(),
         ],
     ) ?>">
         <?=
             sprintf(
                 $this->translate('Back to %s %d'),
-                $meeting->getType()->value,
-                $meeting->getNumber(),
+                $decision->getMeetingType()->value,
+                $decision->getMeetingNumber(),
             )
         ?>
     </a>
     <script>
-        var decisionCopy = "<?= $this->escapeHtml($decision->getContent()) ?>";
+        let decisionCopy = "<?= sprintf(
+            '\decision[%s]{%s}',
+            $this->escapeHtmlAttr($decision->getAlternativeContent()),
+            $this->escapeHtmlAttr($decision->getContent()),
+        ) ?>";
+
         function copyDecision() {
             navigator.clipboard.writeText(decisionCopy);
         }

--- a/module/Database/view/database/meeting/decisionform.phtml
+++ b/module/Database/view/database/meeting/decisionform.phtml
@@ -76,34 +76,36 @@ case 'other':
     <?= $this->escapeHtml($subdecision->getContent()) ?>
 <?php endforeach; ?>
 
-<button onclick="copyDecision()" class="btn btn-success">
+<br>
+<span class="hidden" id="decision-contents">
+    <?= sprintf(
+        '\decision[%s]{%s}',
+        $this->escapeHtml($decision->getAlternativeContent(true)),
+        $this->escapeHtml($decision->getContent(true)),
+    ) ?>
+</span>
+
+<button onclick="copyDecision()" class="btn btn-info">
     <span class="glyphicon glyphicon-floppy-disk"></span> <?= $this->translate('Copy Decision')?>
 </button>
-<br />
-    <a href="<?= $this->url(
-        'meeting/view',
-        [
-            'type' => $decision->getMeetingType()->value,
-            'number' => $decision->getMeetingNumber(),
-        ],
-    ) ?>">
-        <?=
-            sprintf(
-                $this->translate('Back to %s %d'),
-                $decision->getMeetingType()->value,
-                $decision->getMeetingNumber(),
-            )
-        ?>
-    </a>
+<a href="<?= $this->url(
+    'meeting/view',
+    [
+        'type' => $decision->getMeetingType()->value,
+        'number' => $decision->getMeetingNumber(),
+    ],
+) ?>" class="btn btn-success">
+    <?=
+    sprintf(
+        $this->translate('Back to %s %d'),
+        $decision->getMeetingType()->value,
+        $decision->getMeetingNumber(),
+    )
+    ?>
+</a>
     <script>
-        let decisionCopy = "<?= sprintf(
-            '\decision[%s]{%s}',
-            $this->escapeHtmlAttr($decision->getAlternativeContent(true)),
-            $this->escapeHtmlAttr($decision->getContent(true)),
-        ) ?>";
-
         function copyDecision() {
-            navigator.clipboard.writeText(decisionCopy);
+            navigator.clipboard.writeText(document.getElementById('decision-contents').textContent.trim());
         }
     </script>
 <?php endif; ?>

--- a/module/Database/view/database/meeting/decisionform.phtml
+++ b/module/Database/view/database/meeting/decisionform.phtml
@@ -98,8 +98,8 @@ case 'other':
     <script>
         let decisionCopy = "<?= sprintf(
             '\decision[%s]{%s}',
-            $this->escapeHtmlAttr($decision->getAlternativeContent()),
-            $this->escapeHtmlAttr($decision->getContent()),
+            $this->escapeHtmlAttr($decision->getAlternativeContent(true)),
+            $this->escapeHtmlAttr($decision->getContent(true)),
         ) ?>";
 
         function copyDecision() {

--- a/module/Database/view/database/meeting/view.phtml
+++ b/module/Database/view/database/meeting/view.phtml
@@ -67,21 +67,21 @@ $(document).ready(function () {
     <li>
         <?= $this->translate('Decision') ?> <?= "{$meeting->getNumber()}.{$decision->getPoint()}.{$decision->getNumber()}" ?>:
         <?php if ($decision->isDestroyed()): ?>
-        <?php
-        $dec = $decision->getDestroyedBy()->getDecision();
-        $mt = $dec->getMeeting();
-        ?>
-        <strong>
-            <?=
-                sprintf(
-                    $this->translate('(Annulled by decision %s %d.%d.%d)'),
-                    $mt->getType()->value,
-                    $mt->getNumber(),
-                    $dec->getPoint(),
-                    $dec->getNumber(),
-                )
+            <?php
+            $dec = $decision->getDestroyedBy()->getDecision();
+            $mt = $dec->getMeeting();
             ?>
-        </strong>
+            <strong>
+                <?=
+                    sprintf(
+                        $this->translate('(Annulled by decision %s %d.%d.%d)'),
+                        $mt->getType()->value,
+                        $mt->getNumber(),
+                        $dec->getPoint(),
+                        $dec->getNumber(),
+                    )
+                ?>
+            </strong>
         <?php endif; ?>
         <br />
         <a href="<?= $this->url('meeting/decision/delete', array(
@@ -92,23 +92,26 @@ $(document).ready(function () {
         )) ?>" class="btn btn-danger">
             <span class="glyphicon glyphicon-remove"></span> <?= $this->translate('Delete Decision') ?>
         </a>
-        <button onclick="copyDecision(this)" class="btn btn-success" value="<?= sprintf(
-            '\decision[%s]{%s}',
-            $this->escapeHtmlAttr($decision->getAlternativeContent(true)),
-            $this->escapeHtmlAttr($decision->getContent(true)),
-        ) ?>">
+        <button onclick="copyDecision('<?= $decision->getHash() ?>')" class="btn btn-info">
             <span class="glyphicon glyphicon-floppy-disk"></span> <?= $this->translate('Copy Decision')?>
         </button>
         <ul>
         <?php foreach ($decision->getSubdecisions() as $subdecision): ?>
-            <li><?= $this->escapeHtmlAttr($subdecision->getContent()) ?></li>
+            <li><?= $this->escapeHtml($subdecision->getContent()) ?></li>
         <?php endforeach; ?>
         </ul>
+        <span class="hidden" id="<?= $decision->getHash() ?>">
+            <?= sprintf(
+                '\decision[%s]{%s}',
+                $this->escapeHtmlAttr($decision->getAlternativeContent(true)),
+                $this->escapeHtmlAttr($decision->getContent(true)),
+            ) ?>
+        </span>
     </li>
 <?php endforeach; ?>
 <script>
     function copyDecision(decision) {
-        navigator.clipboard.writeText(decision.value).then(
+        navigator.clipboard.writeText(document.getElementById(decision).textContent.trim()).then(
             () => {
                 // Clipboard succeeded
             },

--- a/module/Database/view/database/meeting/view.phtml
+++ b/module/Database/view/database/meeting/view.phtml
@@ -3,9 +3,13 @@
 declare(strict_types=1);
 
 use Application\View\HelperTrait;
+use Database\Model\Meeting as MeetingModel;
 use Laminas\View\Renderer\PhpRenderer;
 
-/** @var PhpRenderer|HelperTrait $this */
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var MeetingModel $meeting
+ */
 
 // determine last decision of each point
 $map = array();
@@ -48,9 +52,6 @@ $(document).ready(function () {
     });
 });
 </script>
-<?php
-use Database\Model\Meeting;
-?>
     <h1><?= $meeting->getType()->value ?> <?= $meeting->getNumber() ?>
     <small><?= $this->dateFormat(
         $meeting->getDate(),
@@ -91,7 +92,11 @@ use Database\Model\Meeting;
         )) ?>" class="btn btn-danger">
             <span class="glyphicon glyphicon-remove"></span> <?= $this->translate('Delete Decision') ?>
         </a>
-        <button onclick="copyDecision(this)" class="btn btn-success" value="<?= $this->escapeHtmlAttr($decision->getContent()) ?>">
+        <button onclick="copyDecision(this)" class="btn btn-success" value="<?= sprintf(
+            '\decision[%s]{%s}',
+            $this->escapeHtmlAttr($decision->getAlternativeContent()),
+            $this->escapeHtmlAttr($decision->getContent()),
+        ) ?>">
             <span class="glyphicon glyphicon-floppy-disk"></span> <?= $this->translate('Copy Decision')?>
         </button>
         <ul>

--- a/module/Database/view/database/meeting/view.phtml
+++ b/module/Database/view/database/meeting/view.phtml
@@ -94,8 +94,8 @@ $(document).ready(function () {
         </a>
         <button onclick="copyDecision(this)" class="btn btn-success" value="<?= sprintf(
             '\decision[%s]{%s}',
-            $this->escapeHtmlAttr($decision->getAlternativeContent()),
-            $this->escapeHtmlAttr($decision->getContent()),
+            $this->escapeHtmlAttr($decision->getAlternativeContent(true)),
+            $this->escapeHtmlAttr($decision->getContent(true)),
         ) ?>">
             <span class="glyphicon glyphicon-floppy-disk"></span> <?= $this->translate('Copy Decision')?>
         </button>


### PR DESCRIPTION
`getContent()` remains the same, however, an aptly named `getAlternativeContent()` is now also required. Both functions use
their respective template (`getTemplate()` and `getAlternativeTemplate()`) and perform replacements on them using the `replaceContentPlaceholders()` in `SubDecision`.

This change does introduce some duplication, however, creating a whole new system is not a good idea. Furthermore, putting the templates or parts of it in the translation files is also not foolproof. Accidental changes to translations should NEVER lead to
changes in the content of a (sub)decision.

The alternative content is never stored in the database and thus also not propagated to ReportDB (i.e. GEWISWEB).

The "Copy Decision"-button has been updated to automatically include the alternative content next to the original content formatted as the LaTeX `\decision` command.

Ideally, there would have been tests to ensure that replacement tags present in each of the four functions defined in each subdecision. However, this takes a long time to implement. An alternative would be to use PHPUnit and create unit tests that can achieve this. Such a unit test may look as follows:

```php
public function testReplacementsInSpecificSubDecision(): void
{
    $subDecision = new SpecificSubDecision();

    $this->assertStringContainsString(
        '%REPLACEMENT_TAG%',
        $subDecision->getTemplate(),
    );
    $this->assertStringContainsString(
        '%REPLACEMENT_TAG%',
        $subDecision->getAlternativeTemplate(),
    );

    $replacements = $subDecision->getReplacements();
    $this->assertArrayHasKey('%REPLACEMENT_TAG%', $replacements);

    $alternativeReplacements = $subDecision->getAlternativeReplacements();
    $this->assertArrayHasKey('%REPLACEMENT_TAG%', $alternativeReplacements);
}
```

Also adds functionality to enable the escaping of special characters in LaTeX when copying the contents of a decision.

The ordering of the replacements is of utmost importance to prevent creating illegal LaTeX commands or mangling the intended output. As such, we cannot use `str_replace()` which will replace earlier replacements and have to use a regex to actually achieve this.


Closes GH-344.