### PR TITLE
Remove deprecated properties for CLI commands

### DIFF
--- a/module/Checker/src/Command/CheckAuthenticationKeysCommand.php
+++ b/module/Checker/src/Command/CheckAuthenticationKeysCommand.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Checker\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'check:members:keys',
+    description: 'Check and update authentication keys of members when necessary.',
+)]
 class CheckAuthenticationKeysCommand extends AbstractCheckerCommand
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'check:members:keys';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Check and update authentication keys of members when necessary.';
-
     protected function execute(
         InputInterface $input,
         OutputInterface $output,

--- a/module/Checker/src/Command/CheckDatabaseCommand.php
+++ b/module/Checker/src/Command/CheckDatabaseCommand.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Checker\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'check:database',
+    description: 'Check if the database is sound.',
+)]
 class CheckDatabaseCommand extends AbstractCheckerCommand
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'check:database';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Check if the database is sound.';
-
     protected function execute(
         InputInterface $input,
         OutputInterface $output,

--- a/module/Checker/src/Command/CheckDischargesCommand.php
+++ b/module/Checker/src/Command/CheckDischargesCommand.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Checker\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'check:discharges',
+    description: 'Check that no member is installed in a non-existing or abrogated organ.',
+)]
 class CheckDischargesCommand extends AbstractCheckerCommand
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'check:discharges';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Check that no member is installed in a non-existing or abrogated organ.';
-
     protected function execute(
         InputInterface $input,
         OutputInterface $output,

--- a/module/Checker/src/Command/CheckMembershipExpirationCommand.php
+++ b/module/Checker/src/Command/CheckMembershipExpirationCommand.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Checker\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'check:membership:expiration',
+    description: 'Check and update memberships expirations when necessary.',
+)]
 class CheckMembershipExpirationCommand extends AbstractCheckerCommand
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'check:membership:expiration';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Check and update memberships expirations when necessary.';
-
     protected function execute(
         InputInterface $input,
         OutputInterface $output,

--- a/module/Checker/src/Command/CheckMembershipGraduateRenewalCommand.php
+++ b/module/Checker/src/Command/CheckMembershipGraduateRenewalCommand.php
@@ -5,18 +5,17 @@ declare(strict_types=1);
 namespace Checker\Command;
 
 use Checker\Service\Renewal as RenewalService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'check:membership:renewal:graduate',
+    description: 'Check graduates who are expiring at the end of the association year and send renewal emails.',
+)]
 class CheckMembershipGraduateRenewalCommand extends Command
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'check:membership:renewal:graduate';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription =
-        'Check graduates who are expiring at the end of the association year and send renewal emails.';
-
     public function __construct(private readonly RenewalService $renewalService)
     {
         parent::__construct();

--- a/module/Checker/src/Command/CheckMembershipTUeCommand.php
+++ b/module/Checker/src/Command/CheckMembershipTUeCommand.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Checker\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'check:membership:tue',
+    description: 'Check whether ordinary members are still studying at the TU/e.',
+)]
 class CheckMembershipTUeCommand extends AbstractCheckerCommand
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'check:membership:tue';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Check whether ordinary members are still studying at the TU/e.';
-
     protected function execute(
         InputInterface $input,
         OutputInterface $output,

--- a/module/Checker/src/Command/CheckMembershipTypeCommand.php
+++ b/module/Checker/src/Command/CheckMembershipTypeCommand.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Checker\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'check:membership:type',
+    description: 'Check and update membership types when necessary.',
+)]
 class CheckMembershipTypeCommand extends AbstractCheckerCommand
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'check:membership:type';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Check and update membership types when necessary.';
-
     protected function execute(
         InputInterface $input,
         OutputInterface $output,

--- a/module/Database/src/Command/DeleteExpiredMembersCommand.php
+++ b/module/Database/src/Command/DeleteExpiredMembersCommand.php
@@ -9,18 +9,18 @@ use DateTime;
 use Laminas\Cli\Command\AbstractParamAwareCommand;
 use Laminas\Cli\Input\ParamAwareInputInterface;
 use Laminas\Cli\Input\StringParam;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
+#[AsCommand(
+    name: 'database:members:delete-expired',
+    description: 'Delete members whose membership expired on or before the specified date.',
+)]
 class DeleteExpiredMembersCommand extends AbstractParamAwareCommand
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'database:members:delete-expired';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Delete members whose membership expired on or before the specified date.';
-
     public function __construct(private readonly MemberService $memberService)
     {
         parent::__construct();

--- a/module/Database/src/Command/DeleteExpiredProspectiveMembersCommand.php
+++ b/module/Database/src/Command/DeleteExpiredProspectiveMembersCommand.php
@@ -6,17 +6,17 @@ namespace Database\Command;
 
 use Database\Service\Member as MemberService;
 use Laminas\Cli\Command\AbstractParamAwareCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'database:prospective-members:delete-expired',
+    description: 'Delete prospective members whose Checkout Session has expired or failed.',
+)]
 class DeleteExpiredProspectiveMembersCommand extends AbstractParamAwareCommand
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'database:prospective-members:delete-expired';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Delete prospective members whose Checkout Session has expired or failed.';
-
     public function __construct(private readonly MemberService $memberService)
     {
         parent::__construct();

--- a/module/Database/src/Command/GenerateAuthenticationKeysCommand.php
+++ b/module/Database/src/Command/GenerateAuthenticationKeysCommand.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Database\Command;
 
 use Database\Service\Member as MemberService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'database:members:generate-keys',
+    description: 'Forcefully update the keys used for external authentication on members.',
+)]
 class GenerateAuthenticationKeysCommand extends Command
 {
-    /** @var string $defaultName */
-    protected static $defaultName = 'database:members:generate-keys';
-    /** @var string $defaultDescription */
-    protected static $defaultDescription = 'Forcefully update the keys used for external authentication on members.';
-
     public function __construct(private readonly MemberService $memberService)
     {
         parent::__construct();

--- a/psalm/psalm-baseline.xml
+++ b/psalm/psalm-baseline.xml
@@ -5,70 +5,10 @@
       <code>$decision[$subDecisionType]</code>
     </PossiblyUndefinedArrayOffset>
   </file>
-  <file src="module/Checker/src/Command/CheckAuthenticationKeysCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="module/Checker/src/Command/CheckDatabaseCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="module/Checker/src/Command/CheckDischargesCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="module/Checker/src/Command/CheckMembershipExpirationCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="module/Checker/src/Command/CheckMembershipGraduateRenewalCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="module/Checker/src/Command/CheckMembershipTUeCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="module/Checker/src/Command/CheckMembershipTypeCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
   <file src="module/Checker/src/Model/TueData.php">
     <PossiblyUndefinedArrayOffset occurrences="1">
       <code>$this-&gt;data['registrations']</code>
     </PossiblyUndefinedArrayOffset>
-  </file>
-  <file src="module/Database/src/Command/DeleteExpiredMembersCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="module/Database/src/Command/DeleteExpiredProspectiveMembersCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="module/Database/src/Command/GenerateAuthenticationKeysCommand.php">
-    <NonInvariantDocblockPropertyType occurrences="2">
-      <code>$defaultDescription</code>
-      <code>$defaultName</code>
-    </NonInvariantDocblockPropertyType>
   </file>
   <file src="module/Database/src/Controller/QueryController.php">
     <InvalidReturnStatement occurrences="1"/>


### PR DESCRIPTION
The `$defaultName` and `$defaultDescription` properties for CLI commands where deprecated in Symfony 6.1. As these functions did not support native typing they caused issues with Psalm.

They have been replaced by a native attribute `AsCommand`.

Fixes GH-388.