### PR TITLE
Rename `Destroy` and `Reckoning` sub-decisions

### DIFF
--- a/module/Checker/src/Mapper/Filter.php
+++ b/module/Checker/src/Mapper/Filter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Checker\Mapper;
 
 use Database\Model\SubDecision as SubDecisionModel;
-use Database\Model\SubDecision\Destroy as DestroyModel;
+use Database\Model\SubDecision\Annulment as AnnulmentModel;
 
 use function in_array;
 
@@ -45,11 +45,11 @@ trait Filter
         // use static to only make sure that the variable has only be set once
         static $deleted;
         if (null === $deleted) {
-            // First, fetch all destroy decisions
+            // First, fetch all annulment decisions
             $qb = $this->em->createQueryBuilder();
             $qb->select('d')
-                ->from(DestroyModel::class, 'd');
-            /** @var DestroyModel[] $deletions */
+                ->from(AnnulmentModel::class, 'd');
+            /** @var AnnulmentModel[] $deletions */
             $deletions = $qb->getQuery()->getResult();
 
             // check for all decisions if they are valid
@@ -69,25 +69,25 @@ trait Filter
     }
 
     /**
-     * Checks if a destroy decision is still valid (i,e. is not destroyed
+     * Checks if an annulment decision is still valid (i.e. is not annulled).
      *
-     * @param DestroyModel $d Destroy decision
+     * @param AnnulmentModel $d Annulment decision
      *
-     * @return bool is the destroy decision not destroyed?
+     * @return bool is the annul decision not annulled?
      */
-    protected function isValid(DestroyModel $d): bool
+    protected function isValid(AnnulmentModel $d): bool
     {
         // Get the decision
         $decision = $d->getDecision();
 
-        $destroy = $decision->getDestroyedBy();
+        $annulment = $decision->getAnnulledBy();
 
-        // if this decision was not destroyed, it is certainly valid
-        if (null === $destroy) {
+        // if this decision was not annulled, it is certainly valid
+        if (null === $annulment) {
             return true;
         }
 
-        // else it is valid iff the destroyed by is not valid
-        return !$this->isValid($destroy);
+        // else it is valid iff the annulled by is not valid
+        return !$this->isValid($annulment);
     }
 }

--- a/module/Database/src/Controller/MeetingController.php
+++ b/module/Database/src/Controller/MeetingController.php
@@ -136,7 +136,7 @@ class MeetingController extends AbstractActionController
             'organ_regulation' => $this->meetingService->getRegulationForm(),
             'foundation' => $this->meetingService->getFoundationForm(),
             'abolish' => $this->meetingService->getAbolishForm(),
-            'destroy' => $this->meetingService->getDestroyForm(),
+            'annulment' => $this->meetingService->getAnnulmentForm(),
             'install' => $this->meetingService->getInstallForm(),
             'key_grant' => $this->meetingService->getKeyGrantForm(),
             'key_withdraw' => $this->meetingService->getKeyWithdrawForm(),
@@ -178,8 +178,8 @@ class MeetingController extends AbstractActionController
             'install' => new ViewModel(
                 $this->meetingService->installDecision($this->getRequest()->getPost()->toArray()),
             ),
-            'destroy' => new ViewModel(
-                $this->meetingService->destroyDecision($this->getRequest()->getPost()->toArray()),
+            'annulment' => new ViewModel(
+                $this->meetingService->annulDecision($this->getRequest()->getPost()->toArray()),
             ),
             'key_grant' => new ViewModel(
                 $this->meetingService->keyGrantDecision($this->getRequest()->getPost()->toArray()),

--- a/module/Database/src/Form/Annulment.php
+++ b/module/Database/src/Form/Annulment.php
@@ -11,7 +11,7 @@ use Laminas\Form\Element\Text;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Mvc\I18n\Translator;
 
-class Destroy extends AbstractDecision implements InputFilterProviderInterface
+class Annulment extends AbstractDecision implements InputFilterProviderInterface
 {
     public function __construct(
         private readonly Translator $translator,

--- a/module/Database/src/Form/Budget.php
+++ b/module/Database/src/Form/Budget.php
@@ -33,7 +33,7 @@ class Budget extends AbstractDecision implements InputFilterProviderInterface
                 'label' => $this->translator->translate('Budget/Statement'),
                 'value_options' => [
                     'budget' => $this->translator->translate('Budget'),
-                    'reckoning' => $this->translator->translate('Statement'),
+                    'statement' => $this->translator->translate('Statement'),
                 ],
             ],
         ]);
@@ -110,7 +110,7 @@ class Budget extends AbstractDecision implements InputFilterProviderInterface
                         'options' => [
                             'haystack' => [
                                 'budget',
-                                'reckoning',
+                                'statement',
                             ],
                         ],
                     ],

--- a/module/Database/src/Hydrator/Annulment.php
+++ b/module/Database/src/Hydrator/Annulment.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Database\Hydrator;
 
 use Database\Model\Decision as DecisionModel;
-use Database\Model\SubDecision\Destroy as DestroyModel;
+use Database\Model\SubDecision\Annulment as AnnulmentModel;
 use InvalidArgumentException;
 
-class Destroy extends AbstractDecision
+class Annulment extends AbstractDecision
 {
     /**
-     * abolish hydration
+     * Annulment hydration
      *
      * @param DecisionModel $object
      *
@@ -23,12 +23,12 @@ class Destroy extends AbstractDecision
     ): DecisionModel {
         $object = parent::hydrate($data, $object);
 
-        $destroy = new DestroyModel();
+        $annulment = new AnnulmentModel();
 
-        $destroy->setTarget($data['fdecision']);
+        $annulment->setTarget($data['fdecision']);
 
-        $destroy->setSequence(0);
-        $destroy->setDecision($object);
+        $annulment->setSequence(0);
+        $annulment->setDecision($object);
 
         return $object;
     }

--- a/module/Database/src/Hydrator/Budget.php
+++ b/module/Database/src/Hydrator/Budget.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Database\Hydrator;
 
 use Database\Model\Decision as DecisionModel;
-use Database\Model\SubDecision\Budget as BudgetModel;
-use Database\Model\SubDecision\Reckoning as ReckoningModel;
+use Database\Model\SubDecision\Financial\Budget as BudgetModel;
+use Database\Model\SubDecision\Financial\Statement as StatementModel;
 use DateTime;
 use InvalidArgumentException;
 
@@ -30,7 +30,7 @@ class Budget extends AbstractDecision
         if ('budget' === $data['type']) {
             $subdecision = new BudgetModel();
         } else {
-            $subdecision = new ReckoningModel();
+            $subdecision = new StatementModel();
         }
 
         $subdecision->setSequence(1);

--- a/module/Database/src/Mapper/Member.php
+++ b/module/Database/src/Mapper/Member.php
@@ -7,8 +7,8 @@ namespace Database\Mapper;
 use Application\Model\Enums\AddressTypes;
 use Database\Model\Address as AddressModel;
 use Database\Model\Member as MemberModel;
+use Database\Model\SubDecision\Annulment as AnnulmentModel;
 use Database\Model\SubDecision\Board\Installation as BoardInstallationModel;
-use Database\Model\SubDecision\Destroy as DestroyModel;
 use Database\Model\SubDecision\Discharge as DischargeModel;
 use Database\Model\SubDecision\Financial\Budget as BudgetModel;
 use Database\Model\SubDecision\Financial\Statement as StatementModel;
@@ -167,10 +167,10 @@ class Member
             ->andWhere('x.decision_number = r.decision_number')
             ->andWhere('x.sequence = r.sequence');
 
-        // destroyed discharge decisions
+        // annulled discharge decisions
         $qbnd = $this->em->createQueryBuilder();
         $qbnd->select('b')
-            ->from(DestroyModel::class, 'b')
+            ->from(AnnulmentModel::class, 'b')
             ->join('b.target', 'z')
             ->where('z.meeting_type = d.meeting_type')
             ->andWhere('z.meeting_number = d.meeting_number')
@@ -185,10 +185,10 @@ class Member
             $qb->expr()->exists($qbn->getDql()),
         ));
 
-        // destroyed installation decisions
+        // annulled installation decisions
         $qbd = $this->em->createQueryBuilder();
         $qbd->select('a')
-            ->from(DestroyModel::class, 'a')
+            ->from(AnnulmentModel::class, 'a')
             ->join('a.target', 'y')
             ->where('y.meeting_type = r.meeting_type')
             ->andWhere('y.meeting_number = r.meeting_number')

--- a/module/Database/src/Mapper/Member.php
+++ b/module/Database/src/Mapper/Member.php
@@ -8,11 +8,11 @@ use Application\Model\Enums\AddressTypes;
 use Database\Model\Address as AddressModel;
 use Database\Model\Member as MemberModel;
 use Database\Model\SubDecision\Board\Installation as BoardInstallationModel;
-use Database\Model\SubDecision\Budget as BudgetModel;
 use Database\Model\SubDecision\Destroy as DestroyModel;
 use Database\Model\SubDecision\Discharge as DischargeModel;
+use Database\Model\SubDecision\Financial\Budget as BudgetModel;
+use Database\Model\SubDecision\Financial\Statement as StatementModel;
 use Database\Model\SubDecision\Installation as InstallationModel;
-use Database\Model\SubDecision\Reckoning as ReckoningModel;
 use DateTime;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
@@ -257,11 +257,11 @@ class Member
             return false;
         }
 
-        // check if the member is included in reckonings
+        // check if the member is included in financial statements
         $qb = $this->em->createQueryBuilder();
 
         $qb->select('b')
-            ->from(ReckoningModel::class, 'b')
+            ->from(StatementModel::class, 'b')
             ->where('b.member = :member');
         $qb->setParameter('member', $member);
 

--- a/module/Database/src/Mapper/Organ.php
+++ b/module/Database/src/Mapper/Organ.php
@@ -6,7 +6,7 @@ namespace Database\Mapper;
 
 use Application\Model\Enums\MeetingTypes;
 use Database\Model\SubDecision\Abrogation as AbrogationModel;
-use Database\Model\SubDecision\Destroy as DestroyModel;
+use Database\Model\SubDecision\Annulment as AnnulmentModel;
 use Database\Model\SubDecision\Discharge as DischargeModel;
 use Database\Model\SubDecision\Foundation as FoundationModel;
 use Database\Model\SubDecision\Installation as InstallationModel;
@@ -64,10 +64,10 @@ class Organ
             ->andWhere('x.decision_number = r.decision_number')
             ->andWhere('x.sequence = r.sequence');
 
-        // destroyed discharge decisions
+        // annulled discharge decisions
         $qbnd = $this->em->createQueryBuilder();
         $qbnd->select('b')
-            ->from(DestroyModel::class, 'b')
+            ->from(AnnulmentModel::class, 'b')
             ->join('b.target', 'z')
             ->where('z.meeting_type = d.meeting_type')
             ->andWhere('z.meeting_number = d.meeting_number')
@@ -82,10 +82,10 @@ class Organ
             $qb->expr()->exists($qbn->getDql()),
         ));
 
-        // destroyed installation decisions
+        // annulled installation decisions
         $qbd = $this->em->createQueryBuilder();
         $qbd->select('a')
-            ->from(DestroyModel::class, 'a')
+            ->from(AnnulmentModel::class, 'a')
             ->join('a.target', 'y')
             ->where('y.meeting_type = r.meeting_type')
             ->andWhere('y.meeting_number = r.meeting_number')
@@ -181,10 +181,10 @@ class Organ
             ->join('o.decision', 'd')
             ->join('d.meeting', 'm');
 
-        // destroyed foundation decisions
+        // annulled foundation decisions
         $qbd = $this->em->createQueryBuilder();
         $qbd->select('b')
-            ->from(DestroyModel::class, 'b')
+            ->from(AnnulmentModel::class, 'b')
             ->join('b.target', 'y')
             ->where('y.meeting_type = o.meeting_type')
             ->andWhere('y.meeting_number = o.meeting_number')
@@ -207,10 +207,10 @@ class Organ
                 ->andWhere('x.decision_number = o.decision_number')
                 ->andWhere('x.sequence = o.sequence');
 
-            // leave out destroyed abrogation decisions
+            // leave out annulled abrogation decisions
             $qbnd = $this->em->createQueryBuilder();
             $qbnd->select('c')
-                ->from(DestroyModel::class, 'c')
+                ->from(AnnulmentModel::class, 'c')
                 ->join('c.target', 'z')
                 ->where('z.meeting_type = a.meeting_type')
                 ->andWhere('z.meeting_number = a.meeting_number')

--- a/module/Database/src/Model/Decision.php
+++ b/module/Database/src/Model/Decision.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Database\Model;
 
 use Application\Model\Enums\MeetingTypes;
-use Database\Model\SubDecision\Destroy;
+use Database\Model\SubDecision\Annulment;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
@@ -95,13 +95,13 @@ class Decision
     protected Collection $subdecisions;
 
     /**
-     * Destroyed by.
+     * Annulled by.
      */
     #[OneToOne(
-        targetEntity: Destroy::class,
+        targetEntity: Annulment::class,
         mappedBy: 'target',
     )]
-    protected ?Destroy $destroyedby = null;
+    protected ?Annulment $annulledBy = null;
 
     /**
      * Set the meeting.
@@ -203,21 +203,21 @@ class Decision
     }
 
     /**
-     * Get the subdecision by which this decision is destroyed.
+     * Get the subdecision by which this decision is annulled.
      *
-     * Or null, if it wasn't destroyed.
+     * Or null, if it wasn't annulled.
      */
-    public function getDestroyedBy(): ?Destroy
+    public function getAnnulledBy(): ?Annulment
     {
-        return $this->destroyedby;
+        return $this->annulledBy;
     }
 
     /**
-     * Check if this decision is destroyed by another decision.
+     * Check if this decision is annulled by another decision.
      */
-    public function isDestroyed(): bool
+    public function isAnnulled(): bool
     {
-        return null !== $this->destroyedby;
+        return null !== $this->annulledBy;
     }
 
     /**

--- a/module/Database/src/Model/SubDecision.php
+++ b/module/Database/src/Model/SubDecision.php
@@ -9,9 +9,10 @@ use Database\Model\SubDecision\Abrogation;
 use Database\Model\SubDecision\Board\Discharge as BoardDischarge;
 use Database\Model\SubDecision\Board\Installation as BoardInstallation;
 use Database\Model\SubDecision\Board\Release as BoardRelease;
-use Database\Model\SubDecision\Budget;
 use Database\Model\SubDecision\Destroy;
 use Database\Model\SubDecision\Discharge;
+use Database\Model\SubDecision\Financial\Budget;
+use Database\Model\SubDecision\Financial\Statement;
 use Database\Model\SubDecision\Foundation;
 use Database\Model\SubDecision\FoundationReference;
 use Database\Model\SubDecision\Installation;
@@ -20,7 +21,6 @@ use Database\Model\SubDecision\Key\Withdrawal as KeyWithdrawal;
 use Database\Model\SubDecision\OrganRegulation;
 use Database\Model\SubDecision\Other;
 use Database\Model\SubDecision\Reappointment;
-use Database\Model\SubDecision\Reckoning;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -50,8 +50,8 @@ use function str_replace;
         'installation' => Installation::class,
         'reappointment' => Reappointment::class,
         'discharge' => Discharge::class,
-        'budget' => Budget::class,
-        'reckoning' => Reckoning::class,
+        'financial_budget' => Budget::class,
+        'financial_statement' => Statement::class,
         'other' => Other::class,
         'destroy' => Destroy::class,
         'board_installation' => BoardInstallation::class,

--- a/module/Database/src/Model/SubDecision.php
+++ b/module/Database/src/Model/SubDecision.php
@@ -6,10 +6,10 @@ namespace Database\Model;
 
 use Application\Model\Enums\MeetingTypes;
 use Database\Model\SubDecision\Abrogation;
+use Database\Model\SubDecision\Annulment;
 use Database\Model\SubDecision\Board\Discharge as BoardDischarge;
 use Database\Model\SubDecision\Board\Installation as BoardInstallation;
 use Database\Model\SubDecision\Board\Release as BoardRelease;
-use Database\Model\SubDecision\Destroy;
 use Database\Model\SubDecision\Discharge;
 use Database\Model\SubDecision\Financial\Budget;
 use Database\Model\SubDecision\Financial\Statement;
@@ -53,7 +53,7 @@ use function str_replace;
         'financial_budget' => Budget::class,
         'financial_statement' => Statement::class,
         'other' => Other::class,
-        'destroy' => Destroy::class,
+        'annulment' => Annulment::class,
         'board_installation' => BoardInstallation::class,
         'board_release' => BoardRelease::class,
         'board_discharge' => BoardDischarge::class,

--- a/module/Database/src/Model/SubDecision/Annulment.php
+++ b/module/Database/src/Model/SubDecision/Annulment.php
@@ -11,26 +11,26 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
 
 /**
- * Destroying a decision.
+ * Annulling a decision.
  *
  * This decision references to a different decision. The given decision is
- * destroyed, as if it did never exist.
+ * annulled, as if it did never exist.
  *
  * Note that this behaviour might not always work flawlessly. It is very
  * complicated, and thus there might be edge cases that I didn't completely
  * catch. If that is the case, let me know!
  *
- * Also note that destroying decisions that destroy is undefined behaviour!
+ * Also note that annulling decisions that annul is undefined behaviour!
  */
 #[Entity]
-class Destroy extends SubDecision
+class Annulment extends SubDecision
 {
     /**
-     * Reference to the destruction of a decision.
+     * Reference to the annulment of a decision.
      */
     #[OneToOne(
         targetEntity: Decision::class,
-        inversedBy: 'destroyedby',
+        inversedBy: 'annulledBy',
     )]
     #[JoinColumn(
         name: 'r_meeting_type',

--- a/module/Database/src/Model/SubDecision/Financial/Budget.php
+++ b/module/Database/src/Model/SubDecision/Financial/Budget.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Database\Model\SubDecision;
+namespace Database\Model\SubDecision\Financial;
 
 use Database\Model\SubDecision;
 use Database\Model\Trait\FormattableDateTrait;

--- a/module/Database/src/Model/SubDecision/Financial/Statement.php
+++ b/module/Database/src/Model/SubDecision/Financial/Statement.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Database\Model\SubDecision;
+namespace Database\Model\SubDecision\Financial;
 
 use Doctrine\ORM\Mapping\Entity;
 
 #[Entity]
-class Reckoning extends Budget
+class Statement extends Budget
 {
     protected function getTemplate(): string
     {

--- a/module/Database/src/Module.php
+++ b/module/Database/src/Module.php
@@ -12,6 +12,7 @@ use Database\Command\Factory\GenerateAuthenticationKeysCommandFactory;
 use Database\Command\GenerateAuthenticationKeysCommand;
 use Database\Form\Abolish as AbolishForm;
 use Database\Form\Address as AddressForm;
+use Database\Form\Annulment as AnnulmentForm;
 use Database\Form\AuditEntry\AuditNote as AuditNoteForm;
 use Database\Form\Board\Discharge as BoardDischargeForm;
 use Database\Form\Board\Install as BoardInstallForm;
@@ -21,7 +22,6 @@ use Database\Form\CreateMeeting as CreateMeetingForm;
 use Database\Form\DeleteAddress as DeleteAddressForm;
 use Database\Form\DeleteDecision as DeleteDecisionForm;
 use Database\Form\DeleteList as DeleteListForm;
-use Database\Form\Destroy as DestroyForm;
 use Database\Form\Export as ExportForm;
 use Database\Form\Fieldset\Address as AddressFieldset;
 use Database\Form\Fieldset\Decision as DecisionFieldset;
@@ -49,12 +49,12 @@ use Database\Form\Query as QueryForm;
 use Database\Form\QueryExport as QueryExportForm;
 use Database\Form\QuerySave as QuerySaveForm;
 use Database\Hydrator\Abolish as AbolishHydrator;
+use Database\Hydrator\Annulment as AnnulmentHydrator;
 use Database\Hydrator\AuditEntry as AuditEntryHydrator;
 use Database\Hydrator\Board\Discharge as BoardDischargeHydrator;
 use Database\Hydrator\Board\Install as BoardInstallHydrator;
 use Database\Hydrator\Board\Release as BoardReleaseHydrator;
 use Database\Hydrator\Budget as BudgetHydrator;
-use Database\Hydrator\Destroy as DestroyHydrator;
 use Database\Hydrator\Foundation as FoundationHydrator;
 use Database\Hydrator\Install as InstallHydrator;
 use Database\Hydrator\Key\Grant as KeyGrantHydrator;
@@ -135,7 +135,7 @@ class Module
             'invokables' => [
                 AbolishHydrator::class => AbolishHydrator::class,
                 BudgetHydrator::class => BudgetHydrator::class,
-                DestroyHydrator::class => DestroyHydrator::class,
+                AnnulmentHydrator::class => AnnulmentHydrator::class,
                 RegulationHydrator::class => RegulationHydrator::class,
                 FoundationHydrator::class => FoundationHydrator::class,
                 InstallHydrator::class => InstallHydrator::class,
@@ -285,13 +285,13 @@ class Module
 
                     return $form;
                 },
-                DestroyForm::class => static function (ContainerInterface $container) {
-                    $form = new DestroyForm(
+                AnnulmentForm::class => static function (ContainerInterface $container) {
+                    $form = new AnnulmentForm(
                         $container->get(MvcTranslator::class),
                         $container->get(MeetingFieldset::class),
                         $container->get(DecisionFieldset::class),
                     );
-                    $form->setHydrator($container->get(DestroyHydrator::class));
+                    $form->setHydrator($container->get(AnnulmentHydrator::class));
 
                     return $form;
                 },

--- a/module/Database/src/Service/Factory/MeetingFactory.php
+++ b/module/Database/src/Service/Factory/MeetingFactory.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Database\Service\Factory;
 
 use Database\Form\Abolish as AbolishForm;
+use Database\Form\Annulment as AnnulmentForm;
 use Database\Form\Board\Discharge as BoardDischargeForm;
 use Database\Form\Board\Install as BoardInstallForm;
 use Database\Form\Board\Release as BoardReleaseForm;
 use Database\Form\Budget as BudgetForm;
 use Database\Form\CreateMeeting as CreateMeetingForm;
 use Database\Form\DeleteDecision as DeleteDecisionForm;
-use Database\Form\Destroy as DestroyForm;
 use Database\Form\Export as ExportForm;
 use Database\Form\Foundation as FoundationForm;
 use Database\Form\Install as InstallForm;
@@ -50,8 +50,8 @@ class MeetingFactory implements FactoryInterface
         $createMeetingForm = $container->get(CreateMeetingForm::class);
         /** @var DeleteDecisionForm $deleteDecisionForm */
         $deleteDecisionForm = $container->get(DeleteDecisionForm::class);
-        /** @var DestroyForm $destroyForm */
-        $destroyForm = $container->get(DestroyForm::class);
+        /** @var AnnulmentForm $annulmentForm */
+        $annulmentForm = $container->get(AnnulmentForm::class);
         /** @var ExportForm $exportForm */
         $exportForm = $container->get(ExportForm::class);
         /** @var FoundationForm $foundationForm */
@@ -75,13 +75,13 @@ class MeetingFactory implements FactoryInterface
 
         return new MeetingService(
             $abolishForm,
+            $annulmentForm,
             $boardDischargeForm,
             $boardInstallForm,
             $boardReleaseForm,
             $budgetForm,
             $createMeetingForm,
             $deleteDecisionForm,
-            $destroyForm,
             $exportForm,
             $foundationForm,
             $installForm,

--- a/module/Database/src/Service/Meeting.php
+++ b/module/Database/src/Service/Meeting.php
@@ -6,13 +6,13 @@ namespace Database\Service;
 
 use Application\Model\Enums\MeetingTypes;
 use Database\Form\Abolish as AbolishForm;
+use Database\Form\Annulment as AnnulmentForm;
 use Database\Form\Board\Discharge as BoardDischargeForm;
 use Database\Form\Board\Install as BoardInstallForm;
 use Database\Form\Board\Release as BoardReleaseForm;
 use Database\Form\Budget as BudgetForm;
 use Database\Form\CreateMeeting as CreateMeetingForm;
 use Database\Form\DeleteDecision as DeleteDecisionForm;
-use Database\Form\Destroy as DestroyForm;
 use Database\Form\Export as ExportForm;
 use Database\Form\Foundation as FoundationForm;
 use Database\Form\Install as InstallForm;
@@ -41,13 +41,13 @@ class Meeting
 {
     public function __construct(
         private readonly AbolishForm $abolishForm,
+        private readonly AnnulmentForm $annulmentForm,
         private readonly BoardDischargeForm $boardDischargeForm,
         private readonly BoardInstallForm $boardInstallForm,
         private readonly BoardReleaseForm $boardReleaseForm,
         private readonly BudgetForm $budgetForm,
         private readonly CreateMeetingForm $createMeetingForm,
         private readonly DeleteDecisionForm $deleteDecisionForm,
-        private readonly DestroyForm $destroyForm,
         private readonly ExportForm $exportForm,
         private readonly FoundationForm $foundationForm,
         private readonly InstallForm $installForm,
@@ -170,11 +170,11 @@ class Meeting
     }
 
     /**
-     * Destroy decision.
+     * Annul decision.
      *
      * @return array{
      *     type: string,
-     *     form: DestroyForm,
+     *     form: AnnulmentForm,
      * }|array{
      *     type: string,
      *     decision: DecisionModel,
@@ -182,16 +182,16 @@ class Meeting
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
      */
-    public function destroyDecision(array $data): array
+    public function annulDecision(array $data): array
     {
-        $form = $this->getDestroyForm();
+        $form = $this->getAnnulmentForm();
 
         $form->setData($data);
         $form->bind(new DecisionModel());
 
         if (!$form->isValid()) {
             return [
-                'type' => 'destroy',
+                'type' => 'annulment',
                 'form' => $form,
             ];
         }
@@ -203,7 +203,7 @@ class Meeting
         $this->getMeetingMapper()->persist($decision->getMeeting());
 
         return [
-            'type' => 'destroy',
+            'type' => 'annulment',
             'decision' => $decision,
         ];
     }
@@ -940,11 +940,11 @@ class Meeting
     }
 
     /**
-     * Get the destroy form.
+     * Get the annulment form.
      */
-    public function getDestroyForm(): DestroyForm
+    public function getAnnulmentForm(): AnnulmentForm
     {
-        return $this->destroyForm;
+        return $this->annulmentForm;
     }
 
     /**

--- a/module/Database/view/database/export/index.phtml
+++ b/module/Database/view/database/export/index.phtml
@@ -33,8 +33,8 @@ function determineCategory($decision)
 
     switch (strtolower($type)) {
         case 'budget':
-        case 'reckoning':
-            return 'budget';
+        case 'statement':
+            return 'financial';
             break;
         case 'foundation':
         case 'abrogation':
@@ -68,7 +68,7 @@ function showCategory(Escaper $escaper, array $decisions): void
 if (isset($data)): ?>
     <?php
     $categories = array(
-        'budget' => array(),
+        'financial' => array(),
         'install' => array(),
         'other' => array(),
     );
@@ -81,7 +81,7 @@ if (isset($data)): ?>
     ob_start();
     ?>
     <h2>\subsection*{Begrotingen en Afrekeningen}</h2>
-    <?php showCategory($escaper, $categories['budget']) ?>
+    <?php showCategory($escaper, $categories['financial']) ?>
 
     <h2>\subsection*{Installaties en Decharges}</h2>
     <?php showCategory($escaper, $categories['install']) ?>

--- a/module/Database/view/database/meeting/annulmentform.phtml
+++ b/module/Database/view/database/meeting/annulmentform.phtml
@@ -3,17 +3,17 @@
 declare(strict_types=1);
 
 use Application\View\HelperTrait;
-use Database\Form\Destroy as DestroyForm;
+use Database\Form\Annulment as AnnulmentForm;
 use Laminas\View\Renderer\PhpRenderer;
 
 /**
  * @var PhpRenderer|HelperTrait $this
- * @var DestroyForm $form
+ * @var AnnulmentForm $form
  */
 ?>
 <script>
 $(document).ready(function() {
-    $('#destroy-decision').autocomplete({
+    $('#annulment-decision').autocomplete({
         minLength: 2,
         delay: 0,
         source: function(rq, response) {
@@ -45,14 +45,14 @@ $(document).ready(function() {
         },
         select: function(event, ui) {
             var decision = ui.item.id;
-            $('#destroy-meeting-type').val(decision.meeting_type);
-            $('#destroy-meeting-number').val(decision.meeting_number);
-            $('#destroy-decision-point').val(decision.decision_point);
-            $('#destroy-number').val(decision.decision_number);
-            $('.destroy-decision-num').text(decision.num);
-            $('.destroy-decision-content').text(decision.content);
-            $('.destroy-decision-display').show();
-            $('#destroy-decision-button').prop('disabled', false);
+            $('#annulment-meeting-type').val(decision.meeting_type);
+            $('#annulment-meeting-number').val(decision.meeting_number);
+            $('#annulment-decision-point').val(decision.decision_point);
+            $('#annulment-number').val(decision.decision_number);
+            $('.annulment-decision-num').text(decision.num);
+            $('.annulment-decision-content').text(decision.content);
+            $('.annulment-decision-display').show();
+            $('#annulment-decision-button').prop('disabled', false);
         }
     });
 });
@@ -61,7 +61,7 @@ $(document).ready(function() {
 <?php
 $form->prepare();
 
-$form->setAttribute('action', $this->url('meeting/decision/form', array('form' => 'destroy')));
+$form->setAttribute('action', $this->url('meeting/decision/form', array('form' => 'annulment')));
 $form->setAttribute('method', 'post');
 
 $form->setAttribute('role', 'form');
@@ -81,29 +81,29 @@ $fs = $form->get('fdecision');
 ?>
 <?php
 $element = $fs->get('meeting_type');
-$element->setAttribute('id', 'destroy-meeting-type');
+$element->setAttribute('id', 'annulment-meeting-type');
 ?>
 <?= $this->formHidden($element) ?>
 <?php
 $element = $fs->get('meeting_number');
-$element->setAttribute('id', 'destroy-meeting-number');
+$element->setAttribute('id', 'annulment-meeting-number');
 ?>
 <?= $this->formHidden($element) ?>
 <?php
 $element = $fs->get('point');
-$element->setAttribute('id', 'destroy-decision-point');
+$element->setAttribute('id', 'annulment-decision-point');
 ?>
 <?= $this->formHidden($element) ?>
 <?php
 $element = $fs->get('number');
-$element->setAttribute('id', 'destroy-number');
+$element->setAttribute('id', 'annulment-number');
 ?>
 <?= $this->formHidden($element) ?>
 <div class="form-group">
 <?php
 $element = $form->get('name');
 $element->setAttribute('class', 'form-control');
-$element->setAttribute('id', 'destroy-decision');
+$element->setAttribute('id', 'annulment-decision');
 $element->setAttribute('placeholder', $this->translate('Decision'));
 ?>
     <?= $this->formLabel($element) ?>
@@ -111,15 +111,15 @@ $element->setAttribute('placeholder', $this->translate('Decision'));
     <?= $this->formElementErrors($element) ?>
 </div>
 
-<p class="destroy-decision-display" style="display: none;">
-<strong><?= $this->translate('Decision') ?></strong> <strong class="destroy-decision-num"></strong>: <span class="destroy-decision-content"></span>
+<p class="annulment-decision-display" style="display: none;">
+<strong><?= $this->translate('Decision') ?></strong> <strong class="annulment-decision-num"></strong>: <span class="annulment-decision-content"></span>
 </p>
 
 <?php
 $submit = $form->get('submit');
 $submit->setLabel($this->translate('Annul Decision'));
 $submit->setAttribute('class', 'btn btn-primary');
-$submit->setAttribute('id', 'destroy-decision-button');
+$submit->setAttribute('id', 'annulment-decision-button');
 $submit->setAttribute('disabled', 'disabled');
 ?>
 <?= $this->formButton($submit) ?>

--- a/module/Database/view/database/meeting/decision.phtml
+++ b/module/Database/view/database/meeting/decision.phtml
@@ -117,8 +117,8 @@ use Laminas\View\Renderer\PhpRenderer;
     </div>
     <div class="tab-pane" id="vernietig">
         <br>
-        <?= $this->partial('database/meeting/destroyform', array(
-            'form' => $forms['destroy'],
+        <?= $this->partial('database/meeting/annulmentform', array(
+            'form' => $forms['annulment'],
         )); ?>
     </div>
     <div class="tab-pane" id="overig">

--- a/module/Database/view/database/meeting/decisionform.phtml
+++ b/module/Database/view/database/meeting/decisionform.phtml
@@ -27,8 +27,8 @@ case 'organ_regulation':
         'form' => $form
     ));
     break;
-case 'destroy':
-    echo $this->partial('database/meeting/destroyform', array(
+case 'annulment':
+    echo $this->partial('database/meeting/annulmentform', array(
         'form' => $form
     ));
     break;

--- a/module/Database/view/database/meeting/view.phtml
+++ b/module/Database/view/database/meeting/view.phtml
@@ -66,9 +66,9 @@ $(document).ready(function () {
 <?php foreach ($meeting->getDecisions() as $decision): ?>
     <li>
         <?= $this->translate('Decision') ?> <?= "{$meeting->getNumber()}.{$decision->getPoint()}.{$decision->getNumber()}" ?>:
-        <?php if ($decision->isDestroyed()): ?>
+        <?php if ($decision->isAnnulled()): ?>
             <?php
-            $dec = $decision->getDestroyedBy()->getDecision();
+            $dec = $decision->getAnnulledBy()->getDecision();
             $mt = $dec->getMeeting();
             ?>
             <strong>

--- a/module/Report/src/Model/Decision.php
+++ b/module/Report/src/Model/Decision.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
-use Report\Model\SubDecision\Destroy;
+use Report\Model\SubDecision\Annulment;
 
 /**
  * Decision model.
@@ -99,13 +99,13 @@ class Decision
     protected Collection $subdecisions;
 
     /**
-     * Destroyed by.
+     * Annulled by.
      */
     #[OneToOne(
-        targetEntity: Destroy::class,
+        targetEntity: Annulment::class,
         mappedBy: 'target',
     )]
-    protected ?Destroy $destroyedby = null;
+    protected ?Annulment $annulledBy = null;
 
     /**
      * Set the meeting.
@@ -223,20 +223,20 @@ class Decision
     }
 
     /**
-     * Get the subdecision by which this decision is destroyed.
+     * Get the subdecision by which this decision is annulled.
      *
-     * Or null, if it wasn't destroyed.
+     * Or null, if it wasn't annulled.
      */
-    public function getDestroyedBy(): ?Destroy
+    public function getAnnulledBy(): ?Annulment
     {
-        return $this->destroyedby;
+        return $this->annulledBy;
     }
 
     /**
-     * Check if this decision is destroyed by another decision.
+     * Check if this decision is annulled by another decision.
      */
-    public function isDestroyed(): bool
+    public function isAnnulled(): bool
     {
-        return null !== $this->destroyedby;
+        return null !== $this->annulledBy;
     }
 }

--- a/module/Report/src/Model/SubDecision.php
+++ b/module/Report/src/Model/SubDecision.php
@@ -17,9 +17,10 @@ use Report\Model\SubDecision\Abrogation;
 use Report\Model\SubDecision\Board\Discharge as BoardDischarge;
 use Report\Model\SubDecision\Board\Installation as BoardInstallation;
 use Report\Model\SubDecision\Board\Release as BoardRelease;
-use Report\Model\SubDecision\Budget;
 use Report\Model\SubDecision\Destroy;
 use Report\Model\SubDecision\Discharge;
+use Report\Model\SubDecision\Financial\Budget;
+use Report\Model\SubDecision\Financial\Statement;
 use Report\Model\SubDecision\Foundation;
 use Report\Model\SubDecision\FoundationReference;
 use Report\Model\SubDecision\Installation;
@@ -28,7 +29,6 @@ use Report\Model\SubDecision\Key\Withdrawal as KeyWithdrawal;
 use Report\Model\SubDecision\OrganRegulation;
 use Report\Model\SubDecision\Other;
 use Report\Model\SubDecision\Reappointment;
-use Report\Model\SubDecision\Reckoning;
 
 /**
  * SubDecision model.
@@ -47,8 +47,8 @@ use Report\Model\SubDecision\Reckoning;
         'installation' => Installation::class,
         'reappointment' => Reappointment::class,
         'discharge' => Discharge::class,
-        'budget' => Budget::class,
-        'reckoning' => Reckoning::class,
+        'financial_budget' => Budget::class,
+        'financial_statement' => Statement::class,
         'other' => Other::class,
         'destroy' => Destroy::class,
         'board_installation' => BoardInstallation::class,

--- a/module/Report/src/Model/SubDecision.php
+++ b/module/Report/src/Model/SubDecision.php
@@ -14,10 +14,10 @@ use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Report\Model\SubDecision\Abrogation;
+use Report\Model\SubDecision\Annulment;
 use Report\Model\SubDecision\Board\Discharge as BoardDischarge;
 use Report\Model\SubDecision\Board\Installation as BoardInstallation;
 use Report\Model\SubDecision\Board\Release as BoardRelease;
-use Report\Model\SubDecision\Destroy;
 use Report\Model\SubDecision\Discharge;
 use Report\Model\SubDecision\Financial\Budget;
 use Report\Model\SubDecision\Financial\Statement;
@@ -50,7 +50,7 @@ use Report\Model\SubDecision\Reappointment;
         'financial_budget' => Budget::class,
         'financial_statement' => Statement::class,
         'other' => Other::class,
-        'destroy' => Destroy::class,
+        'annulment' => Annulment::class,
         'board_installation' => BoardInstallation::class,
         'board_release' => BoardRelease::class,
         'board_discharge' => BoardDischarge::class,

--- a/module/Report/src/Model/SubDecision/Annulment.php
+++ b/module/Report/src/Model/SubDecision/Annulment.php
@@ -11,26 +11,26 @@ use Report\Model\Decision;
 use Report\Model\SubDecision;
 
 /**
- * Destroying a decision.
+ * Annulling a decision.
  *
  * This decision references to a different decision. The given decision is
- * destroyed, as if it did never exist.
+ * annulled, as if it did never exist.
  *
  * Note that this behaviour might not always work flawlessly. It is very
  * complicated, and thus there might be edge cases that I didn't completely
  * catch. If that is the case, let me know!
  *
- * Also note that destroying decisions that destroy is undefined behaviour!
+ * Also note that annulling decisions that annul is undefined behaviour!
  */
 #[Entity]
-class Destroy extends SubDecision
+class Annulment extends SubDecision
 {
     /**
-     * Reference to the destruction of a decision.
+     * Reference to the annulment of a decision.
      */
     #[OneToOne(
         targetEntity: Decision::class,
-        inversedBy: 'destroyedby',
+        inversedBy: 'annulledBy',
     )]
     #[JoinColumn(
         name: 'r_meeting_type',

--- a/module/Report/src/Model/SubDecision/Financial/Budget.php
+++ b/module/Report/src/Model/SubDecision/Financial/Budget.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Report\Model\SubDecision;
+namespace Report\Model\SubDecision\Financial;
 
 use DateTime;
 use Doctrine\ORM\Mapping\Column;

--- a/module/Report/src/Model/SubDecision/Financial/Statement.php
+++ b/module/Report/src/Model/SubDecision/Financial/Statement.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Report\Model\SubDecision;
+namespace Report\Model\SubDecision\Financial;
 
 use Doctrine\ORM\Mapping\Entity;
 
 #[Entity]
-class Reckoning extends Budget
+class Statement extends Budget
 {
 }

--- a/module/Report/src/Service/Meeting.php
+++ b/module/Report/src/Service/Meeting.php
@@ -291,7 +291,7 @@ class Meeting
 
             $reportSubDecision->setGranting($granting);
             $reportSubDecision->setWithdrawnOn($subdecision->getWithdrawnOn());
-        } elseif ($subdecision instanceof DatabaseSubDecisionModel\Destroy) {
+        } elseif ($subdecision instanceof DatabaseSubDecisionModel\Annulment) {
             $ref = $subdecision->getTarget();
             $target = $decRepo->find([
                 'meeting_type' => $ref->getMeeting()->getType(),
@@ -332,8 +332,8 @@ class Meeting
     public function deleteSubDecision(ReportSubDecisionModel $subDecision): void
     {
         switch (true) {
-            case $subDecision instanceof ReportSubDecisionModel\Destroy:
-                throw new Exception('Deletion of destroy decisions not implemented');
+            case $subDecision instanceof ReportSubDecisionModel\Annulment:
+                throw new Exception('Annulment of annulling decisions not implemented');
 
             case $subDecision instanceof ReportSubDecisionModel\Reappointment:
                 $installation = $subDecision->getInstallation();

--- a/module/Report/src/Service/Meeting.php
+++ b/module/Report/src/Service/Meeting.php
@@ -226,11 +226,11 @@ class Meeting
             $reportSubDecision->setName($subdecision->getName());
             $reportSubDecision->setOrganType($subdecision->getOrganType());
         } elseif (
-            $subdecision instanceof DatabaseSubDecisionModel\Reckoning
-            || $subdecision instanceof DatabaseSubDecisionModel\Budget
+            $subdecision instanceof DatabaseSubDecisionModel\Financial\Statement
+            || $subdecision instanceof DatabaseSubDecisionModel\Financial\Budget
             || $subdecision instanceof DatabaseSubDecisionModel\OrganRegulation
         ) {
-            // budget and reckoning
+            // financial budgets and statements
             if (null !== $subdecision->getMember()) {
                 $reportSubDecision->setMember($this->findMember($subdecision->getMember()));
             }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -101,9 +101,9 @@
         <exclude-pattern>module/User/src/Service/Factory/UserServiceFactory.php</exclude-pattern>
         <!-- Hydrators -->
         <exclude-pattern>module/Database/src/Hydrator/Abolish.php</exclude-pattern>
+        <exclude-pattern>module/Database/src/Hydrator/Annulment.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/AbstractDecision.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/Budget.php</exclude-pattern>
-        <exclude-pattern>module/Database/src/Hydrator/Destroy.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/Foundation.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/OrganRegulation.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/Install.php</exclude-pattern>
@@ -135,8 +135,8 @@
         <!-- Hydrators -->
         <exclude-pattern>module/Database/src/Hydrator/Abolish.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/AbstractDecision.php</exclude-pattern>
+        <exclude-pattern>module/Database/src/Hydrator/Annulment.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/Budget.php</exclude-pattern>
-        <exclude-pattern>module/Database/src/Hydrator/Destroy.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/Foundation.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/OrganRegulation.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Hydrator/Install.php</exclude-pattern>
@@ -153,12 +153,12 @@
         <exclude-pattern>module/Database/src/Module.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/Abolish.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/Address.php</exclude-pattern>
+        <exclude-pattern>module/Database/src/Form/Annulment.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/Budget.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/CreateMeeting.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/DeleteAddress.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/DeleteDecision.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/DeleteList.php</exclude-pattern>
-        <exclude-pattern>module/Database/src/Form/Destroy.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/Export.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/Foundation.php</exclude-pattern>
         <exclude-pattern>module/Database/src/Form/OrganRegulation.php</exclude-pattern>


### PR DESCRIPTION
`destroy` is a grossly inaccurate translation of `vernietigen` in the context of annulling decisions.

`reckoning` is a grossly inaccurate translation of `afrekening` in the context of finances. With this change we now have a financial `budget` and `statement`. These sub-decisions have also been moved into their own category.

Closes GH-248 and closes GH-249.