### PR TITLE
feat: do not show deleted members in API

### DIFF
--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-19 17:25+0200\n"
+"POT-Creation-Date: 2024-06-19 20:59+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Rink Pieters <rinkp@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.4\n"
+"X-Generator: Poedit 2.2.4\n"
 
 msgid "# Decisions"
 msgstr "# Decisions"
@@ -859,6 +859,9 @@ msgstr "Make Inactive"
 msgid "Make Member Inactive"
 msgstr "Make Member Inactive"
 
+msgid "Meeting"
+msgstr "Meeting"
+
 msgid "Meeting Date"
 msgstr "Meeting Date"
 
@@ -896,6 +899,9 @@ msgstr "Membership Type"
 msgid "Membership of Committees and Fraternities"
 msgstr "Membership of Committees and Fraternities"
 
+msgid "Member¹ - Allow operations on `deleted' members"
+msgstr "Member¹ - Allow operations on `deleted' members"
+
 msgid "Member¹ - Check if has reached age 16"
 msgstr "Member¹ - Check if has reached age 16"
 
@@ -919,6 +925,9 @@ msgstr "Member¹ - Get email address"
 
 msgid "Message"
 msgstr "Message"
+
+msgid "Minutes"
+msgstr "Minutes"
 
 msgid "Mistake?"
 msgstr "Mistake?"
@@ -1181,6 +1190,9 @@ msgstr "Student Address"
 
 msgid "Study"
 msgstr "Study"
+
+msgid "Submit"
+msgstr "Submit"
 
 msgid "Subscribe"
 msgstr "Subscribe"

--- a/module/Application/language/gewisdb.pot
+++ b/module/Application/language/gewisdb.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GEWISdb 2dbfbb7e-dirty\n"
+"Project-Id-Version: GEWISdb bbdacb70-dirty\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-19 17:25+0200\n"
+"POT-Creation-Date: 2024-06-19 20:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -801,6 +801,9 @@ msgstr ""
 msgid "Make Member Inactive"
 msgstr ""
 
+msgid "Meeting"
+msgstr ""
+
 msgid "Meeting Date"
 msgstr ""
 
@@ -838,6 +841,9 @@ msgstr ""
 msgid "Membership of Committees and Fraternities"
 msgstr ""
 
+msgid "Member¹ - Allow operations on `deleted' members"
+msgstr ""
+
 msgid "Member¹ - Check if has reached age 16"
 msgstr ""
 
@@ -860,6 +866,9 @@ msgid "Member¹ - Get email address"
 msgstr ""
 
 msgid "Message"
+msgstr ""
+
+msgid "Minutes"
 msgstr ""
 
 msgid "Mistake?"
@@ -1108,6 +1117,9 @@ msgid "Student Address"
 msgstr ""
 
 msgid "Study"
+msgstr ""
+
+msgid "Submit"
 msgstr ""
 
 msgid "Subscribe"

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-19 17:25+0200\n"
+"POT-Creation-Date: 2024-06-19 20:59+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Rink Pieters <rinkp@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.4\n"
+"X-Generator: Poedit 2.2.4\n"
 
 msgid "# Decisions"
 msgstr "# besluiten"
@@ -865,6 +865,9 @@ msgstr "Maak inactief"
 msgid "Make Member Inactive"
 msgstr "Maak lid inactief"
 
+msgid "Meeting"
+msgstr "Vergadering"
+
 msgid "Meeting Date"
 msgstr "Vergaderdatum"
 
@@ -902,6 +905,9 @@ msgstr "Lidmaatschapstype"
 msgid "Membership of Committees and Fraternities"
 msgstr "Lidmaatschap van commissies en disputen"
 
+msgid "Member¹ - Allow operations on `deleted' members"
+msgstr "Lid¹ - Acties op `verwijderde' leden toestaan"
+
 msgid "Member¹ - Check if has reached age 16"
 msgstr "Lid¹ - Controleer of lid ten minste 16 jaar is"
 
@@ -925,6 +931,9 @@ msgstr "Lid¹ - E-mailadres inzien"
 
 msgid "Message"
 msgstr "Bericht"
+
+msgid "Minutes"
+msgstr "Notulen"
 
 msgid "Mistake?"
 msgstr "Foutje?"
@@ -1186,6 +1195,9 @@ msgstr "Kameradres"
 
 msgid "Study"
 msgstr "Studie"
+
+msgid "Submit"
+msgstr "Verstuur"
 
 msgid "Subscribe"
 msgstr "Inschrijven"

--- a/module/Database/config/module.config.php
+++ b/module/Database/config/module.config.php
@@ -171,28 +171,28 @@ return [
                     'info' => [
                         'type' => Segment::class,
                         'options' => [
-                            'route' => '/info/:type/:number/:point/:decision/:subdecision',
+                            'route' => '/info/:type/:number/:point/:decision/:sequence',
                             'defaults' => ['action' => 'info'],
                             'constraints' => [
                                 'type' => 'ALV|BV|VV|Virt',
                                 'number' => '[0-9]*',
                                 'point' => '[0-9]*',
                                 'decision' => '[0-9]*',
-                                'subdecision' => '[0-9]*',
+                                'sequence' => '[0-9]*',
                             ],
                         ],
                     ],
                     'view' => [
                         'type' => Segment::class,
                         'options' => [
-                            'route' => '/:type/:number/:point/:decision/:subdecision',
+                            'route' => '/:type/:number/:point/:decision/:sequence',
                             'defaults' => ['action' => 'view'],
                             'constraints' => [
                                 'type' => 'ALV|BV|VV|Virt',
                                 'number' => '[0-9]*',
                                 'point' => '[0-9]*',
                                 'decision' => '[0-9]*',
-                                'subdecision' => '[0-9]*',
+                                'sequence' => '[0-9]*',
                             ],
                         ],
                     ],

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -45,7 +45,9 @@ class ApiController extends AbstractActionController
             $additionalProperties = array_diff($additionalProperties, ['organs']);
         }
 
-        $members = $this->apiService->getMembers($additionalProperties);
+        $allowDeleted = $this->apiAuthService->currentUserCan(ApiPermissions::MembersDeleted);
+
+        $members = $this->apiService->getMembers($additionalProperties, $allowDeleted);
         $res = ['data' => $members];
 
         return new JsonModel($res);
@@ -58,9 +60,11 @@ class ApiController extends AbstractActionController
     {
         $this->apiAuthService->assertCan(ApiPermissions::MembersR);
 
+        $allowDeleted = $this->apiAuthService->currentUserCan(ApiPermissions::MembersDeleted);
         $member = $this->apiService->getMember(
             (int) $this->params()->fromRoute('id'),
             $this->additionalProperties(),
+            $allowDeleted,
         );
         if (null === $member) {
             return $this->noContent();
@@ -79,8 +83,13 @@ class ApiController extends AbstractActionController
         $this->apiAuthService->assertCan(ApiPermissions::MembersActiveR);
 
         $includeInactiveFraternity = (bool) $this->getRequest()->getQuery('includeInactive', false);
+        $allowDeleted = $this->apiAuthService->currentUserCan(ApiPermissions::MembersDeleted);
 
-        $members = $this->apiService->getActiveMembers($this->additionalProperties(), $includeInactiveFraternity);
+        $members = $this->apiService->getActiveMembers(
+            $this->additionalProperties(),
+            $includeInactiveFraternity,
+            $allowDeleted,
+        );
         $res = ['data' => $members];
 
         return new JsonModel($res);

--- a/module/Database/src/Model/AuditRenewal.php
+++ b/module/Database/src/Model/AuditRenewal.php
@@ -66,7 +66,7 @@ class AuditRenewal extends AuditEntry
      */
     public function setOldExpiration(DateTime $oldExpiration): void
     {
-        $this->newExpiration = $oldExpiration;
+        $this->oldExpiration = $oldExpiration;
     }
 
     /**

--- a/module/Database/view/database/member/show.phtml
+++ b/module/Database/view/database/member/show.phtml
@@ -134,7 +134,7 @@ use Laminas\View\Renderer\PhpRenderer;
                         'number' => $install->getFoundation()->getDecision()->getMeeting()->getNumber(),
                         'point' => $install->getFoundation()->getDecision()->getPoint(),
                         'decision' => $install->getFoundation()->getDecision()->getNumber(),
-                        'subdecision' => $install->getFoundation()->getSequence(),
+                        'sequence' => $install->getFoundation()->getSequence(),
                     )) ?>">
                         <?= $install->getFoundation()->getAbbr() ?>
                     </a>

--- a/module/User/src/Model/Enums/ApiPermissions.php
+++ b/module/User/src/Model/Enums/ApiPermissions.php
@@ -21,6 +21,7 @@ enum ApiPermissions: string
     case MembersPropertyAge16 = 'members_read_is16';
     case MembersPropertyAge18 = 'members_read_is18';
     case MembersPropertyAge21 = 'members_read_is21';
+    case MembersDeleted = 'members_deleted';
     case OrgansMembershipR = 'organs_members_read';
     case All = '*';
 
@@ -43,6 +44,7 @@ enum ApiPermissions: string
             self::MembersPropertyAge16 => $translator->translate('Member¹ - Check if has reached age 16'),
             self::MembersPropertyAge18 => $translator->translate('Member¹ - Check if has reached age 18'),
             self::MembersPropertyAge21 => $translator->translate('Member¹ - Check if has reached age 21'),
+            self::MembersDeleted => $translator->translate('Member¹ - Allow operations on `deleted\' members'),
             self::OrgansMembershipR => $translator->translate('Read organ membership (per user/organ)'),
             self::All => $translator->translate('All API permissions'),
         };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -208,6 +208,7 @@ components:
         deleted:
           type: boolean
           example: false
+          description: Always false unless the API principal has MembersDeleted permission
         expiration:
           type: string
           format: date


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
With the introduction of this feature, we no longer return deleted members in the API unless the API token specifically has this permission. The main reason for this is that we do not want to sync data of members which we cannot delete for procedural reasons (e.g. they are linked to decisions) into other systems such as SudoSOS. This is a second catch for systems that do not consider 

With this change, by default, deleted members are hidden. 

Since this is a **breaking change**, we should grant existing applications with MembersR the MembersDeleted permission and then decide on a later date to cut this access together with the API principals. @GEWIS/pos @GEWIS/cbc-ad-software 

## Related issues/external references
Fixes GH-405 

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [x] New bugs, probably
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
