### PR TITLE
Fix `REMOTE_ADDR` not being actual remote addr behind reverse proxy

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -26,6 +26,12 @@ APP_URL=https://database.gewis.nl
 # Use off or "\"Restricted\"" (or another escaped string); also required an entry in docker/nginx/.htpasswd
 NGINX_REQUIRE_AUTH=off
 
+# Proxy configuration to allow getting actual IP address from remote
+# Note that PROXY_IPS must be a comma-delimited string
+PROXY_ENABLED=false
+PROXY_IPS=
+PROXY_HEADER=X-Real-IP
+
 # Stripe settings to enable auto-magic payment flow in enrolment form
 # The STRIPE_SECRET_KEY should at all times be a restricted key with the following permissions:
 # Write on "Core Objects: Charges", rak_charge_write (for refunds) and write on "Checkout"

--- a/config/autoload/local.development.php.dist
+++ b/config/autoload/local.development.php.dist
@@ -23,6 +23,15 @@ return [
     ],
 
     /**
+     * Proxy configuration.
+     */
+    'proxy' => [
+        'enabled' => boolval(getenv('PROXY_ENABLED')),
+        'ip_addresses' => explode(',', getenv('PROXY_IPS') ?: ''),
+        'header' => getenv('PROXY_HEADER'),
+    ],
+
+    /**
      * Checker service configuration.
      */
     'checker' => [

--- a/config/autoload/local.production.php.dist
+++ b/config/autoload/local.production.php.dist
@@ -23,6 +23,15 @@ return [
     ],
 
     /**
+     * Proxy configuration.
+     */
+    'proxy' => [
+        'enabled' => boolval(getenv('PROXY_ENABLED')),
+        'ip_addresses' => explode(',', getenv('PROXY_IPS') ?: ''),
+        'header' => getenv('PROXY_HEADER'),
+    ],
+
+    /**
      * Checker service configuration.
      */
     'checker' => [

--- a/module/Database/src/Controller/Factory/MemberControllerFactory.php
+++ b/module/Database/src/Controller/Factory/MemberControllerFactory.php
@@ -30,12 +30,15 @@ class MemberControllerFactory implements FactoryInterface
         $memberService = $container->get(MemberService::class);
         /** @var StripeService $stripeService */
         $stripeService = $container->get(StripeService::class);
+        /** @var string $remoteAddress */
+        $remoteAddress = $container->get('database_remoteaddress');
 
         return new MemberController(
             $translator,
             $checkerService,
             $memberService,
             $stripeService,
+            $remoteAddress,
         );
     }
 }

--- a/module/Database/src/Controller/MemberController.php
+++ b/module/Database/src/Controller/MemberController.php
@@ -33,6 +33,7 @@ class MemberController extends AbstractActionController
         private readonly CheckerService $checkerService,
         private readonly MemberService $memberService,
         private readonly StripeService $stripeService,
+        private readonly string $remoteAddress,
     ) {
     }
 
@@ -49,9 +50,8 @@ class MemberController extends AbstractActionController
      */
     public function subscribeAction(): Response|ViewModel
     {
-        $ipMCS = isset($_SERVER['REMOTE_ADDR'])
-            && ip2long($_SERVER['REMOTE_ADDR']) >= ip2long('131.155.68.0')
-            && ip2long($_SERVER['REMOTE_ADDR']) <= ip2long('131.155.71.255');
+        $ipMCS = ip2long($this->remoteAddress) >= ip2long('131.155.68.0')
+            && ip2long($this->remoteAddress) <= ip2long('131.155.71.255');
         if (7 === intval((new DateTime())->format('n')) && !$ipMCS) {
             return (new ViewModel())->setTemplate('database/member/subscribe-disabled');
         }

--- a/module/Database/src/Module.php
+++ b/module/Database/src/Module.php
@@ -115,6 +115,7 @@ use Database\Service\Member as MemberService;
 use Database\Service\Query as QueryService;
 use Database\Service\Stripe as StripeService;
 use Doctrine\Laminas\Hydrator\DoctrineObject;
+use Laminas\Http\PhpEnvironment\RemoteAddress;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\Mvc\I18n\Translator as MvcTranslator;
 use Psr\Container\ContainerInterface;
@@ -561,6 +562,19 @@ class Module
                     $transport->setOptions(new $optionsClass($config['options']));
 
                     return $transport;
+                },
+                ///////////////////////////////////////////////////////////////////////////
+                'database_remoteaddress' => static function (ContainerInterface $container) {
+                    $remote = new RemoteAddress();
+                    $isProxied = $container->get('config')['proxy']['enabled'];
+                    $trustedProxies = $container->get('config')['proxy']['ip_addresses'];
+                    $proxyHeader = $container->get('config')['proxy']['header'];
+
+                    $remote->setUseProxy($isProxied)
+                        ->setTrustedProxies($trustedProxies)
+                        ->setProxyHeader($proxyHeader);
+
+                    return $remote->getIpAddress();
                 },
             ],
             'shared' => [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This copies the proxy detection and real IP address parsing from GEWISWEB. Note that we currently abuse the DI to get the IP address into the `MemberController` such that it can be re-used elsewhere if necessary in the future.

It uses Laminas' `RemoteAddress` functionality to do the parsing automagically.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-413.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
