### PR TITLE
Change how renewal works for existing external members

### DIFF
--- a/module/Checker/src/Mapper/Member.php
+++ b/module/Checker/src/Mapper/Member.php
@@ -41,7 +41,7 @@ class Member
         $qb->select('m')
             ->addSelect('CASE WHEN m.lastCheckedOn IS NULL THEN 0 ELSE 1 END AS HIDDEN fix_ordering')
             ->from('Database\Model\Member', 'm')
-            ->where('m.type = \'ordinary\'')
+            ->where('m.type = \'ordinary\' OR m.type = \'external\'')
             ->andWhere('m.tueUsername IS NOT NULL')
             ->andWhere('m.membershipEndsOn IS NULL')
             ->andWhere('m.lastCheckedOn IS NULL OR m.lastCheckedOn < CURRENT_DATE()')
@@ -86,7 +86,7 @@ class Member
 
         $qb->select('m')
             ->from('Database\Model\Member', 'm')
-            ->where('m.type = \'ordinary\'')
+            ->where('m.type = \'ordinary\' OR m.type = \'external\'')
             ->andWhere('m.membershipEndsOn IS NULL')
             ->andWhere('m.expiration <= :endOfCurrentAssociationYear');
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
External members are now included in the yearly "`isStudying`" check. A flow from `external` to `ordinary` now also exists if the member was already studying but not at the department (and now is).

And included sanity check for making sure that renewals of external membership only happen if you were checked in the past year. To make sure that this properly works, if you become graduate `isStudying` is changed to `false`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [X] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
