### PR TITLE
Fix `membershipEndsOn` not updating when making `Member` `external`

### DIFF
--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -756,7 +756,7 @@ class Member
             case MembershipTypes::External:
                 $member->setIsStudying(true);
                 $membershipEndsOn = clone $expiration;
-                $membershipEndsOn->setDate($year - 1, 7, 1);
+                $membershipEndsOn->setDate($year, 7, 1);
                 $member->setMembershipEndsOn($membershipEndsOn);
                 $member->setType(MembershipTypes::External);
                 break;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

Original code was added in 0b26dfb to address an issue with the membership change, however, later in 9f75598de the `+ 2` / `+ 1` for the expiration were reverted to make all membership changes retroactive again. Unfortunately, the case for `external` was never changed to reflect this. As such, the `membershipEndsOn` was always in the past, while for `external` this is not allowed (should always be at the end of the current assocation year).

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-420 and ABC-2407-095.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
