### PR TITLE
[API] Improve status reporting content/headers

### DIFF
--- a/module/Application/src/Controller/IndexController.php
+++ b/module/Application/src/Controller/IndexController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Controller;
 
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\Plugin\Identity\Identity;
 use Laminas\Session\Container as SessionContainer;
@@ -16,7 +16,7 @@ use function explode;
  */
 class IndexController extends AbstractActionController
 {
-    public function langAction(): Response
+    public function langAction(): HttpResponse
     {
         $session = new SessionContainer('lang');
         $session->lang = $this->params()->fromRoute('lang');

--- a/module/Database/config/module.config.php
+++ b/module/Database/config/module.config.php
@@ -660,6 +660,16 @@ return [
                             ],
                         ],
                     ],
+                    'example500' => [
+                        'type' => Literal::class,
+                        'options' => [
+                            'route' => '/example500',
+                            'defaults' => [
+                                'controller' => ApiController::class,
+                                'action' => 'example500',
+                            ],
+                        ],
+                    ],
                     'members' => [
                         'type' => Literal::class,
                         'options' => [

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -8,7 +8,6 @@ use Database\Model\Enums\ApiResponseStatuses;
 use Database\Service\Api as ApiService;
 use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\JsonModel;
 use RuntimeException;
 use User\Model\Enums\ApiPermissions;
@@ -74,7 +73,7 @@ class ApiController extends AbstractActionController
     /**
      * Return member
      */
-    public function memberAction(): JsonModel|ResponseInterface
+    public function memberAction(): JsonModel
     {
         $this->apiAuthService->assertCan(ApiPermissions::MembersR);
 

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -10,6 +10,7 @@ use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\JsonModel;
+use RuntimeException;
 use User\Model\Enums\ApiPermissions;
 use User\Service\ApiAuthenticationService;
 
@@ -38,6 +39,13 @@ class ApiController extends AbstractActionController
             'sync_paused' => $syncPaused,
         ]);
     }
+
+    /**
+     * Error 500 action.
+     */
+    public function example500Action(): JsonModel
+    {
+        throw new RuntimeException('An example exception was thrown.');
     }
 
     /**
@@ -118,7 +126,7 @@ class ApiController extends AbstractActionController
     {
         $response = $this->getResponse();
         if ($response instanceof Response) {
-        $response->setStatusCode(Response::STATUS_CODE_204);
+            $response->setStatusCode(Response::STATUS_CODE_204);
         }
 
         $res = [

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -6,7 +6,7 @@ namespace Database\Controller;
 
 use Database\Model\Enums\ApiResponseStatuses;
 use Database\Service\Api as ApiService;
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\JsonModel;
@@ -125,8 +125,8 @@ class ApiController extends AbstractActionController
     private function noContent(): JsonModel
     {
         $response = $this->getResponse();
-        if ($response instanceof Response) {
-            $response->setStatusCode(Response::STATUS_CODE_204);
+        if ($response instanceof HttpResponse) {
+            $response->setStatusCode(HttpResponse::STATUS_CODE_204);
         }
 
         $res = [

--- a/module/Database/src/Controller/ApiController.php
+++ b/module/Database/src/Controller/ApiController.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Database\Controller;
 
+use Database\Model\Enums\ApiResponseStatuses;
 use Database\Service\Api as ApiService;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\JsonModel;
 use User\Model\Enums\ApiPermissions;
 use User\Service\ApiAuthenticationService;
@@ -30,7 +32,12 @@ class ApiController extends AbstractActionController
 
         $syncPaused = $this->apiService->isSyncPaused();
 
-        return new JsonModel(['healthy' => true, 'sync_paused' => $syncPaused]);
+        return new JsonModel([
+            'status' => ApiResponseStatuses::Success,
+            'healthy' => true,
+            'sync_paused' => $syncPaused,
+        ]);
+    }
     }
 
     /**
@@ -48,7 +55,10 @@ class ApiController extends AbstractActionController
         $allowDeleted = $this->apiAuthService->currentUserCan(ApiPermissions::MembersDeleted);
 
         $members = $this->apiService->getMembers($additionalProperties, $allowDeleted);
-        $res = ['data' => $members];
+        $res = [
+            'status' => ApiResponseStatuses::Success,
+            'data' => $members,
+        ];
 
         return new JsonModel($res);
     }
@@ -56,7 +66,7 @@ class ApiController extends AbstractActionController
     /**
      * Return member
      */
-    public function memberAction(): JsonModel|Response
+    public function memberAction(): JsonModel|ResponseInterface
     {
         $this->apiAuthService->assertCan(ApiPermissions::MembersR);
 
@@ -70,7 +80,10 @@ class ApiController extends AbstractActionController
             return $this->noContent();
         }
 
-        $res = ['data' => $member];
+        $res = [
+            'status' => ApiResponseStatuses::Success,
+            'data' => $member,
+        ];
 
         return new JsonModel($res);
     }
@@ -90,7 +103,10 @@ class ApiController extends AbstractActionController
             $includeInactiveFraternity,
             $allowDeleted,
         );
-        $res = ['data' => $members];
+        $res = [
+            'status' => ApiResponseStatuses::Success,
+            'data' => $members,
+        ];
 
         return new JsonModel($res);
     }
@@ -98,12 +114,19 @@ class ApiController extends AbstractActionController
     /**
      * To follow best practices, we generate a 204 for empty datasets
      */
-    private function noContent(): Response
+    private function noContent(): JsonModel
     {
-        $response = new Response();
+        $response = $this->getResponse();
+        if ($response instanceof Response) {
         $response->setStatusCode(Response::STATUS_CODE_204);
+        }
 
-        return $response;
+        $res = [
+            'status' => ApiResponseStatuses::Success,
+            'data' => null,
+        ];
+
+        return new JsonModel($res);
     }
 
     /**

--- a/module/Database/src/Controller/MeetingController.php
+++ b/module/Database/src/Controller/MeetingController.php
@@ -11,7 +11,7 @@ use Database\Model\Meeting as MeetingModel;
 use Database\Service\Api as ApiService;
 use Database\Service\Meeting as MeetingService;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
@@ -42,7 +42,7 @@ class MeetingController extends AbstractActionController
     /**
      * Create a new meeting.
      */
-    public function createAction(): Response|ViewModel
+    public function createAction(): HttpResponse|ViewModel
     {
         $request = $this->getRequest();
 
@@ -159,7 +159,7 @@ class MeetingController extends AbstractActionController
     /**
      * Decision form action.
      */
-    public function decisionformAction(): Response|ViewModel
+    public function decisionformAction(): HttpResponse|ViewModel
     {
         if (!$this->getRequest()->isPost()) {
             return $this->redirect()->toRoute('meeting');

--- a/module/Database/src/Controller/ProspectiveMemberController.php
+++ b/module/Database/src/Controller/ProspectiveMemberController.php
@@ -7,7 +7,7 @@ namespace Database\Controller;
 use Database\Model\ProspectiveMember as ProspectiveMemberModel;
 use Database\Service\Member as MemberService;
 use Database\Service\Stripe as StripeService;
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\View\Model\JsonModel;
@@ -72,7 +72,7 @@ class ProspectiveMemberController extends AbstractActionController
      *
      * Shows prospective member information.
      */
-    public function finalizeAction(): Response
+    public function finalizeAction(): HttpResponse
     {
         $lidnr = (int) $this->params()->fromRoute('id');
 
@@ -111,7 +111,7 @@ class ProspectiveMemberController extends AbstractActionController
      *
      * Delete a prospective member.
      */
-    public function deleteAction(): Response|ViewModel
+    public function deleteAction(): HttpResponse|ViewModel
     {
         $lidnr = (int) $this->params()->fromRoute('id');
         $prospectiveMember = $this->memberService->getProspectiveMember($lidnr);

--- a/module/Database/src/Controller/QueryController.php
+++ b/module/Database/src/Controller/QueryController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Database\Controller;
 
 use Database\Service\Query as QueryService;
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
@@ -18,7 +18,7 @@ class QueryController extends AbstractActionController
     /**
      * Index action.
      */
-    public function indexAction(): Response|ViewModel
+    public function indexAction(): HttpResponse|ViewModel
     {
         if ($this->getRequest()->isPost()) {
             $post = $this->getRequest()->getPost()->toArray();
@@ -74,7 +74,7 @@ class QueryController extends AbstractActionController
     /**
      * Export action.
      */
-    public function exportAction(): Response|ViewModel
+    public function exportAction(): HttpResponse|ViewModel
     {
         if ($this->getRequest()->isPost()) {
             $result = $this->queryService->execute(

--- a/module/Database/src/Controller/SettingsController.php
+++ b/module/Database/src/Controller/SettingsController.php
@@ -6,7 +6,7 @@ namespace Database\Controller;
 
 use Database\Service\InstallationFunction as InstallationFunctionService;
 use Database\Service\MailingList as MailingListService;
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
@@ -59,7 +59,7 @@ class SettingsController extends AbstractActionController
     /**
      * List deletion action
      */
-    public function deleteListAction(): Response|ViewModel
+    public function deleteListAction(): HttpResponse|ViewModel
     {
         $name = $this->params()->fromRoute('name');
 

--- a/module/Database/src/Model/Enums/ApiResponseStatuses.php
+++ b/module/Database/src/Model/Enums/ApiResponseStatuses.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Model\Enums;
+
+/**
+ * Enum for the different statuses an API response can have
+ */
+enum ApiResponseStatuses: string
+{
+    // For 2xx codes
+    case Success = 'success';
+
+    // For 404 HTTP code
+    case NotFound = 'notfound';
+
+    // For 5xx HTTP codes
+    case Error = 'error';
+}

--- a/module/Database/src/Model/Enums/ApiResponseStatuses.php
+++ b/module/Database/src/Model/Enums/ApiResponseStatuses.php
@@ -15,6 +15,9 @@ enum ApiResponseStatuses: string
     // For 404 HTTP code
     case NotFound = 'notfound';
 
+    // For 403 HTTP code
+    case Forbidden = 'forbidden';
+
     // For 5xx HTTP codes
     case Error = 'error';
 }

--- a/module/User/src/Controller/ApiSettingsController.php
+++ b/module/User/src/Controller/ApiSettingsController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace User\Controller;
 
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\I18n\Translator as MvcTranslator;
 use Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger;
@@ -41,7 +41,7 @@ class ApiSettingsController extends AbstractActionController
     /**
      * Create an API principal
      */
-    public function createPrincipalAction(): Response|ViewModel
+    public function createPrincipalAction(): HttpResponse|ViewModel
     {
         $form = $this->apiPrincipalService->getCreateForm();
 
@@ -72,7 +72,7 @@ class ApiSettingsController extends AbstractActionController
     /**
      * Edit an API principal
      */
-    public function editPrincipalAction(): Response|ViewModel
+    public function editPrincipalAction(): HttpResponse|ViewModel
     {
         $id = (int) $this->params()->fromRoute('id');
         $principal = $this->apiPrincipalService->find($id);
@@ -104,7 +104,7 @@ class ApiSettingsController extends AbstractActionController
         ]);
     }
 
-    public function removePrincipalAction(): Response
+    public function removePrincipalAction(): HttpResponse
     {
         if ($this->getRequest()->isPost()) {
             $result = $this->apiPrincipalService->remove((int) $this->params()->fromRoute('id'));
@@ -122,12 +122,12 @@ class ApiSettingsController extends AbstractActionController
         return $this->redirectList();
     }
 
-    private function redirectList(): Response
+    private function redirectList(): HttpResponse
     {
         return $this->redirect()->toRoute('settings/api-principals');
     }
 
-    public function notFoundAction(): Response
+    public function notFoundAction(): HttpResponse
     {
         $this->flashMessenger()->addWarningMessage(
             sprintf(

--- a/module/User/src/Controller/SettingsController.php
+++ b/module/User/src/Controller/SettingsController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace User\Controller;
 
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use User\Service\UserService;
@@ -34,7 +34,7 @@ class SettingsController extends AbstractActionController
     /**
      * Create a user.
      */
-    public function createUserAction(): Response|ViewModel
+    public function createUserAction(): HttpResponse|ViewModel
     {
         $form = $this->userService->getCreateForm();
 
@@ -52,7 +52,7 @@ class SettingsController extends AbstractActionController
     /**
      * Edit a user.
      */
-    public function editUserAction(): Response|ViewModel
+    public function editUserAction(): HttpResponse|ViewModel
     {
         $form = $this->userService->getEditForm();
         $id = (int) $this->params()->fromRoute('id');
@@ -81,7 +81,7 @@ class SettingsController extends AbstractActionController
     /**
      * Remove a user.
      */
-    public function removeUserAction(): Response
+    public function removeUserAction(): HttpResponse
     {
         if ($this->getRequest()->isPost()) {
             $this->userService->remove((int) $this->params()->fromRoute('id'));

--- a/module/User/src/Controller/UserController.php
+++ b/module/User/src/Controller/UserController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace User\Controller;
 
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 use User\Service\UserService;
@@ -23,7 +23,7 @@ class UserController extends AbstractActionController
     /**
      * User login action
      */
-    public function indexAction(): Response|ViewModel
+    public function indexAction(): HttpResponse|ViewModel
     {
         if ($this->getRequest()->isPost()) {
             $result = $this->service->login($this->getRequest()->getPost()->toArray());
@@ -42,7 +42,7 @@ class UserController extends AbstractActionController
     /**
      * User logout action
      */
-    public function logoutAction(): Response
+    public function logoutAction(): HttpResponse
     {
         $this->service->logout();
 

--- a/module/User/src/Listener/AuthenticationListener.php
+++ b/module/User/src/Listener/AuthenticationListener.php
@@ -69,10 +69,11 @@ final class AuthenticationListener
             return null;
         }
 
-        $e->stopPropagation(true);
         $response = $e->getResponse();
         $response->getHeaders()->addHeaderLine('Location', '/login');
         $response->setStatusCode(302);
+
+        $e->stopPropagation();
 
         return $response;
     }

--- a/module/User/src/Listener/AuthenticationListener.php
+++ b/module/User/src/Listener/AuthenticationListener.php
@@ -6,8 +6,9 @@ namespace User\Listener;
 
 use InvalidArgumentException;
 use Laminas\Authentication\AuthenticationService;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\MvcEvent;
-use Laminas\Stdlib\ResponseInterface as Response;
+use Laminas\Stdlib\ResponseInterface;
 use LogicException;
 use User\Adapter\ApiPrincipalAdapter;
 use User\Service\ApiAuthenticationService;
@@ -29,7 +30,7 @@ final class AuthenticationListener
     ) {
     }
 
-    public function __invoke(MvcEvent $e): ?Response
+    public function __invoke(MvcEvent $e): ?ResponseInterface
     {
         if (MvcEvent::EVENT_ROUTE !== $e->getName()) {
             throw new InvalidArgumentException(
@@ -62,17 +63,21 @@ final class AuthenticationListener
     /**
      * Handle authentication for users
      */
-    private function dbuserAuth(MvcEvent $e): ?Response
+    private function dbuserAuth(MvcEvent $e): ?ResponseInterface
     {
         if ($this->authService->hasIdentity()) {
             // user is logged in, just continue
             return null;
         }
 
+        // If this is a HTTP request, we redirect the user to the login page
         $response = $e->getResponse();
-        $response->getHeaders()->addHeaderLine('Location', '/login');
-        $response->setStatusCode(302);
+        if ($response instanceof HttpResponse) {
+            $response->getHeaders()->addHeaderLine('Location', '/login');
+            $response->setStatusCode(302);
+        }
 
+        // Return $response will prevent output, but we also stop other listeners when we need to logon first
         $e->stopPropagation();
 
         return $response;
@@ -81,7 +86,7 @@ final class AuthenticationListener
     /**
      * Handle authentication for api tokens
      */
-    private function apiAuth(MvcEvent $e): ?Response
+    private function apiAuth(MvcEvent $e): ?ResponseInterface
     {
         if ($e->getRequest()->getHeaders()->has('Authorization')) {
             // This is an API call, we do this on every request
@@ -93,9 +98,14 @@ final class AuthenticationListener
             }
         }
 
+        // If this is a HTTP request, we add authentication headers
         $response = $e->getResponse();
-        $response->getHeaders()->addHeaderLine('WWW-Authenticate', 'Bearer realm="/api"');
-        $response->setStatusCode(401);
+        if ($response instanceof HttpResponse) {
+            $response->getHeaders()->addHeaderLine('WWW-Authenticate', 'Bearer realm="/api"');
+            $response->setStatusCode(401);
+        }
+
+        $e->stopPropagation();
 
         return $response;
     }

--- a/module/User/src/Listener/AuthorizationListener.php
+++ b/module/User/src/Listener/AuthorizationListener.php
@@ -39,6 +39,6 @@ final class AuthorizationListener
             $response->setStatusCode(Response::STATUS_CODE_403);
         }
 
-        $e->stopPropagation(true);
+        $e->stopPropagation();
     }
 }

--- a/module/User/src/Listener/AuthorizationListener.php
+++ b/module/User/src/Listener/AuthorizationListener.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace User\Listener;
 
+use Database\Model\Enums\ApiResponseStatuses;
+use Laminas\Http\Response;
 use Laminas\Mvc\MvcEvent;
 use Laminas\View\Model\JsonModel;
 use User\Model\Exception\NotAllowed as NotAllowedException;
@@ -25,14 +27,18 @@ final class AuthorizationListener
             return;
         }
 
-        $e->stopPropagation(true);
         $e->setViewModel(new JsonModel([
-            'status' => 'error',
+            'status' => ApiResponseStatuses::Error,
             'error' => [
                 'type' => NotAllowedException::class,
                 'message' => $e->getParam('exception')->getMessage(),
             ],
         ]));
-        $e->getResponse()->setStatusCode(403);
+        $response = $e->getResponse();
+        if ($response instanceof Response) {
+            $response->setStatusCode(Response::STATUS_CODE_403);
+        }
+
+        $e->stopPropagation(true);
     }
 }

--- a/module/User/src/Listener/AuthorizationListener.php
+++ b/module/User/src/Listener/AuthorizationListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace User\Listener;
 
 use Database\Model\Enums\ApiResponseStatuses;
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\MvcEvent;
 use Laminas\View\Model\JsonModel;
 use User\Model\Exception\NotAllowed as NotAllowedException;
@@ -29,8 +29,8 @@ final class AuthorizationListener
             ],
         ]));
         $response = $e->getResponse();
-        if ($response instanceof Response) {
-            $response->setStatusCode(Response::STATUS_CODE_403);
+        if ($response instanceof HttpResponse) {
+            $response->setStatusCode(HttpResponse::STATUS_CODE_403);
         }
 
         $e->stopPropagation();

--- a/module/User/src/Listener/AuthorizationListener.php
+++ b/module/User/src/Listener/AuthorizationListener.php
@@ -9,15 +9,9 @@ use Laminas\Http\Response;
 use Laminas\Mvc\MvcEvent;
 use Laminas\View\Model\JsonModel;
 use User\Model\Exception\NotAllowed as NotAllowedException;
-use User\Service\ApiAuthenticationService;
 
 final class AuthorizationListener
 {
-    public function __construct(
-        private readonly ApiAuthenticationService $apiAuthService,
-    ) {
-    }
-
     public function __invoke(MvcEvent $e): void
     {
         if (

--- a/module/User/src/Listener/AuthorizationListener.php
+++ b/module/User/src/Listener/AuthorizationListener.php
@@ -22,7 +22,7 @@ final class AuthorizationListener
         }
 
         $e->setViewModel(new JsonModel([
-            'status' => ApiResponseStatuses::Error,
+            'status' => ApiResponseStatuses::Forbidden,
             'error' => [
                 'type' => NotAllowedException::class,
                 'message' => $e->getParam('exception')->getMessage(),

--- a/module/User/src/Listener/DispatchErrorFormatterListener.php
+++ b/module/User/src/Listener/DispatchErrorFormatterListener.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace User\Listener;
+
+use Database\Model\Enums\ApiResponseStatuses;
+use Laminas\Http\Request;
+use Laminas\Http\Response;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Router\RouteMatch;
+use Laminas\Router\RouteStackInterface as Router;
+use Laminas\View\Model\JsonModel;
+use LogicException;
+
+use function strpos;
+use function strrpos;
+use function substr;
+
+final class DispatchErrorFormatterListener
+{
+    private function matchAncestorRoute(
+        Request $request,
+        Router $router,
+    ): ?RouteMatch {
+        $request = clone $request;
+        $uri = clone $request->getUri();
+        $path = $uri->getPath();
+        $match = null;
+
+        while (null === $match && false !== strpos($path, '/')) {
+            $path = substr($path, 0, strrpos($path, '/'));
+            if ('' === $path) {
+                $uri->setPath('/');
+            } else {
+                $uri->setPath($path);
+            }
+
+            $request->setUri($uri);
+            $match = $router->match($request);
+        }
+
+        return $match;
+    }
+
+    private function isApiMatch(RouteMatch $match): bool
+    {
+        return AuthenticationListener::AUTH_API === $match->getParam('auth_type', AuthenticationListener::AUTH_DBUSER);
+    }
+
+    private function handleNoMatchedRoute(MvcEvent $e): void
+    {
+        $router = $e->getRouter();
+        $request = $e->getRequest();
+
+        // If this is not a HTTP request, we cannot assume anything about routes
+        if (!($request instanceof Request)) {
+            return;
+        }
+
+        $match = $this->matchAncestorRoute($request, $router);
+
+        // Regular routes are dealt with by default handling
+        if (!$this->isApiMatch($match)) {
+            return;
+        }
+
+        // If this is probably an API route, response should be JSON
+        $view = new JsonModel([
+            'status' => ApiResponseStatuses::NotFound,
+            'error' => [
+                'type' => $e->getError(),
+                'exception' => $e->getParam('exception')?->getMessage(),
+            ],
+        ]);
+        $e->setViewModel($view);
+        $response = $e->getResponse();
+        if ($response instanceof Response) {
+            $response->setStatusCode(Response::STATUS_CODE_404);
+        }
+
+        $e->stopPropagation(true);
+    }
+
+    private function handleMatchedRoute(
+        MvcEvent $e,
+        RouteMatch $match,
+    ): void {
+        // Regular routes are dealt with by default handling
+        if (!$this->isApiMatch($match)) {
+            return;
+        }
+
+        // If this is probably an API route, response should be JSON
+        $view = new JsonModel([
+            'status' => ApiResponseStatuses::Error,
+            'error' => [
+                'type' => $e->getError(),
+                'exception' => $e->getParam('exception')?->getMessage(),
+            ],
+        ]);
+        $e->setViewModel($view);
+        $response = $e->getResponse();
+        if ($response instanceof Response) {
+            $response->setStatusCode(Response::STATUS_CODE_500);
+        }
+
+        $e->stopPropagation(true);
+    }
+
+    public function __invoke(MvcEvent $e): void
+    {
+        /**
+         * The source code is public so we can give away 404 errors if it is because of no route
+         * This does not include 404 responses that are returned by logic, such as when a member does not exist
+         **/
+        if ('error-router-no-match' === $e->getError()) {
+            $this->handleNoMatchedRoute($e);
+
+            return;
+        }
+
+        /**
+         * If this is not an error-router-no-match error, we must have a matching route
+         */
+        $match = $e->getRouteMatch();
+
+        // We should always have a match here; if we do not, throw an exception
+        // possibly including previous exceptions
+        if (null === $match) {
+            throw new LogicException(
+                message: 'Assumed route would be present; no route present',
+                previous: $e->getParam('exception', null),
+            );
+        }
+
+        // If we do have a match, this implies we have properly authenticated before
+        $this->handleMatchedRoute($e, $match);
+    }
+}

--- a/module/User/src/Listener/DispatchErrorFormatterListener.php
+++ b/module/User/src/Listener/DispatchErrorFormatterListener.php
@@ -6,7 +6,7 @@ namespace User\Listener;
 
 use Database\Model\Enums\ApiResponseStatuses;
 use Laminas\Http\Request;
-use Laminas\Http\Response;
+use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteMatch;
 use Laminas\Router\RouteStackInterface as Router;
@@ -75,8 +75,8 @@ final class DispatchErrorFormatterListener
         ]);
         $e->setViewModel($view);
         $response = $e->getResponse();
-        if ($response instanceof Response) {
-            $response->setStatusCode(Response::STATUS_CODE_404);
+        if ($response instanceof HttpResponse) {
+            $response->setStatusCode(HttpResponse::STATUS_CODE_404);
         }
 
         $e->stopPropagation();
@@ -101,8 +101,8 @@ final class DispatchErrorFormatterListener
         ]);
         $e->setViewModel($view);
         $response = $e->getResponse();
-        if ($response instanceof Response) {
-            $response->setStatusCode(Response::STATUS_CODE_500);
+        if ($response instanceof HttpResponse) {
+            $response->setStatusCode(HttpResponse::STATUS_CODE_500);
         }
 
         $e->stopPropagation();

--- a/module/User/src/Listener/DispatchErrorFormatterListener.php
+++ b/module/User/src/Listener/DispatchErrorFormatterListener.php
@@ -79,7 +79,7 @@ final class DispatchErrorFormatterListener
             $response->setStatusCode(Response::STATUS_CODE_404);
         }
 
-        $e->stopPropagation(true);
+        $e->stopPropagation();
     }
 
     private function handleMatchedRoute(
@@ -105,7 +105,7 @@ final class DispatchErrorFormatterListener
             $response->setStatusCode(Response::STATUS_CODE_500);
         }
 
-        $e->stopPropagation(true);
+        $e->stopPropagation();
     }
 
     public function __invoke(MvcEvent $e): void

--- a/module/User/src/Module.php
+++ b/module/User/src/Module.php
@@ -42,9 +42,7 @@ class Module
         /**
          * Catch authorization exceptions
          */
-        $authorizationListener = new AuthorizationListener(
-            $apiAuthService,
-        );
+        $authorizationListener = new AuthorizationListener();
         $eventManager->attach(MvcEvent::EVENT_DISPATCH_ERROR, $authorizationListener, 10);
 
         /**

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,7 +9,7 @@ info:
   license:
     name: GNU GENERAL PUBLIC LICENSE Version 3
     url: https://github.com/GEWIS/gewisdb/blob/main/LICENSE.txt
-  version: 61a3f816c126d454d7bd665dd6788f9d7a619961
+  version: 3.0.1
 externalDocs:
   description: Contribute to this API
   url: https://github.com/GEWIS/gewisdb
@@ -90,6 +90,9 @@ paths:
               schema:
                 type: object
                 properties:
+                  status:
+                    type: string
+                    example: "success"
                   data:
                     type: array
                     items:
@@ -121,6 +124,9 @@ paths:
               schema:
                 type: object
                 properties:
+                  status:
+                    type: string
+                    example: "success"
                   data:
                     $ref: '#/components/schemas/Member'
         204:
@@ -153,6 +159,9 @@ paths:
               schema:
                 type: object
                 properties:
+                  status:
+                    type: string
+                    example: "success"
                   data:
                     type: array
                     items:
@@ -168,6 +177,9 @@ components:
     health:
       type: object
       properties:
+        status:
+          type: string
+          example: "success"
         healthy:
           type: boolean
         sync_paused:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -328,6 +328,44 @@ components:
           type: string
           example: Testorgaan
   responses:
+    server_error:
+      description: There was an error in the server. Most likely, this is a permanent error.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                default: "error"
+              error:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    default: "error-exception"
+                  exception:
+                    type: string
+                    example: "An example exception was thrown"
+    not_found_route:
+      description: This route does not exist (which is different from not finding a specific resource)
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                default: "error"
+              error:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    default: "error-router-no-match"
+                  exception:
+                    type: string
+                    example: null
     no_permission:
       description: The token that was used does not have the required permissions
       content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -393,7 +393,7 @@ components:
             properties:
               status:
                 type: string
-                default: "error"
+                default: "forbidden"
               error:
                 type: object
                 properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -171,7 +171,25 @@ paths:
       security:
         - api_auth:
             - MembersActiveR
-
+  /example404:
+    get:
+      summary: Example 404
+      description: This 404 will be returned if there is a mistake in the requested path
+      tags:
+        - errors
+      responses:
+        404:
+          $ref: '#/components/responses/not_found_route'
+  /example500:
+    get:
+      summary: Example 500
+      description: This 500 will be returned if there is a mistake in the requested path
+      tags:
+        - errors
+      responses:
+        500:
+          $ref: '#/components/responses/server_error'
+          
 components:
   schemas:
     health:

--- a/psalm/psalm-baseline.xml
+++ b/psalm/psalm-baseline.xml
@@ -13,7 +13,7 @@
   <file src="module/Database/src/Controller/QueryController.php">
     <InvalidReturnStatement occurrences="1"/>
     <InvalidReturnType occurrences="1">
-      <code>Response|ViewModel</code>
+      <code>HttpResponse|ViewModel</code>
     </InvalidReturnType>
   </file>
   <file src="module/Database/src/Form/OrganRegulation.php">
@@ -43,7 +43,7 @@
       <code>$this-&gt;redirect()-&gt;toRoute('home')</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="1">
-      <code>Response|ViewModel</code>
+      <code>HttpResponse|ViewModel</code>
     </InvalidReturnType>
   </file>
   <file src="public/index.php">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
In this PR, we update the way normal and abnormal situations are reported on in the API. Authentication and authorization is handled separately from error reporting. We also distinguish between API routes and regular interactive routes for displaying models.

This also introduces a test endpoint for 404 and 500 errors. 

## Related issues/external references
Resolves GH-423, will now return a 500 instead of a 302 on internal server errors.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_<br/>**Client applications that rely on a 302 status code to detect failures may experience issues, API version was upgraded to major version 3 as a result.**
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
