### PR TITLE
fix: incorrect time comparison for keyholder expiration

### DIFF
--- a/module/Report/src/Model/Keyholder.php
+++ b/module/Report/src/Model/Keyholder.php
@@ -167,7 +167,7 @@ class Keyholder
      */
     public function isCurrent(): bool
     {
-        $now = new DateTime();
+        $now = new DateTime('today');
 
         return $this->getExpirationDate() >= $now
             && (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Default argument is `now` which includes the current time. Changing it to `today` makes the check correct as the decision is inclusive.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-432 and is related to CBC-2408-403.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
