### PR TITLE
fix(decision): language of statutory content not explicitly defined

### DIFF
--- a/module/Database/src/Model/Decision.php
+++ b/module/Database/src/Model/Decision.php
@@ -280,7 +280,7 @@ class Decision
      */
     public function getContent(bool $escapeCharacters = false): string
     {
-        return $this->getTranslatedContent(null, null, $escapeCharacters);
+        return $this->getTranslatedContent(null, AppLanguages::Dutch, $escapeCharacters);
     }
 
     /**
@@ -288,7 +288,7 @@ class Decision
      */
     public function getTranslatedContent(
         ?MvcTranslator $translator,
-        ?AppLanguages $language,
+        AppLanguages $language,
         bool $escapeCharacters = false,
     ): string {
         if (null === $translator) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Retrieval (read creation) of annulling decisions failed because the language for the statutory content of a decision was not explicitly defined.

Since Dutch is the official/statutory language of the association this is now the default.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes ABC-2505-378.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
