### PR TITLE
fix: wrong error message when deleting annulling decision

### DIFF
--- a/module/Report/src/Service/Meeting.php
+++ b/module/Report/src/Service/Meeting.php
@@ -353,7 +353,7 @@ class Meeting
     {
         switch (true) {
             case $subDecision instanceof ReportSubDecisionModel\Annulment:
-                throw new Exception('Annulment of annulling decisions not implemented');
+                throw new Exception('Deletion of annulling decisions not implemented');
 
             case $subDecision instanceof ReportSubDecisionModel\Reappointment:
                 $installation = $subDecision->getInstallation();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Clarify that deletion of annulling decisions is not supported (as the decision is removed and not annulled).

After ABC-2411-508 and https://github.com/tomudding/gewisdb/tree/feature/reverse-original-decision-by-annulment the deletion of an annulling decision can be properly implemented (up to a TBD recursion depth).

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Noticed when ABC-2507-011 was shown to me.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
