### PR TITLE
fix(mailman): Performance improvement when verifying members

### DIFF
--- a/docker/web/development/crontab
+++ b/docker/web/development/crontab
@@ -15,5 +15,5 @@
 */30    *   * * * { . /code/config/bash.env && /usr/bin/php /code/web check:membership:renewal:graduate; } > /data/logs/cron-check-renewal.log 2>&1
 0       2   * * * { . /code/config/bash.env && /usr/bin/php /code/web database:prospective-members:delete-expired; } > /data/logs/cron-delete-prospective.log 2>&1
 55      *   * * * { . /code/config/bash.env && /usr/bin/php /code/web database:mailman:fetch; } > /data/logs/cron-mailman-fetch.log 2>&1
-*/15    *   * * * { . /code/config/bash.env && /usr/bin/php /code/web database:mailman:syncmembership -f -vv; } > /data/logs/cron-mailman-syncmembership.log 2>&1
-20      2   * * * { . /code/config/bash.env && /usr/bin/php /code/web database:mailinglist:maintenance -f -vv; } > /data/logs/cron-mailinglist-maintenance.log 2>&1
+5       *   * * * { . /code/config/bash.env && /usr/bin/php /code/web database:mailman:syncmembership -f -vv; } > /data/logs/cron-mailman-syncmembership.log 2>&1
+40      2   * * * { . /code/config/bash.env && /usr/bin/php /code/web database:mailinglist:maintenance -f -vv; } > /data/logs/cron-mailinglist-maintenance.log 2>&1

--- a/module/Database/src/Mapper/MailingList.php
+++ b/module/Database/src/Mapper/MailingList.php
@@ -42,7 +42,7 @@ class MailingList
      */
     public function findAll(): array
     {
-        return $this->getRepository()->findAll();
+        return $this->getRepository()->findBy([], ['name' => 'ASC']);
     }
 
     /**
@@ -52,7 +52,7 @@ class MailingList
      */
     public function findAllOnForm(): array
     {
-        return $this->getRepository()->findBy(['onForm' => true]);
+        return $this->getRepository()->findBy(['onForm' => true], ['name' => 'ASC']);
     }
 
     /**
@@ -65,6 +65,8 @@ class MailingList
         return $this->getRepository()->findBy([
             'defaultSub' => true,
             'onForm' => false,
+        ], [
+            'name' => 'ASC',
         ]);
     }
 

--- a/module/Database/src/Service/Mailman.php
+++ b/module/Database/src/Service/Mailman.php
@@ -76,6 +76,9 @@ class Mailman
         $client->setAdapter(Curl::class)
             ->setAuth($this->mailmanConfig['username'], $this->mailmanConfig['password'])
             ->setMethod($method)
+            ->setOptions([
+                'timeout' => 600,
+            ])
             ->setUri($this->mailmanConfig['endpoint'] . $uri);
 
         // Data encoding is automatically set to `application/x-www-form-urlencoded` for "POST"-like requests.

--- a/module/Database/view/database/settings/add-list.phtml
+++ b/module/Database/view/database/settings/add-list.phtml
@@ -37,9 +37,6 @@ if ('add' === $action) {
         $form->setAttribute('class', 'form-horizontal');
         ?>
         <?= $this->form()->openTag($form) ?>
-        <p>
-            <?= $this->translate('Please note that if you create a mailing list here, it must also exist in mailman (with the same name!).') ?>
-        </p>
 
         <div class="form-group">
             <?php
@@ -47,6 +44,10 @@ if ('add' === $action) {
             $element->setAttribute('class', 'form-control');
             $element->setAttribute('placeholder', $element->getLabel());
             $element->setLabelAttributes(['class' => 'col-sm-2 control-label']);
+
+            if ('add' !== $action) {
+                $element->setAttribute('readonly', true);
+            }
             ?>
             <?= $this->formLabel($element) ?>
             <div class="col-sm-10">


### PR DESCRIPTION
# Description
Improves mailman sync performance when no changes must be made. 

## Related issues/external references


- Fixes GH-489 (sync performance)
- Fixes GH-491 (sync timeouts)
- bans changing list names in the frontend
- sorts lists alphabetically


## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
