### PR TITLE
fix: house number regex still too restrictive

### DIFF
--- a/module/Database/src/Form/Address.php
+++ b/module/Database/src/Form/Address.php
@@ -120,7 +120,7 @@ class Address extends Form implements InputFilterProviderInterface
                 'validators' => [
                     [
                         'name' => Regex::class,
-                        'options' => ['pattern' => '/^[1-9]\d*(?:[ \/\-\#\.]?(?:[a-zA-Z]+|[0-9]\d*))?$/'],
+                        'options' => ['pattern' => '/^[1-9]\d*(?:[ \/\-\#\.]?[a-zA-Z0-9]+)?$/'],
                     ],
                 ],
             ],

--- a/module/Database/src/Form/Fieldset/Address.php
+++ b/module/Database/src/Form/Fieldset/Address.php
@@ -136,7 +136,7 @@ class Address extends Fieldset implements InputFilterProviderInterface
                 'validators' => [
                     [
                         'name' => Regex::class,
-                        'options' => ['pattern' => '/^[1-9]\d*(?:[ \/\-\#\.]?(?:[a-zA-Z]+|[0-9]\d*))?$/'],
+                        'options' => ['pattern' => '/^[1-9]\d*(?:[ \/\-\#\.]?[a-zA-Z0-9]+)?$/'],
                     ],
                 ],
             ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Changes from GH-441 are still too restrictive. As such, the suffix check is now less restrictive, but still accounts for the comment from https://github.com/GEWIS/gewisdb/pull/436#discussion_r1739921490.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-492.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
