### PR TITLE
Set issue type when creating new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,6 +1,7 @@
 name: "🐛 Bug Report"
 description: Report a bug found while using the GEWIS database.
 labels: ["Type: Bug", "Status: Triage"]
+type: "Bug"
 body:
     -   type: textarea
         id: current-behavior

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,6 +1,7 @@
 name: "✨ Feature Request"
 description: Suggest a feature or enhancement to improve the GEWIS database.
 labels: ["Type: Idea"]
+type: "Feature"
 body:
     -   type: textarea
         id: feature


### PR DESCRIPTION
# Description
org/GEWIS defines three issue types: Bug, Feature and Task. This ensures that these types are used when creating new issues in this repository

## Related issues/external references
Fixes GH-496.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [x] Other _(please specify)_: GitHub specific
