### PR TITLE
fix: key policy duration 🧂 and missing localisation data 

### DIFF
--- a/docker/web/development/Dockerfile
+++ b/docker/web/development/Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk add --virtual .build-deps \
         tzdata \
     && apk add --virtual .runtime-programs \
+        icu-data-full \
         git \
         nano \
         ${PHPVERSION} \

--- a/docker/web/production/Dockerfile
+++ b/docker/web/production/Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk add --virtual .build-deps \
         tzdata \
     && apk add --virtual .runtime-programs \
+        icu-data-full \
         git \
         ${PHPVERSION} \
         ${PHPVERSION}-calendar \

--- a/module/Checker/src/Service/Checker.php
+++ b/module/Checker/src/Service/Checker.php
@@ -329,6 +329,8 @@ class Checker
     {
         $errors = [];
         $grantings = $this->keyService->getKeysGrantedDuringMeeting($meeting);
+        // With BV 1749.15.1 no more restrictions on max. one year.
+        $maxOneYearCutOff = new DateTime('2025-07-01 midnight');
 
         // `$today` is when the meeting took place
         $today = $meeting->getDate();
@@ -349,7 +351,10 @@ class Checker
             if ($until < $today) {
                 $errors[] = new ErrorModel\KeyGrantedInThePast($granting);
             } else {
-                if ($until > $todayNextYear) {
+                if (
+                    $today < $maxOneYearCutOff
+                    && $until > $todayNextYear
+                ) {
                     $errors[] = new ErrorModel\KeyGrantedLongerThanOneYear($granting);
                 }
 

--- a/module/Database/src/Form/Key/Grant.php
+++ b/module/Database/src/Form/Key/Grant.php
@@ -7,7 +7,6 @@ namespace Database\Form\Key;
 use Database\Form\AbstractDecision;
 use Database\Form\Fieldset\Meeting as MeetingFieldset;
 use Database\Form\Fieldset\Member as MemberFieldset;
-use DateInterval;
 use DateTime;
 use Laminas\Form\Element\Date;
 use Laminas\Form\Element\Submit;
@@ -73,19 +72,6 @@ class Grant extends AbstractDecision implements InputFilterProviderInterface
                         'name' => Callback::class,
                         'options' => [
                             'callback' => function ($value, $context) {
-                                return $this->isMaxOneYear($value, $context);
-                            },
-                            'messages' => [
-                                Callback::INVALID_VALUE => $this->translator->translate(
-                                    'Key code cannot be granted for more than one year.',
-                                ),
-                            ],
-                        ],
-                    ],
-                    [
-                        'name' => Callback::class,
-                        'options' => [
-                            'callback' => function ($value, $context) {
                                 return $this->isNotTooFar($value, $context);
                             },
                             'messages' => [
@@ -111,22 +97,6 @@ class Grant extends AbstractDecision implements InputFilterProviderInterface
             $today = new DateTime($context['meeting']['date']);
 
             return (new DateTime($value)) >= $today;
-        } catch (Throwable) {
-            return false;
-        }
-    }
-
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
-     */
-    private function isMaxOneYear(
-        string $value,
-        array $context = [],
-    ): bool {
-        try {
-            $future = (new DateTime($context['meeting']['date']))->add(new DateInterval('P1Y'));
-
-            return (new DateTime($value)) <= $future;
         } catch (Throwable) {
             return false;
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
With BV 1749.15.1, no more restrictions apply on the maximum duration of a key granting (except for no longer than September 1, next association year).

And puts `icu-data-full` back as a runtime dependency. Because without ICU data, there is no localisation for decision contents.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

Fixes GH-499 and closes ABC-2509-000.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
