### PR TITLE
fix(bodies): not allowing `null` for purpose

### DIFF
--- a/module/Report/src/Model/SubDecision/Foundation.php
+++ b/module/Report/src/Model/SubDecision/Foundation.php
@@ -119,7 +119,7 @@ class Foundation extends SubDecision
     /**
      * Set the purpose.
      */
-    public function setPurpose(string $purpose): void
+    public function setPurpose(?string $purpose): void
     {
         $this->purpose = $purpose;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
I added this without any `null` checks in the report generation code:

```php
$reportSubDecision->setPurpose($subdecision->getPurpose());
```

because it should just work, either `null` or the actual string is returned. However, that only works if you allow `null` in `setPurpose()` in Report.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

See emails from the database regarding generation failures.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
