### PR TITLE
Allow for founding organs with members that have >1 function on foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v4.5.2](https://github.com/GEWIS/gewisdb/tree/v4.5.2) (2026-05-12)
+
+* Add Digital Innovation Officer, deprecate Community Development Officer
+
 ## [v4.5.1](https://github.com/GEWIS/gewisdb/tree/v4.5.1) (2026-05-06)
 
 * Fix body generation when purpose is `null`

--- a/module/Database/src/Hydrator/Foundation.php
+++ b/module/Database/src/Hydrator/Foundation.php
@@ -11,6 +11,7 @@ use Database\Model\SubDecision\Foundation as FoundationModel;
 use Database\Model\SubDecision\Installation as InstallationModel;
 use InvalidArgumentException;
 
+use function in_array;
 use function sprintf;
 
 class Foundation extends AbstractDecision
@@ -58,6 +59,8 @@ class Foundation extends AbstractDecision
 
         $num = 2;
 
+        $addedMembers = [];
+
         // create installations
         foreach ($data['members'] as $install) {
             if (!($install['function'] instanceof InstallationFunctions)) {
@@ -69,6 +72,7 @@ class Foundation extends AbstractDecision
             if (
                 InstallationFunctions::Member !== $install['function']
                 && InstallationFunctions::InactiveMember !== $install['function']
+                && !in_array($install['member']->getLidnr(), $addedMembers, true)
             ) {
                 $installation = new InstallationModel();
                 $installation->setSequence($num++);
@@ -76,6 +80,7 @@ class Foundation extends AbstractDecision
                 $installation->setFunction(InstallationFunctions::Member);
                 $installation->setMember($install['member']);
                 $installation->setDecision($decision);
+                $addedMembers[] = $install['member']->getLidnr();
             }
 
             $installation = new InstallationModel();


### PR DESCRIPTION
# Description
Currently it is possible for a member to be a "Chair" or "Secretary" during foundation. However, committee regulations do not have to restrict how many functions a member has. Currently, this will cause the member to be installed as `member` twice.

## Related issues/external references
Fixes GH-531.

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
