### PR TITLE
Introduce audit entries for mailing lists

### DIFF
--- a/module/Database/migrations/Version20260601191545.php
+++ b/module/Database/migrations/Version20260601191545.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ * phpcs:disable SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall
+ */
+final class Version20260601191545 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add fields to AuditEntry for mailing list membership audits';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE auditentry ADD action VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE auditentry ADD mailing_list VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE auditentry ADD CONSTRAINT FK_DE382FBB15C473AF FOREIGN KEY (mailing_list) REFERENCES MailingList (name) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_DE382FBB15C473AF ON auditentry (mailing_list)');
+        $this->addSql('ALTER TABLE auditentry ADD email VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE auditentry ADD origin VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE AuditEntry DROP action');
+        $this->addSql('ALTER TABLE AuditEntry DROP CONSTRAINT FK_DE382FBB15C473AF');
+        $this->addSql('DROP INDEX IDX_DE382FBB15C473AF');
+        $this->addSql('ALTER TABLE AuditEntry DROP mailing_list');
+        $this->addSql('ALTER TABLE AuditEntry DROP email');
+        $this->addSql('ALTER TABLE AuditEntry DROP origin');
+    }
+}

--- a/module/Database/src/Model/AuditEntry.php
+++ b/module/Database/src/Model/AuditEntry.php
@@ -34,6 +34,7 @@ use function strip_tags;
 )]
 #[DiscriminatorMap(
     value: [
+        'mailing_list_membership' => AuditMailingListMembership::class,
         'note' => AuditNote::class,
         'renewal' => AuditRenewal::class,
     ],

--- a/module/Database/src/Model/AuditMailingListMembership.php
+++ b/module/Database/src/Model/AuditMailingListMembership.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Model;
+
+use Database\Model\Enums\MailingListMemberAction;
+use Database\Model\Enums\MailingListMemberOrigin;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Override;
+use User\Model\User;
+
+#[Entity]
+#[AssociationOverrides([
+    new AssociationOverride(
+        name: 'member',
+        joinColumns: new JoinColumn(
+            name: 'member',
+            referencedColumnName: 'lidnr',
+            onDelete: 'cascade',
+            nullable: false,
+        ),
+    ),
+])]
+class AuditMailingListMembership extends AuditEntry
+{
+    private const string BODY_FORMAT = '<strong>%s mailinglist subscription</strong> for '
+        . '<emph>%s</emph> on <emph>%s</emph> (%s)';
+
+    #[Column(type: 'string', enumType: MailingListMemberAction::class)]
+    private MailingListMemberAction $action;
+
+    #[ManyToOne(
+        targetEntity: MailingList::class,
+        inversedBy: 'auditEntries',
+    )]
+    #[JoinColumn(
+        name: 'mailing_list',
+        referencedColumnName: 'name',
+        onDelete: 'cascade',
+        nullable: true,
+    )]
+    private MailingList $mailingList;
+
+    #[Column(type: 'string')]
+    private string $email;
+
+    #[Column(type: 'string', enumType: MailingListMemberOrigin::class)]
+    private MailingListMemberOrigin $origin;
+
+    public static function create(
+        MailingListMemberAction $action,
+        MailingListMemberOrigin $origin,
+        Member $member,
+        MailingList $mailingList,
+        string $email,
+        ?User $user = null,
+    ): self {
+        $audit = new self();
+        $audit->setAction($action);
+        $audit->setOrigin($origin);
+        $audit->setMember($member);
+        $audit->setMailingList($mailingList);
+        $audit->setEmail($email);
+        $audit->setUser($user);
+
+        return $audit;
+    }
+
+    public function getAction(): MailingListMemberAction
+    {
+        return $this->action;
+    }
+
+    public function setAction(MailingListMemberAction $action): void
+    {
+        $this->action = $action;
+    }
+
+    public function getMailingList(): MailingList
+    {
+        return $this->mailingList;
+    }
+
+    public function setMailingList(MailingList $mailingList): void
+    {
+        $this->mailingList = $mailingList;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+    }
+
+    public function getOrigin(): MailingListMemberOrigin
+    {
+        return $this->origin;
+    }
+
+    public function setOrigin(MailingListMemberOrigin $origin): void
+    {
+        $this->origin = $origin;
+    }
+
+    #[Override]
+    protected function getStringBodyFormatted(): string
+    {
+        return self::BODY_FORMAT;
+    }
+
+    /**
+     * @return array<string>
+     */
+    #[Override]
+    protected function getStringArguments(): array
+    {
+        return [
+            match ($this->action) {
+                MailingListMemberAction::Add => 'Add',
+                MailingListMemberAction::Remove => 'Remove',
+            },
+            $this->email,
+            $this->mailingList->getName(),
+            match ($this->origin) {
+                MailingListMemberOrigin::Manual => 'manual',
+                MailingListMemberOrigin::SyncMailman => 'mailman sync',
+                MailingListMemberOrigin::SyncListmonk => 'listmonk sync',
+            },
+        ];
+    }
+}

--- a/module/Database/src/Model/Enums/MailingListMemberAction.php
+++ b/module/Database/src/Model/Enums/MailingListMemberAction.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Model\Enums;
+
+enum MailingListMemberAction: string
+{
+    case Add = 'add';
+    case Remove = 'remove';
+}

--- a/module/Database/src/Model/Enums/MailingListMemberOrigin.php
+++ b/module/Database/src/Model/Enums/MailingListMemberOrigin.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Model\Enums;
+
+enum MailingListMemberOrigin: string
+{
+    case Manual = 'manual';
+    case SyncMailman = 'sync_mailman';
+    case SyncListmonk = 'sync_listmonk';
+}

--- a/module/Database/src/Model/MailingList.php
+++ b/module/Database/src/Model/MailingList.php
@@ -89,9 +89,21 @@ class MailingList
     )]
     private Collection $mailingListMemberships;
 
+    /**
+     * Audit entries for the mailing list.
+     *
+     * @var Collection<array-key, AuditMailingListMembership>
+     */
+    #[OneToMany(
+        targetEntity: AuditMailingListMembership::class,
+        mappedBy: 'mailingList',
+    )]
+    private Collection $auditEntries;
+
     public function __construct()
     {
         $this->mailingListMemberships = new ArrayCollection();
+        $this->auditEntries = new ArrayCollection();
     }
 
     /**
@@ -230,6 +242,16 @@ class MailingList
     public function getMailingListMemberships(): Collection
     {
         return $this->mailingListMemberships;
+    }
+
+    /**
+     * Get the audit entries for this mailing list.
+     *
+     * @return Collection<array-key, AuditMailingListMembership>
+     */
+    public function getAuditEntries(): Collection
+    {
+        return $this->auditEntries;
     }
 
     /**

--- a/module/Database/src/Module.php
+++ b/module/Database/src/Module.php
@@ -109,7 +109,9 @@ use Database\Model\SubDecision\Foundation as FoundationModel;
 use Database\Model\SubDecision\Key\Granting as KeyGrantingModel;
 use Database\Model\SubDecision\Reappointment as ReappointmentModel;
 use Database\Service\Api as ApiService;
+use Database\Service\Audit as AuditService;
 use Database\Service\Factory\ApiFactory as ApiServiceFactory;
+use Database\Service\Factory\AuditFactory as AuditServiceFactory;
 use Database\Service\Factory\FrontPageFactory as FrontPageServiceFactory;
 use Database\Service\Factory\ListmonkFactory as ListmonkServiceFactory;
 use Database\Service\Factory\MailingListFactory as MailingListServiceFactory;
@@ -181,6 +183,7 @@ class Module
                 ApiService::class => ApiServiceFactory::class,
                 FrontPageService::class => FrontPageServiceFactory::class,
                 ListmonkService::class => ListmonkServiceFactory::class,
+                AuditService::class => AuditServiceFactory::class,
                 MailingListService::class => MailingListServiceFactory::class,
                 MailmanService::class => MailmanServiceFactory::class,
                 MeetingService::class => MeetingServiceFactory::class,

--- a/module/Database/src/Service/Audit.php
+++ b/module/Database/src/Service/Audit.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Service;
+
+use Database\Mapper\Audit as AuditMapper;
+use Database\Model\AuditEntry as AuditEntryModel;
+
+class Audit
+{
+    public function __construct(
+        private readonly AuditMapper $auditMapper,
+    ) {
+    }
+
+    public function persist(AuditEntryModel $entry): void
+    {
+        $this->auditMapper->persist($entry);
+    }
+}

--- a/module/Database/src/Service/Factory/AuditFactory.php
+++ b/module/Database/src/Service/Factory/AuditFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Service\Factory;
+
+use Database\Mapper\Audit as AuditMapper;
+use Database\Service\Audit as AuditService;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Override;
+use Psr\Container\ContainerInterface;
+
+class AuditFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     */
+    #[Override]
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null,
+    ): AuditService {
+        /** @var AuditMapper $auditMapper */
+        $auditMapper = $container->get(AuditMapper::class);
+
+        return new AuditService($auditMapper);
+    }
+}

--- a/module/Database/src/Service/Factory/ListmonkFactory.php
+++ b/module/Database/src/Service/Factory/ListmonkFactory.php
@@ -9,6 +9,7 @@ use Database\Mapper\ListmonkMailingList as ListmonkMailingListMapper;
 use Database\Mapper\MailingList as MailingListMapper;
 use Database\Mapper\MailingListMember as MailingListMemberMapper;
 use Database\Mapper\Member as MemberMapper;
+use Database\Service\Audit as AuditService;
 use Database\Service\Listmonk as ListmonkService;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
@@ -35,6 +36,8 @@ class ListmonkFactory implements FactoryInterface
         $memberMapper = $container->get(MemberMapper::class);
         /** @var ConfigService $configService */
         $configService = $container->get(ConfigService::class);
+        /** @var AuditService $auditService */
+        $auditService = $container->get(AuditService::class);
         /** @var array $listmonkConfig */
         $listmonkConfig = $container->get('config')['listmonk_api'];
 
@@ -43,6 +46,7 @@ class ListmonkFactory implements FactoryInterface
             $listmonkMailingListMapper,
             $mailingListMemberMapper,
             $memberMapper,
+            $auditService,
             $configService,
             $listmonkConfig,
         );

--- a/module/Database/src/Service/Factory/MailmanFactory.php
+++ b/module/Database/src/Service/Factory/MailmanFactory.php
@@ -9,6 +9,7 @@ use Database\Mapper\MailingList as MailingListMapper;
 use Database\Mapper\MailingListMember as MailingListMemberMapper;
 use Database\Mapper\MailmanMailingList as MailmanMailingListMapper;
 use Database\Mapper\Member as MemberMapper;
+use Database\Service\Audit as AuditService;
 use Database\Service\Mailman as MailmanService;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
@@ -35,6 +36,8 @@ class MailmanFactory implements FactoryInterface
         $memberMapper = $container->get(MemberMapper::class);
         /** @var ConfigService $configService */
         $configService = $container->get(ConfigService::class);
+        /** @var AuditService $auditService */
+        $auditService = $container->get(AuditService::class);
         /** @var array $mailmanConfig */
         $mailmanConfig = $container->get('config')['mailman_api'];
 
@@ -45,6 +48,7 @@ class MailmanFactory implements FactoryInterface
             $memberMapper,
             $configService,
             $mailmanConfig,
+            $auditService,
         );
     }
 }

--- a/module/Database/src/Service/Factory/MemberFactory.php
+++ b/module/Database/src/Service/Factory/MemberFactory.php
@@ -23,6 +23,7 @@ use Database\Mapper\MailingListMember as MailingListMemberMapper;
 use Database\Mapper\Member as MemberMapper;
 use Database\Mapper\MemberUpdate as MemberUpdateMapper;
 use Database\Mapper\ProspectiveMember as ProspectiveMemberMapper;
+use Database\Service\Audit as AuditService;
 use Database\Service\MailingList as MailingListService;
 use Database\Service\Member as MemberService;
 use Laminas\Mail\Transport\TransportInterface;
@@ -84,6 +85,8 @@ class MemberFactory implements FactoryInterface
         $fileStorageService = $container->get(FileStorageService::class);
         /** @var MailingListService $mailingListService */
         $mailingListService = $container->get(MailingListService::class);
+        /** @var AuditService $auditService */
+        $auditService = $container->get(AuditService::class);
         /** @var RenewalService $renewalService */
         $renewalService = $container->get(RenewalService::class);
         /** @var UserService $userService */
@@ -120,6 +123,7 @@ class MemberFactory implements FactoryInterface
             $userService,
             $viewRenderer,
             $mailTransport,
+            $auditService,
             $config,
         );
     }

--- a/module/Database/src/Service/Listmonk.php
+++ b/module/Database/src/Service/Listmonk.php
@@ -10,9 +10,13 @@ use Database\Mapper\ListmonkMailingList as ListmonkMailingListMapper;
 use Database\Mapper\MailingList as MailingListMapper;
 use Database\Mapper\MailingListMember as MailingListMemberMapper;
 use Database\Mapper\Member as MemberMapper;
+use Database\Model\AuditMailingListMembership;
+use Database\Model\Enums\MailingListMemberAction;
+use Database\Model\Enums\MailingListMemberOrigin;
 use Database\Model\ListmonkMailingList as ListmonkMailingListModel;
 use Database\Model\MailingList as MailingListModel;
 use Database\Model\MailingListMember as MailingListMemberModel;
+use Database\Service\Audit as AuditService;
 use DateInterval;
 use DateTime;
 use Laminas\Http\Client;
@@ -43,6 +47,7 @@ class Listmonk
         private readonly ListmonkMailingListMapper $listmonkMailingListMapper,
         private readonly MailingListMemberMapper $mailingListMemberMapper,
         private readonly MemberMapper $memberMapper,
+        private readonly AuditService $auditService,
         private readonly ConfigService $configService,
         private readonly array $listmonkConfig,
     ) {
@@ -506,6 +511,20 @@ class Listmonk
             return;
         }
 
+        $member = $mailingListMember->getMember();
+
+        if (null !== $member && false === $mailingListMember->isToBeDeleted()) {
+            $this->auditService->persist(
+                AuditMailingListMembership::create(
+                    MailingListMemberAction::Remove,
+                    MailingListMemberOrigin::SyncListmonk,
+                    $member,
+                    $mailingListMember->getMailingList(),
+                    $mailingListMember->getEmail(),
+                ),
+            );
+        }
+
         // Find the subscriber by email
         $subscribers = $this->performListmonkRequest('subscribers', Request::METHOD_GET, [
             'query' => $this->buildListmonkEmailQuery($email),
@@ -606,6 +625,20 @@ class Listmonk
             return;
         }
 
+        $member = $mailingListMember->getMember();
+
+        if (null !== $member && false === $mailingListMember->isToBeDeleted()) {
+            $this->auditService->persist(
+                AuditMailingListMembership::create(
+                    MailingListMemberAction::Remove,
+                    MailingListMemberOrigin::SyncListmonk,
+                    $member,
+                    $mailingListMember->getMailingList(),
+                    $mailingListMember->getEmail(),
+                ),
+            );
+        }
+
         $this->mailingListMemberMapper->remove($mailingListMember);
     }
 
@@ -671,12 +704,22 @@ class Listmonk
                     );
 
                     if (!$dryRun) {
-                        $mailingListMember = new MailingListMemberModel();
-                        $mailingListMember->setMailingList($mailingList);
-                        $mailingListMember->setMember($foundMember);
-                        $mailingListMember->setEmail($subscriber['email']);
-                        $mailingListMember->setToBeCreated(false);
-                        $this->mailingListMemberMapper->persist($mailingListMember);
+                        $this->auditService->persist(
+                            AuditMailingListMembership::create(
+                                MailingListMemberAction::Add,
+                                MailingListMemberOrigin::SyncListmonk,
+                                $foundMember,
+                                $mailingList,
+                                $subscriber['email'],
+                            ),
+                        );
+
+                        $newMailingListMember = new MailingListMemberModel();
+                        $newMailingListMember->setMailingList($mailingList);
+                        $newMailingListMember->setMember($foundMember);
+                        $newMailingListMember->setEmail($subscriber['email']);
+                        $newMailingListMember->setToBeCreated(false);
+                        $this->mailingListMemberMapper->persist($newMailingListMember);
                     }
                 }
             }

--- a/module/Database/src/Service/Mailman.php
+++ b/module/Database/src/Service/Mailman.php
@@ -10,6 +10,9 @@ use Database\Mapper\MailingList as MailingListMapper;
 use Database\Mapper\MailingListMember as MailingListMemberMapper;
 use Database\Mapper\MailmanMailingList as MailmanMailingListMapper;
 use Database\Mapper\Member as MemberMapper;
+use Database\Model\AuditMailingListMembership;
+use Database\Model\Enums\MailingListMemberAction;
+use Database\Model\Enums\MailingListMemberOrigin;
 use Database\Model\MailingList as MailingListModel;
 use Database\Model\MailingListMember as MailingListMemberModel;
 use Database\Model\MailmanMailingList as MailmanMailingListModel;
@@ -58,6 +61,7 @@ class Mailman
         private readonly MemberMapper $memberMapper,
         private readonly ConfigService $configService,
         private readonly array $mailmanConfig,
+        private readonly Audit $auditService,
     ) {
     }
 
@@ -498,6 +502,20 @@ class Mailman
             return;
         }
 
+        $member = $mailingListMember->getMember();
+
+        if (null !== $member && false === $mailingListMember->isToBeDeleted()) {
+            $this->auditService->persist(
+                AuditMailingListMembership::create(
+                    MailingListMemberAction::Remove,
+                    MailingListMemberOrigin::SyncMailman,
+                    $member,
+                    $mailingListMember->getMailingList(),
+                    $mailingListMember->getEmail(),
+                ),
+            );
+        }
+
         if (1 === $response['total_size']) {
             $memberId = $response['entries'][0]['member_id'];
 
@@ -584,6 +602,20 @@ class Mailman
             return;
         }
 
+        $member = $mailingListMember->getMember();
+
+        if (null !== $member && false === $mailingListMember->isToBeDeleted()) {
+            $this->auditService->persist(
+                AuditMailingListMembership::create(
+                    MailingListMemberAction::Remove,
+                    MailingListMemberOrigin::SyncMailman,
+                    $member,
+                    $mailingListMember->getMailingList(),
+                    $mailingListMember->getEmail(),
+                ),
+            );
+        }
+
         $this->mailingListMemberMapper->remove($mailingListMember);
     }
 
@@ -640,6 +672,16 @@ class Mailman
                 );
 
                 if (!$dryRun) {
+                    $this->auditService->persist(
+                        AuditMailingListMembership::create(
+                            MailingListMemberAction::Add,
+                            MailingListMemberOrigin::SyncMailman,
+                            $foundMember,
+                            $mailingList,
+                            $entry['email'],
+                        ),
+                    );
+
                     $mailingListMember = new MailingListMemberModel();
                     $mailingListMember->setMailingList($mailingList);
                     $mailingListMember->setMember($foundMember);

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -28,8 +28,11 @@ use Database\Mapper\MemberUpdate as MemberUpdateMapper;
 use Database\Mapper\ProspectiveMember as ProspectiveMemberMapper;
 use Database\Model\Address as AddressModel;
 use Database\Model\AuditEntry as AuditEntryModel;
+use Database\Model\AuditMailingListMembership;
 use Database\Model\AuditNote as AuditNoteModel;
 use Database\Model\AuditRenewal as AuditRenewalModel;
+use Database\Model\Enums\MailingListMemberAction;
+use Database\Model\Enums\MailingListMemberOrigin;
 use Database\Model\Enums\Studies;
 use Database\Model\MailingList as MailingListModel;
 use Database\Model\MailingListMember as MailingListMemberModel;
@@ -93,6 +96,7 @@ class Member
         private readonly UserService $userService,
         private readonly PhpRenderer $viewRenderer,
         private readonly TransportInterface $mailTransport,
+        private readonly Audit $auditService,
         private readonly array $config,
     ) {
     }
@@ -634,7 +638,7 @@ class Member
         $member->setSupremum('optout');
         $member->setHidden(true);
         $member->setDeleted(true);
-        $this->unsubscribeLists($member);
+        $this->unsubscribeLists($member, false);
 
         $this->getMemberMapper()->persist($member);
     }
@@ -889,6 +893,17 @@ class Member
 
             $membership = $this->mailingListMemberMapper->findByListAndMember($list, $member);
             $membership->setToBeDeleted(true);
+
+            $this->auditService->persist(
+                AuditMailingListMembership::create(
+                    MailingListMemberAction::Remove,
+                    MailingListMemberOrigin::Manual,
+                    $member,
+                    $list,
+                    $membership->getEmail(),
+                    $this->userService->getIdentity(),
+                ),
+            );
         }
 
         // Mailing lists to add
@@ -904,6 +919,17 @@ class Member
             $mailingListMember->setMember($member);
             // Force cascade by adding to member.
             $member->addList($mailingListMember);
+
+            $this->auditService->persist(
+                AuditMailingListMembership::create(
+                    MailingListMemberAction::Add,
+                    MailingListMemberOrigin::Manual,
+                    $member,
+                    $list,
+                    $mailingListMember->getEmail(),
+                    $this->userService->getIdentity(),
+                ),
+            );
         }
 
         // Simply cascade persist through member.
@@ -912,10 +938,30 @@ class Member
         return $member;
     }
 
-    public function unsubscribeLists(MemberModel $member): void
-    {
+    /**
+     * Unsubscribe a member from all mailing lists. This is used when removing/clearing a member.
+     * We never use recordAudit = true yet, but it is implemented to avoid forgetting it.
+     */
+    public function unsubscribeLists(
+        MemberModel $member,
+        bool $recordAudit = true,
+    ): void {
         foreach ($member->getMailingListMemberships() as $mailingListMembership) {
             $mailingListMembership->setToBeDeleted(true);
+
+            if ($recordAudit) {
+                $this->auditService->persist(
+                    AuditMailingListMembership::create(
+                        MailingListMemberAction::Remove,
+                        MailingListMemberOrigin::Manual,
+                        $member,
+                        $mailingListMembership->getMailingList(),
+                        $mailingListMembership->getEmail(),
+                        $this->userService->getIdentity(),
+                    ),
+                );
+            }
+
             $this->mailingListMemberMapper->persist($mailingListMembership);
         }
     }


### PR DESCRIPTION
# Description
With this PR, changes to mailing lists and their reasons are kept.

Design choice: we only keep track of the change on the GEWISDB side. 
That means: recording creations/deletions when they are first initiated.

If the secretary removes a member from a mailing list at time A and the sync script effectuates this 15 minutes later at time B, the event will only be recorded at time A. 

## Related
GH-538 should be merged first. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
