### PR TITLE
feat: introduce bulk renewal form

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,7 +67,8 @@
 		9725,
 		8080,
 		8021,
-		8025
+		8025,
+		8022
 	],
 	"portsAttributes": {
 		"9725": {
@@ -87,6 +88,11 @@
 		},
 		"8025": {
 			"label": "mailhog",
+			"onAutoForward": "silent",
+			"protocol": "http"
+		},
+		"8022": {
+			"label": "Listmonk admin interface",
 			"onAutoForward": "silent",
 			"protocol": "http"
 		}

--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-20 14:15+0000\n"
+"POT-Creation-Date: 2026-06-21 15:01+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Rink <rinkp@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -252,6 +252,23 @@ msgstr ""
 "received your registration and sent you an e-mail containing a link that "
 "allows you to restart the checkout process at a later time."
 
+msgid ""
+"Annual bulk conversion of non-active non-studying ordinary/external members. "
+"New type is graduate."
+msgstr ""
+"Annual bulk conversion of non-active non-studying ordinary/external members. "
+"New type is graduate."
+
+msgid ""
+"Annual renewal of active non-studying ordinary/external members. New type is "
+"external."
+msgstr ""
+"Annual renewal of active non-studying ordinary/external members. New type is "
+"external."
+
+msgid "Annual renewal of studying members. New type is ordinary."
+msgstr "Annual renewal of studying members. New type is ordinary."
+
 msgid "Annul Decision"
 msgstr "Annul Decision"
 
@@ -414,11 +431,17 @@ msgstr "Budget"
 msgid "Budget/Statement"
 msgstr "Budget/Statement"
 
+msgid "Bulk renew memberships"
+msgstr "Bulk renew memberships"
+
 msgid "CM (Chair's Meeting)"
 msgstr "CM (Chair's Meeting)"
 
 msgid "CSV"
 msgstr "CSV"
+
+msgid "Cancel"
+msgstr "Cancel"
 
 msgid "Cancelled"
 msgstr "Cancelled"
@@ -524,6 +547,13 @@ msgstr "Committee"
 msgid "Confirm Changes"
 msgstr "Confirm Changes"
 
+msgid "Confirm renewal"
+msgstr "Confirm renewal"
+
+#, php-format
+msgid "Confirmed %d membership renewal(s)."
+msgstr "Confirmed %d membership renewal(s)."
+
 msgid "Controller"
 msgstr "Controller"
 
@@ -579,6 +609,9 @@ msgstr "Current Mailing Lists"
 
 msgid "Current Members"
 msgstr "Current Members"
+
+msgid "Current expiration"
+msgstr "Current expiration"
 
 #, php-format
 msgid ""
@@ -751,6 +784,13 @@ msgid ""
 msgstr ""
 "Enter changes chronologically. Example: after entering a change on %s, it is "
 "not possible to enter a change for %s."
+
+msgid ""
+"Enter one or more GEWIS membership numbers, choose the target membership "
+"type, and <strong>review the preview</strong> before confirming the renewal."
+msgstr ""
+"Enter one or more GEWIS membership numbers, choose the target membership "
+"type, and <strong>review the preview</strong> before confirming the renewal."
 
 msgid "Execute"
 msgstr "Execute"
@@ -1055,6 +1095,9 @@ msgstr "Last fetch of available Listmonk lists was %s."
 msgid "Last fetch of available mailman lists was %s."
 msgstr "Last fetch of available mailman lists was %s."
 
+msgid "Last type"
+msgstr "Last type"
+
 msgid "Leave note"
 msgstr "Leave note"
 
@@ -1168,6 +1211,15 @@ msgstr "Member %s cannot be deleted."
 msgid "Member Number"
 msgstr "Member Number"
 
+msgid "Member already has a future membership."
+msgstr "Member already has a future membership."
+
+msgid "Member is deleted."
+msgstr "Member is deleted."
+
+msgid "Member not found."
+msgstr "Member not found."
+
 msgid "Members"
 msgstr "Members"
 
@@ -1185,6 +1237,9 @@ msgstr "Membership Type (today)"
 
 msgid "Membership number"
 msgstr "Membership number"
+
+msgid "Membership numbers"
+msgstr "Membership numbers"
 
 msgid "Membership of Committees and Fraternities"
 msgstr "Membership of Committees and Fraternities"
@@ -1234,6 +1289,12 @@ msgstr "Name"
 msgid "Name (Sync)"
 msgstr "Name (Sync)"
 
+msgid "New expiration"
+msgstr "New expiration"
+
+msgid "New type"
+msgstr "New type"
+
 msgid "No"
 msgstr "No"
 
@@ -1265,6 +1326,15 @@ msgid "Note"
 msgstr "Note"
 
 msgid ""
+"Note: all changes will take effect at the end of the current membership of a "
+"member. Do you want to make changes now or in the past? Go to the individual "
+"member profile."
+msgstr ""
+"Note: all changes will take effect at the end of the current membership of a "
+"member. Do you want to make changes now or in the past? Go to the individual "
+"member profile."
+
+msgid ""
 "Note: if you updated your email address, you have to sign in to the GEWIS "
 "website using your new email address once this change has been processed."
 msgstr ""
@@ -1279,6 +1349,9 @@ msgstr "Oh snap!"
 
 msgid "On Form"
 msgstr "On Form"
+
+msgid "One membership number per line, or separated by spaces or commas"
+msgstr "One membership number per line, or separated by spaces or commas"
 
 msgid "Opperhoofd"
 msgstr "Opperhoofd"
@@ -1415,6 +1488,13 @@ msgstr "Pre-master Information Security Technology"
 msgid "Pre-master Programs"
 msgstr "Pre-master Programs"
 
+msgid "Preview changes"
+msgstr "Preview changes"
+
+#, php-format
+msgid "Previewing %1$d valid change(s) and %2$d issue(s)."
+msgstr "Previewing %1$d valid change(s) and %2$d issue(s)."
+
 msgid "Previous exceptions"
 msgstr "Previous exceptions"
 
@@ -1438,6 +1518,9 @@ msgstr "Query"
 
 msgid "Query Result"
 msgstr "Query Result"
+
+msgid "Ready to renew."
+msgstr "Ready to renew."
 
 msgid "Reappoint"
 msgstr "Reappoint"
@@ -1486,6 +1569,9 @@ msgstr "Renew/Type"
 
 msgid "Renewal"
 msgstr "Renewal"
+
+msgid "Renewed."
+msgstr "Renewed."
 
 msgid "Result"
 msgstr "Result"
@@ -1789,6 +1875,13 @@ msgstr ""
 "This renewal link could not be found. Perhaps it has been used before or has "
 "expired."
 
+msgid ""
+"Tip: perform these changes in this order before July 1st of each association "
+"year. This form will prevent you from renewing the membership twice."
+msgstr ""
+"Tip: perform these changes in this order before July 1st of each association "
+"year. This form will prevent you from renewing the membership twice."
+
 msgid "To pay the membership fee you must accept Stripe's privacy policy."
 msgstr "To pay the membership fee you must accept Stripe's privacy policy."
 
@@ -1810,6 +1903,9 @@ msgstr "Unable to check refund status"
 msgid "Unable to create refund"
 msgstr "Unable to create refund"
 
+msgid "Unable to renew deleted member."
+msgstr "Unable to renew deleted member."
+
 msgid "Unknown"
 msgstr "Unknown"
 
@@ -1828,6 +1924,9 @@ msgstr "Update API principal"
 
 msgid "Update Address"
 msgstr "Update Address"
+
+msgid "Use cases:"
+msgstr "Use cases:"
 
 msgid "Username"
 msgstr "Username"

--- a/module/Application/language/en.po
+++ b/module/Application/language/en.po
@@ -434,6 +434,15 @@ msgstr "Budget/Statement"
 msgid "Bulk renew memberships"
 msgstr "Bulk renew memberships"
 
+msgid ""
+"Bulk renewal is available for expiring active members and bulk conversion to "
+"graduate available for expiring non-active members. Do this <strong>after</"
+"strong> studying members have been renewed."
+msgstr ""
+"Bulk renewal is available for expiring active members and bulk conversion to "
+"graduate available for expiring non-active members. Do this <strong>after</"
+"strong> studying members have been renewed."
+
 msgid "CM (Chair's Meeting)"
 msgstr "CM (Chair's Meeting)"
 
@@ -556,6 +565,9 @@ msgstr "Confirmed %d membership renewal(s)."
 
 msgid "Controller"
 msgstr "Controller"
+
+msgid "Convert expiring non-active members to graduate"
+msgstr "Convert expiring non-active members to graduate"
 
 msgid "Copy Decision"
 msgstr "Copy Decision"
@@ -1560,6 +1572,9 @@ msgstr "Remove Prospective Member"
 
 msgid "Renew"
 msgstr "Renew"
+
+msgid "Renew expiring active members"
+msgstr "Renew expiring active members"
 
 msgid "Renew until"
 msgstr "Renew until"

--- a/module/Application/language/gewisdb.pot
+++ b/module/Application/language/gewisdb.pot
@@ -396,6 +396,12 @@ msgstr ""
 msgid "Bulk renew memberships"
 msgstr ""
 
+msgid ""
+"Bulk renewal is available for expiring active members and bulk conversion to "
+"graduate available for expiring non-active members. Do this <strong>after</"
+"strong> studying members have been renewed."
+msgstr ""
+
 msgid "CM (Chair's Meeting)"
 msgstr ""
 
@@ -515,6 +521,9 @@ msgid "Confirmed %d membership renewal(s)."
 msgstr ""
 
 msgid "Controller"
+msgstr ""
+
+msgid "Convert expiring non-active members to graduate"
 msgstr ""
 
 msgid "Copy Decision"
@@ -1456,6 +1465,9 @@ msgid "Remove Prospective Member"
 msgstr ""
 
 msgid "Renew"
+msgstr ""
+
+msgid "Renew expiring active members"
 msgstr ""
 
 msgid "Renew until"

--- a/module/Application/language/gewisdb.pot
+++ b/module/Application/language/gewisdb.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: GEWISdb v4.5.2-23-g5ce8e32b\n"
+"Project-Id-Version: GEWISdb v4.5.2-26-gc8abd2f8-dirty\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-20 14:15+0000\n"
+"POT-Creation-Date: 2026-06-21 15:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -236,6 +236,19 @@ msgid ""
 "allows you to restart the checkout process at a later time."
 msgstr ""
 
+msgid ""
+"Annual bulk conversion of non-active non-studying ordinary/external members. "
+"New type is graduate."
+msgstr ""
+
+msgid ""
+"Annual renewal of active non-studying ordinary/external members. New type is "
+"external."
+msgstr ""
+
+msgid "Annual renewal of studying members. New type is ordinary."
+msgstr ""
+
 msgid "Annul Decision"
 msgstr ""
 
@@ -380,10 +393,16 @@ msgstr ""
 msgid "Budget/Statement"
 msgstr ""
 
+msgid "Bulk renew memberships"
+msgstr ""
+
 msgid "CM (Chair's Meeting)"
 msgstr ""
 
 msgid "CSV"
+msgstr ""
+
+msgid "Cancel"
 msgstr ""
 
 msgid "Cancelled"
@@ -488,6 +507,13 @@ msgstr ""
 msgid "Confirm Changes"
 msgstr ""
 
+msgid "Confirm renewal"
+msgstr ""
+
+#, php-format
+msgid "Confirmed %d membership renewal(s)."
+msgstr ""
+
 msgid "Controller"
 msgstr ""
 
@@ -542,6 +568,9 @@ msgid "Current Mailing Lists"
 msgstr ""
 
 msgid "Current Members"
+msgstr ""
+
+msgid "Current expiration"
 msgstr ""
 
 #, php-format
@@ -700,6 +729,11 @@ msgstr ""
 msgid ""
 "Enter changes chronologically. Example: after entering a change on %s, it is "
 "not possible to enter a change for %s."
+msgstr ""
+
+msgid ""
+"Enter one or more GEWIS membership numbers, choose the target membership "
+"type, and <strong>review the preview</strong> before confirming the renewal."
 msgstr ""
 
 msgid "Execute"
@@ -973,6 +1007,9 @@ msgstr ""
 msgid "Last fetch of available mailman lists was %s."
 msgstr ""
 
+msgid "Last type"
+msgstr ""
+
 msgid "Leave note"
 msgstr ""
 
@@ -1086,6 +1123,15 @@ msgstr ""
 msgid "Member Number"
 msgstr ""
 
+msgid "Member already has a future membership."
+msgstr ""
+
+msgid "Member is deleted."
+msgstr ""
+
+msgid "Member not found."
+msgstr ""
+
 msgid "Members"
 msgstr ""
 
@@ -1102,6 +1148,9 @@ msgid "Membership Type (today)"
 msgstr ""
 
 msgid "Membership number"
+msgstr ""
+
+msgid "Membership numbers"
 msgstr ""
 
 msgid "Membership of Committees and Fraternities"
@@ -1152,6 +1201,12 @@ msgstr ""
 msgid "Name (Sync)"
 msgstr ""
 
+msgid "New expiration"
+msgstr ""
+
+msgid "New type"
+msgstr ""
+
 msgid "No"
 msgstr ""
 
@@ -1183,6 +1238,12 @@ msgid "Note"
 msgstr ""
 
 msgid ""
+"Note: all changes will take effect at the end of the current membership of a "
+"member. Do you want to make changes now or in the past? Go to the individual "
+"member profile."
+msgstr ""
+
+msgid ""
 "Note: if you updated your email address, you have to sign in to the GEWIS "
 "website using your new email address once this change has been processed."
 msgstr ""
@@ -1194,6 +1255,9 @@ msgid "Oh snap!"
 msgstr ""
 
 msgid "On Form"
+msgstr ""
+
+msgid "One membership number per line, or separated by spaces or commas"
 msgstr ""
 
 msgid "Opperhoofd"
@@ -1321,6 +1385,13 @@ msgstr ""
 msgid "Pre-master Programs"
 msgstr ""
 
+msgid "Preview changes"
+msgstr ""
+
+#, php-format
+msgid "Previewing %1$d valid change(s) and %2$d issue(s)."
+msgstr ""
+
 msgid "Previous exceptions"
 msgstr ""
 
@@ -1343,6 +1414,9 @@ msgid "Query"
 msgstr ""
 
 msgid "Query Result"
+msgstr ""
+
+msgid "Ready to renew."
 msgstr ""
 
 msgid "Reappoint"
@@ -1391,6 +1465,9 @@ msgid "Renew/Type"
 msgstr ""
 
 msgid "Renewal"
+msgstr ""
+
+msgid "Renewed."
 msgstr ""
 
 msgid "Result"
@@ -1660,6 +1737,11 @@ msgid ""
 "expired."
 msgstr ""
 
+msgid ""
+"Tip: perform these changes in this order before July 1st of each association "
+"year. This form will prevent you from renewing the membership twice."
+msgstr ""
+
 msgid "To pay the membership fee you must accept Stripe's privacy policy."
 msgstr ""
 
@@ -1681,6 +1763,9 @@ msgstr ""
 msgid "Unable to create refund"
 msgstr ""
 
+msgid "Unable to renew deleted member."
+msgstr ""
+
 msgid "Unknown"
 msgstr ""
 
@@ -1698,6 +1783,9 @@ msgid "Update API principal"
 msgstr ""
 
 msgid "Update Address"
+msgstr ""
+
+msgid "Use cases:"
 msgstr ""
 
 msgid "Username"

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-20 14:15+0000\n"
+"POT-Creation-Date: 2026-06-21 15:01+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Rink <rinkp@users.noreply.github.com>\n"
 "Language-Team: \n"
@@ -254,6 +254,23 @@ msgstr ""
 "een link waarmee je het betalingsproces op een later tijdstip opnieuw kunt "
 "starten."
 
+msgid ""
+"Annual bulk conversion of non-active non-studying ordinary/external members. "
+"New type is graduate."
+msgstr ""
+"Jaarlijkse bulk-omzetting van niet-actieve niet-studerende gewone/externe "
+"leden. Nieuw type is afgestudeerde."
+
+msgid ""
+"Annual renewal of active non-studying ordinary/external members. New type is "
+"external."
+msgstr ""
+"Jaarlijkse verlenging van actieve niet-studerende gewone/externe leden. "
+"Nieuwe type is extern."
+
+msgid "Annual renewal of studying members. New type is ordinary."
+msgstr "Jaarlijkse verlenging van studerende leden. Nieuwe type is gewoon."
+
 msgid "Annul Decision"
 msgstr "Vernietig Besluit"
 
@@ -414,11 +431,17 @@ msgstr "Begroting"
 msgid "Budget/Statement"
 msgstr "Begroting/Afrekening"
 
+msgid "Bulk renew memberships"
+msgstr "Bulk-verlenging lidmaatschap"
+
 msgid "CM (Chair's Meeting)"
 msgstr "VV (voorzittersvergadering)"
 
 msgid "CSV"
 msgstr "CSV"
+
+msgid "Cancel"
+msgstr "Annuleer"
 
 msgid "Cancelled"
 msgstr "Afgebroken"
@@ -526,6 +549,13 @@ msgstr "Commissie"
 msgid "Confirm Changes"
 msgstr "Wijzigingen bevestigen"
 
+msgid "Confirm renewal"
+msgstr "Bevestig verlengen"
+
+#, php-format
+msgid "Confirmed %d membership renewal(s)."
+msgstr "%d lidmaatschapsverlengingen bevestigd."
+
 msgid "Controller"
 msgstr "Controller"
 
@@ -581,6 +611,9 @@ msgstr "Huidige mailinglijsten"
 
 msgid "Current Members"
 msgstr "Huidige leden"
+
+msgid "Current expiration"
+msgstr "Huidige afloopdatum"
 
 #, php-format
 msgid ""
@@ -756,6 +789,14 @@ msgstr ""
 "Wijzigingen moeten in chronologische volgorde worden ingevoerd. Het is "
 "bijvoorbeeld niet mogelijk om een wijziging in te voeren voor %s nadat een "
 "andere wijziging in is gegaan per %s."
+
+msgid ""
+"Enter one or more GEWIS membership numbers, choose the target membership "
+"type, and <strong>review the preview</strong> before confirming the renewal."
+msgstr ""
+"Voer één of meerdere GEWIS-lidmaatschapsnummers in, kies het gewenste type "
+"en <strong>controleer het voorbeeld</strong> voorafgaand aan het bevestigen "
+"van de verlenging."
 
 msgid "Execute"
 msgstr "Uitvoeren"
@@ -1064,6 +1105,9 @@ msgstr "Beschikbare Listmonk lijsten voor het laatst om %s opgehaald."
 msgid "Last fetch of available mailman lists was %s."
 msgstr "Beschikbare Mailman lijsten voor het laatst om %s opgehaald."
 
+msgid "Last type"
+msgstr "Laatste lidmaatschapstype"
+
 msgid "Leave note"
 msgstr "Voeg notitie toe"
 
@@ -1177,6 +1221,15 @@ msgstr "Lid %s kan niet worden verwijderd."
 msgid "Member Number"
 msgstr "Lidmaatschapsnummer"
 
+msgid "Member already has a future membership."
+msgstr "Lid heeft al een toekomstig lidmaatschap."
+
+msgid "Member is deleted."
+msgstr "Lid is verwijderd."
+
+msgid "Member not found."
+msgstr "Lid niet gevonden."
+
 msgid "Members"
 msgstr "Leden"
 
@@ -1194,6 +1247,9 @@ msgstr "Lidmaatschapstype (huidig)"
 
 msgid "Membership number"
 msgstr "Lidmaatschapsnummer"
+
+msgid "Membership numbers"
+msgstr "Lidmaatschapsnummers"
 
 msgid "Membership of Committees and Fraternities"
 msgstr "Lidmaatschap van commissies en disputen"
@@ -1243,6 +1299,12 @@ msgstr "Naam"
 msgid "Name (Sync)"
 msgstr "Naam (Sync)"
 
+msgid "New expiration"
+msgstr "Nieuwe afloopdatum"
+
+msgid "New type"
+msgstr "Nieuwe type"
+
 msgid "No"
 msgstr "Nee"
 
@@ -1274,6 +1336,15 @@ msgid "Note"
 msgstr "Notitie"
 
 msgid ""
+"Note: all changes will take effect at the end of the current membership of a "
+"member. Do you want to make changes now or in the past? Go to the individual "
+"member profile."
+msgstr ""
+"Nota bene: alle wijzigingen gaan in op de huidige afloopdatum van het "
+"lidmaatschap. Om wijzigingen direct of in het verleden in te laten gaan, "
+"open het individuele lid."
+
+msgid ""
 "Note: if you updated your email address, you have to sign in to the GEWIS "
 "website using your new email address once this change has been processed."
 msgstr ""
@@ -1288,6 +1359,10 @@ msgstr "Oh nee!"
 
 msgid "On Form"
 msgstr "Op inschrijfformulier"
+
+msgid "One membership number per line, or separated by spaces or commas"
+msgstr ""
+"Eén lidmaatschapsnummer per regel, of gescheiden middels spaties of kommas"
 
 msgid "Opperhoofd"
 msgstr "Opperhoofd"
@@ -1424,6 +1499,13 @@ msgstr "Pre-master Information Security Technology"
 msgid "Pre-master Programs"
 msgstr "Schakelprogramma's"
 
+msgid "Preview changes"
+msgstr "Bekijk voorbeeld"
+
+#, php-format
+msgid "Previewing %1$d valid change(s) and %2$d issue(s)."
+msgstr "%1$d geldige wijzigingen en %2$d problemen voorgesteld."
+
 msgid "Previous exceptions"
 msgstr "Previous exceptions"
 
@@ -1447,6 +1529,9 @@ msgstr "Query"
 
 msgid "Query Result"
 msgstr "Queryresultaat"
+
+msgid "Ready to renew."
+msgstr "Klaar om te verlengen."
 
 msgid "Reappoint"
 msgstr "Herbenoemen"
@@ -1495,6 +1580,9 @@ msgstr "Verleng/Type"
 
 msgid "Renewal"
 msgstr "Verlenging"
+
+msgid "Renewed."
+msgstr "Verlengd."
 
 msgid "Result"
 msgstr "Resultaat"
@@ -1806,6 +1894,14 @@ msgstr ""
 "Deze verlengingslink kon niet gevonden worden. Wellicht is deze eerder "
 "gebruikt of reeds verlopen."
 
+msgid ""
+"Tip: perform these changes in this order before July 1st of each association "
+"year. This form will prevent you from renewing the membership twice."
+msgstr ""
+"Tip: voer de wijzigingen in bovenstaande volgorde uit voor 1 juli van elk "
+"verenigingsjaar. Dit formulier voorkomt dat je het lidmaatschap twee keer "
+"verlengt."
+
 msgid "To pay the membership fee you must accept Stripe's privacy policy."
 msgstr ""
 "Om de lidmaatschapsbijdrage te betalen, moet je het privacybeleid van Stripe "
@@ -1829,6 +1925,9 @@ msgstr "Kan terugbetalingsstatus niet controleren"
 msgid "Unable to create refund"
 msgstr "Unable to create refund"
 
+msgid "Unable to renew deleted member."
+msgstr "Kan lidmaatschap van verwijderd lid niet vernieuwen."
+
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -1847,6 +1946,9 @@ msgstr "API-gebruiker bijwerken"
 
 msgid "Update Address"
 msgstr "Adres bijwerken"
+
+msgid "Use cases:"
+msgstr "Wanneer gebruik je dit:"
 
 msgid "Username"
 msgstr "Gebruikersnaam"

--- a/module/Application/language/nl.po
+++ b/module/Application/language/nl.po
@@ -434,6 +434,15 @@ msgstr "Begroting/Afrekening"
 msgid "Bulk renew memberships"
 msgstr "Bulk-verlenging lidmaatschap"
 
+msgid ""
+"Bulk renewal is available for expiring active members and bulk conversion to "
+"graduate available for expiring non-active members. Do this <strong>after</"
+"strong> studying members have been renewed."
+msgstr ""
+"Bulk-verlenging is beschikbaar voor verlopende actieve leden en bulk-"
+"omzetting naar afgestudeerde voor de rest. Doe dit <strong>nadat</strong> "
+"studerende leden zijn verlengd."
+
 msgid "CM (Chair's Meeting)"
 msgstr "VV (voorzittersvergadering)"
 
@@ -558,6 +567,9 @@ msgstr "%d lidmaatschapsverlengingen bevestigd."
 
 msgid "Controller"
 msgstr "Controller"
+
+msgid "Convert expiring non-active members to graduate"
+msgstr "Zet niet-actieve verlopende leden om naar afgestudeerde."
 
 msgid "Copy Decision"
 msgstr "Besluit kopiëren"
@@ -1571,6 +1583,9 @@ msgstr "Verwijder toekomstig lid"
 
 msgid "Renew"
 msgstr "Verleng"
+
+msgid "Renew expiring active members"
+msgstr "Verleng actieve leden"
 
 msgid "Renew until"
 msgstr "Verleng tot en met"

--- a/module/Database/config/module.config.php
+++ b/module/Database/config/module.config.php
@@ -212,6 +212,15 @@ return [
                 ],
                 'may_terminate' => true,
                 'child_routes' => [
+                    'bulk-renewal' => [
+                        'type' => Literal::class,
+                        'options' => [
+                            'route' => '/bulk-renewal',
+                            'defaults' => [
+                                'action' => 'bulkRenewal',
+                            ],
+                        ],
+                    ],
                     'show' => [
                         'type' => Segment::class,
                         'options' => [

--- a/module/Database/src/Controller/MemberController.php
+++ b/module/Database/src/Controller/MemberController.php
@@ -59,6 +59,56 @@ class MemberController extends AbstractActionController
     }
 
     /**
+     * Bulk renewal flow.
+     * Consists of 2 pages: 1 asking for input and a second for confirmation.
+     */
+    public function bulkRenewalAction(): ViewModel
+    {
+        $form = $this->memberService->getBulkMemberRenewalForm();
+        $formData = [
+            'memberIds' => '',
+            'membershipType' => '',
+        ];
+        $preview = null;
+        $result = null;
+
+        if ($this->getRequest()->isPost()) {
+            $form->setData($this->getRequest()->getPost()->toArray());
+            $isValid = $form->isValid();
+            $formData = $form->getData();
+
+            if (!$isValid) {
+                return new ViewModel([
+                    'form' => $form,
+                    'formData' => $formData,
+                    'preview' => null,
+                    'result' => null,
+                ]);
+            }
+
+            if ('confirm' === $this->getRequest()->getPost('intent')) {
+                $result = $this->memberService->executeBulkRenewal(
+                    $formData['memberIds'],
+                    $formData['membershipType'],
+                );
+                $preview = $result['preview'];
+            } else {
+                $preview = $this->memberService->buildBulkRenewalPreview(
+                    $formData['memberIds'],
+                    $formData['membershipType'],
+                );
+            }
+        }
+
+        return new ViewModel([
+            'form' => $form,
+            'formData' => $formData,
+            'preview' => $preview,
+            'result' => $result,
+        ]);
+    }
+
+    /**
      * Subscribe action.
      */
     public function subscribeAction(): HttpResponse|ViewModel

--- a/module/Database/src/Form/BulkMemberRenewal.php
+++ b/module/Database/src/Form/BulkMemberRenewal.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Form;
+
+use Application\Model\Enums\MembershipTypes;
+use Database\Form\Validator\BulkMemberIds as BulkMemberIdsValidator;
+use Laminas\Form\Element\Radio;
+use Laminas\Form\Element\Submit;
+use Laminas\Form\Element\Textarea;
+use Laminas\Form\Form;
+use Laminas\InputFilter\InputFilterProviderInterface;
+use Laminas\Mvc\I18n\Translator;
+use Override;
+use RuntimeException;
+
+use function preg_split;
+use function trim;
+
+class BulkMemberRenewal extends Form implements InputFilterProviderInterface
+{
+    public function __construct(private readonly Translator $translator)
+    {
+        parent::__construct();
+
+        $this->add([
+            'name' => 'memberIds',
+            'type' => Textarea::class,
+            'options' => [
+                'label' => $this->translator->translate('Membership numbers'),
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'membershipType',
+            'type' => Radio::class,
+            'options' => [
+                'label' => $this->translator->translate('Membership Type'),
+                'value_options' => [
+                    // phpcs:ignore -- user-visible strings should not be split
+                    MembershipTypes::Ordinary->value => $this->translator->translate('Ordinary - Enrolled at the department of M&CS'),
+                    // phpcs:ignore -- user-visible strings should not be split
+                    MembershipTypes::External->value => $this->translator->translate('External - Admitted by the board'),
+                    // phpcs:ignore -- user-visible strings should not be split
+                    MembershipTypes::Graduate->value => $this->translator->translate('Graduate - Former member admitted by the board as graduate'),
+                    // phpcs:ignore -- user-visible strings should not be split
+                    MembershipTypes::Honorary->value => $this->translator->translate('Honorary - Appointed by the GMM'),
+                ],
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'submit',
+            'type' => Submit::class,
+            'attributes' => [
+                'value' => $this->translator->translate('Preview changes'),
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'intent',
+            'type' => Submit::class,
+            'attributes' => [
+                'value' => 'preview',
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, array{
+     *     required?: bool,
+     *     validators?: array<int, array{name: class-string, options?: array<string, mixed>}>,
+     * }>
+     */
+    #[Override]
+    public function getInputFilterSpecification(): array
+    {
+        return [
+            'memberIds' => [
+                'required' => true,
+                'validators' => [
+                    [
+                        'name' => BulkMemberIdsValidator::class,
+                    ],
+                ],
+            ],
+            'membershipType' => [
+                'required' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getParsedMemberIds(): array
+    {
+        // After this check we are ensured a unique list of numeric IDs by BulkMemberIdsValidator
+        if (!$this->isValid()) {
+            throw new RuntimeException('Cannot parse member IDs from invalid form.');
+        }
+
+        $rawMemberIds = trim((string) $this->get('memberIds')->getValue());
+        $tokens = preg_split('/[\s,;]+/', $rawMemberIds) ?: [];
+        $memberIds = [];
+
+        foreach ($tokens as $token) {
+            if ('' === $token) {
+                continue;
+            }
+
+            $memberIds[] = (int) $token;
+        }
+
+        return $memberIds;
+    }
+}

--- a/module/Database/src/Form/Validator/BulkMemberIds.php
+++ b/module/Database/src/Form/Validator/BulkMemberIds.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Form\Validator;
+
+use Laminas\Validator\ValidatorInterface;
+use Override;
+
+use function array_key_exists;
+use function ctype_digit;
+use function preg_split;
+use function sprintf;
+use function trim;
+
+class BulkMemberIds implements ValidatorInterface
+{
+    /** @var array<string> */
+    private array $messages = [];
+
+    #[Override]
+    public function isValid(
+        mixed $value,
+        ?array $context = null,
+    ): bool {
+        $this->messages = [];
+
+        $rawMemberIds = trim((string) $value);
+        if ('' === $rawMemberIds) {
+            $this->messages[] = 'Provide at least one membership number.';
+
+            return false;
+        }
+
+        $tokens = preg_split('/[\s,;]+/', $rawMemberIds) ?: [];
+        $seenIds = [];
+
+        foreach ($tokens as $token) {
+            if ('' === $token) {
+                continue;
+            }
+
+            if (!ctype_digit($token)) {
+                $this->messages[] = sprintf('Non-numeric membership number input: %s', $token);
+
+                continue;
+            }
+
+            $memberId = (int) $token;
+
+            if (array_key_exists($memberId, $seenIds)) {
+                $this->messages[] = sprintf('Duplicate membership number in input: %s', $memberId);
+
+                continue;
+            }
+
+            $seenIds[$memberId] = true;
+        }
+
+        return [] === $this->messages;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    #[Override]
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/module/Database/src/Model/Enums/AttentionReasons.php
+++ b/module/Database/src/Model/Enums/AttentionReasons.php
@@ -207,4 +207,22 @@ enum AttentionReasons: string
             default => false,
         };
     }
+
+    public function includeBulkGraduateConversion(): bool
+    {
+        return match ($this) {
+            self::ExpiringOrdinaryNonActive,
+            self::ExpiringExternalNonActive => true,
+            default => false,
+        };
+    }
+
+    public function includeBulkActiveMemberRenewal(): bool
+    {
+        return match ($this) {
+            self::ExpiringOrdinaryActive,
+            self::ExpiringExternalActive => true,
+            default => false,
+        };
+    }
 }

--- a/module/Database/src/Module.php
+++ b/module/Database/src/Module.php
@@ -24,6 +24,7 @@ use Database\Form\Board\Discharge as BoardDischargeForm;
 use Database\Form\Board\Install as BoardInstallForm;
 use Database\Form\Board\Release as BoardReleaseForm;
 use Database\Form\Budget as BudgetForm;
+use Database\Form\BulkMemberRenewal as BulkMemberRenewalForm;
 use Database\Form\CreateMeeting as CreateMeetingForm;
 use Database\Form\DeleteAddress as DeleteAddressForm;
 use Database\Form\DeleteDecision as DeleteDecisionForm;
@@ -54,6 +55,7 @@ use Database\Form\Other as OtherForm;
 use Database\Form\Query as QueryForm;
 use Database\Form\QueryExport as QueryExportForm;
 use Database\Form\QuerySave as QuerySaveForm;
+use Database\Form\Validator\BulkMemberIds as BulkMemberIdsValidator;
 use Database\Hydrator\Abolish as AbolishHydrator;
 use Database\Hydrator\Annulment as AnnulmentHydrator;
 use Database\Hydrator\AuditEntry as AuditEntryHydrator;
@@ -172,6 +174,7 @@ class Module
                 BoardReleaseHydrator::class => BoardReleaseHydrator::class,
                 KeyGrantHydrator::class => KeyGrantHydrator::class,
                 KeyWithdrawHydrator::class => KeyWithdrawHydrator::class,
+                BulkMemberIdsValidator::class => BulkMemberIdsValidator::class,
             ],
             'factories' => [
                 DeleteExpiredMembersCommand::class => DeleteExpiredMembersCommandFactory::class,
@@ -206,6 +209,12 @@ class Module
                     $form = new AuditNoteForm($container->get(MvcTranslator::class));
                     $form->setHydrator(new AuditEntryHydrator());
                     $form->setObject(new AuditNoteModel());
+
+                    return $form;
+                },
+                BulkMemberRenewalForm::class => static function (ContainerInterface $container) {
+                    $form = new BulkMemberRenewalForm($container->get(MvcTranslator::class));
+                    $form->setHydrator($container->get('database_hydrator_default'));
 
                     return $form;
                 },

--- a/module/Database/src/Service/Factory/MemberFactory.php
+++ b/module/Database/src/Service/Factory/MemberFactory.php
@@ -9,6 +9,7 @@ use Checker\Service\Checker as CheckerService;
 use Checker\Service\Renewal as RenewalService;
 use Database\Form\Address as AddressForm;
 use Database\Form\AuditEntry\AuditNote as AuditNoteForm;
+use Database\Form\BulkMemberRenewal as BulkMemberRenewalForm;
 use Database\Form\DeleteAddress as DeleteAddressForm;
 use Database\Form\Member as MemberForm;
 use Database\Form\MemberApprove as MemberApproveForm;
@@ -51,6 +52,8 @@ class MemberFactory implements FactoryInterface
         $addressForm = $container->get(AddressForm::class);
         /** @var AuditNoteForm $auditNoteForm */
         $auditNoteForm = $container->get(AuditNoteForm::class);
+        /** @var BulkMemberRenewalForm $bulkMemberRenewalForm */
+        $bulkMemberRenewalForm = $container->get(BulkMemberRenewalForm::class);
         /** @var DeleteAddressForm $deleteAddressForm */
         $deleteAddressForm = $container->get(DeleteAddressForm::class);
         /** @var MemberApproveForm $memberApproveForm */
@@ -102,6 +105,7 @@ class MemberFactory implements FactoryInterface
             $translator,
             $addressForm,
             $auditNoteForm,
+            $bulkMemberRenewalForm,
             $deleteAddressForm,
             $memberApproveForm,
             $memberForm,

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -664,63 +664,12 @@ class Member
 
         $data = $form->getData();
 
-        // update changed on date
-        $date = new DateTime();
-        $date->setTime(0, 0);
-        $member->setChangedOn($date);
-
-        // Record a renewal audit entry
-        $renewalAudit = new AuditRenewalModel();
-        $renewalAudit->setOldExpiration($member->getExpiration());
-
-        // We always deal with the last membership
-        $lastMembership = $member->getLastMembership();
-
-        // We assume that there is a membership (always the case for non-cleared members)
-        assert($lastMembership instanceof MembershipModel);
-
-        // Start date
-        if (null === $data['changeDate']) {
-            $changeDate = new DateTime();
-        } else {
-            $changeDate = new DateTime($data['changeDate']);
-        }
-
-        $newType = MembershipTypes::from($data['type']);
-
-        // We always change at the start of a day
-        $changeDate->setTime(0, 0);
-
-        // We will never alter anything before the start of the last membership
-        if ($changeDate < $lastMembership->getStartDate()) {
-            $changeDate = $lastMembership->getStartDate();
-        }
-
-        // or after the end date of the last membership
-        if ($changeDate > $lastMembership->getEndDate()) {
-            $changeDate = $lastMembership->getEndDate();
-        }
-
-        if ($changeDate->getTimestamp() === $lastMembership->getStartDate()->getTimestamp()) {
-            $lastMembership->setType($newType);
-        } else {
-            $lastMembership->setEndDate($changeDate);
-            $newMembership = new MembershipModel(
-                member: $member,
-                type: $newType,
-                startDate: $changeDate,
-                endDate: null,
-            );
-            $member->addMembership($newMembership);
-        }
-
-        $renewalAudit->setNewExpiration($member->getExpiration());
-        $renewalAudit->setUser($this->userService->getIdentity());
-        $this->addAuditEntry($member, $renewalAudit);
-
-        $this->getMemberMapper()->persist($member);
-
-        return $member;
+        return $this->applyMembershipChange(
+            $member,
+            MembershipTypes::from($data['type']),
+            null === $data['changeDate'] ? null : new DateTime($data['changeDate']),
+        );
+    }
     }
 
     /**
@@ -1119,6 +1068,94 @@ class Member
         $form->setMembership($member->getLastMembership());
 
         return $form;
+    }
+
+    /**
+     * @return array{
+     *     currentType: MembershipTypes,
+     *     oldExpiration: DateTime,
+     *     newExpiration: DateTime,
+     *     changeDate: DateTime,
+     *     lastMembership: MembershipModel,
+     * }
+     */
+    private function resolveMembershipChange(
+        MemberModel $member,
+        MembershipTypes $newType,
+        ?DateTime $changeDate = null,
+    ): array {
+        $currentMembership = $member->getCurrentOrLastMembership();
+
+        if (null === $currentMembership) {
+            throw new RuntimeException('Unable to change membership type without a membership.');
+        }
+
+        if (MembershipTypes::Honorary === $currentMembership->getType()) {
+            throw new RuntimeException('Unable to change membership type of honorary member.');
+        }
+
+        $lastMembership = $member->getLastMembership();
+        assert($lastMembership instanceof MembershipModel);
+
+        $effectiveChangeDate = null === $changeDate ? new DateTime() : clone $changeDate;
+        $effectiveChangeDate->setTime(0, 0);
+
+        if ($effectiveChangeDate < $lastMembership->getStartDate()) {
+            $effectiveChangeDate = clone $lastMembership->getStartDate();
+        }
+
+        if ($effectiveChangeDate > $lastMembership->getEndDate()) {
+            $effectiveChangeDate = clone $lastMembership->getEndDate();
+        }
+
+        $newExpiration = $effectiveChangeDate->getTimestamp() === $lastMembership->getStartDate()->getTimestamp()
+            ? clone $lastMembership->getEndDate()
+            : (new MembershipModel($member, $newType, clone $effectiveChangeDate))->getEndDate();
+
+        return [
+            'currentType' => $lastMembership->getType(),
+            'oldExpiration' => clone $member->getExpiration(),
+            'newExpiration' => $newExpiration,
+            'changeDate' => $effectiveChangeDate,
+            'lastMembership' => $lastMembership,
+        ];
+    }
+
+    private function applyMembershipChange(
+        MemberModel $member,
+        MembershipTypes $newType,
+        ?DateTime $changeDate = null,
+    ): MemberModel {
+        $resolvedChange = $this->resolveMembershipChange($member, $newType, $changeDate);
+
+        $date = new DateTime();
+        $date->setTime(0, 0);
+        $member->setChangedOn($date);
+
+        $renewalAudit = new AuditRenewalModel();
+        $renewalAudit->setOldExpiration($resolvedChange['oldExpiration']);
+
+        $lastMembership = $resolvedChange['lastMembership'];
+        $effectiveChangeDate = $resolvedChange['changeDate'];
+
+        if ($effectiveChangeDate->getTimestamp() === $lastMembership->getStartDate()->getTimestamp()) {
+            $lastMembership->setType($newType);
+        } else {
+            $lastMembership->setEndDate(clone $effectiveChangeDate);
+            $member->addMembership(new MembershipModel(
+                member: $member,
+                type: $newType,
+                startDate: clone $effectiveChangeDate,
+                endDate: null,
+            ));
+        }
+
+        $renewalAudit->setNewExpiration($resolvedChange['newExpiration']);
+        $renewalAudit->setUser($this->userService->getIdentity());
+        $this->addAuditEntry($member, $renewalAudit);
+        $this->getMemberMapper()->persist($member);
+
+        return $member;
     }
 
     /**

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -11,6 +11,7 @@ use Checker\Service\Checker as CheckerService;
 use Checker\Service\Renewal as RenewalService;
 use Database\Form\Address as AddressForm;
 use Database\Form\AuditEntry\AuditNote as AuditNoteForm;
+use Database\Form\BulkMemberRenewal as BulkMemberRenewalForm;
 use Database\Form\DeleteAddress as DeleteAddressForm;
 use Database\Form\Member as MemberForm;
 use Database\Form\MemberApprove as MemberApproveForm;
@@ -80,6 +81,7 @@ class Member
         private readonly Translator $translator,
         private readonly AddressForm $addressForm,
         private readonly AuditNoteForm $auditNoteForm,
+        private readonly BulkMemberRenewalForm $bulkMemberRenewalForm,
         private readonly DeleteAddressForm $deleteAddressForm,
         private readonly MemberApproveForm $memberApproveForm,
         private readonly MemberForm $memberForm,
@@ -670,6 +672,225 @@ class Member
             null === $data['changeDate'] ? null : new DateTime($data['changeDate']),
         );
     }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getBulkRenewalTypeOptions(): array
+    {
+        $options = [];
+
+        foreach (MembershipTypes::cases() as $membershipType) {
+            $options[$membershipType->value] = $membershipType->getName($this->translator);
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return array{
+     *     memberIds: int[],
+     *     membershipType: ?MembershipTypes,
+     *     rows: array<int, array{
+     *         memberId: int,
+     *         member: ?MemberModel,
+     *         currentExpiration: ?string,
+     *         newExpiration: ?string,
+     *         valid: bool,
+     *         message: string,
+     *         executed: false,
+     *     }>,
+     *     validCount: int,
+     *     invalidCount: int,
+     * }
+     */
+    public function buildBulkRenewalPreview(
+        string $memberIds,
+        string $membershipType,
+    ): array {
+        $form = $this->getBulkMemberRenewalForm();
+        $form->setData([
+            'memberIds' => $memberIds,
+            'membershipType' => $membershipType,
+        ]);
+        $form->isValid();
+
+        $rows = [];
+        $validCount = 0;
+        $invalidCount = 0;
+        $selectedType = MembershipTypes::tryFrom($membershipType);
+
+        $now = new DateTime();
+
+        $memberIds = $form->getParsedMemberIds();
+
+        if (null !== $selectedType) {
+            foreach ($memberIds as $memberId) {
+                $member = $this->getMember($memberId);
+
+                if (null === $member) {
+                    $rows[] = [
+                        'memberId' => $memberId,
+                        'member' => null,
+                        'currentExpiration' => null,
+                        'newExpiration' => null,
+                        'valid' => false,
+                        'message' => $this->translator->translate('Member not found.'),
+                        'executed' => false,
+                    ];
+                    $invalidCount++;
+
+                    continue;
+                }
+
+                if ($member->getDeleted()) {
+                    $rows[] = [
+                        'memberId' => $memberId,
+                        'member' => $member,
+                        'currentExpiration' => $member->getExpiration()->format('Y-m-d'),
+                        'newExpiration' => null,
+                        'valid' => false,
+                        'message' => $this->translator->translate('Member is deleted.'),
+                        'executed' => false,
+                    ];
+                    $invalidCount++;
+
+                    continue;
+                }
+
+                // We allow renewing memberships that have not started yet in resolveMembershipChange
+                // but we don't allow renewal in bulk
+                if ($member->getLastMembership()->getStartDate() > $now) {
+                    $rows[] = [
+                        'memberId' => $memberId,
+                        'member' => $member,
+                        'currentExpiration' => $member->getExpiration()->format('Y-m-d'),
+                        'newExpiration' => null,
+                        'valid' => false,
+                        'message' => $this->translator->translate('Member already has a future membership.'),
+                        'executed' => false,
+                    ];
+                    $invalidCount++;
+
+                    continue;
+                }
+
+                try {
+                    $lastMembership = $member->getLastMembership();
+                    assert($lastMembership instanceof MembershipModel);
+                    $resolvedChange = $this->resolveMembershipChange(
+                        $member,
+                        $selectedType,
+                        clone $lastMembership->getEndDate(),
+                    );
+
+                    $rows[] = [
+                        'memberId' => $memberId,
+                        'member' => $member,
+                        'currentExpiration' => $resolvedChange['oldExpiration']->format('Y-m-d'),
+                        'newExpiration' => $resolvedChange['newExpiration']->format('Y-m-d'),
+                        'valid' => true,
+                        'message' => $this->translator->translate('Ready to renew.'),
+                        'executed' => false,
+                    ];
+                    $validCount++;
+                } catch (RuntimeException $exception) {
+                    $rows[] = [
+                        'memberId' => $memberId,
+                        'member' => $member,
+                        'currentExpiration' => $member->getExpiration()->format('Y-m-d'),
+                        'newExpiration' => null,
+                        'valid' => false,
+                        'message' => $exception->getMessage(),
+                        'executed' => false,
+                    ];
+                    $invalidCount++;
+                }
+            }
+        }
+
+        return [
+            'memberIds' => $memberIds,
+            'membershipType' => $selectedType,
+            'rows' => $rows,
+            'validCount' => $validCount,
+            'invalidCount' => $invalidCount,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     preview: array{
+     *         memberIds: int[],
+     *         membershipType: ?MembershipTypes,
+     *         rows: array<int, array{
+     *             memberId: int,
+     *             member: ?MemberModel,
+     *             currentExpiration: ?string,
+     *             newExpiration: ?string,
+     *             valid: bool,
+     *             message: string,
+     *             executed: bool,
+     *         }>,
+     *         validCount: int,
+     *         invalidCount: int,
+     *     },
+     *     executedCount: int,
+     * }
+     */
+    public function executeBulkRenewal(
+        string $memberIds,
+        string $membershipType,
+    ): array {
+        $preview = $this->buildBulkRenewalPreview($memberIds, $membershipType);
+        $selectedType = $preview['membershipType'];
+        $executedCount = 0;
+
+        if (null === $selectedType) {
+            return [
+                'preview' => $preview,
+                'executedCount' => $executedCount,
+            ];
+        }
+
+        foreach ($preview['rows'] as $index => $row) {
+            if (!$row['valid'] || null === $row['member']) {
+                continue;
+            }
+
+            if (null === $row['member'] || $row['member']->getDeleted()) {
+                $preview['rows'][$index]['valid'] = false;
+                $preview['rows'][$index]['message'] = $this->translator->translate(
+                    'Unable to renew deleted member.',
+                );
+
+                continue;
+            }
+
+            try {
+                $lastMembership = $row['member']->getLastMembership();
+                assert($lastMembership instanceof MembershipModel);
+
+                $row['member'] = $this->applyMembershipChange(
+                    $row['member'],
+                    $selectedType,
+                    clone $lastMembership->getEndDate(),
+                );
+
+                $preview['rows'][$index]['executed'] = true;
+                $preview['rows'][$index]['message'] = $this->translator->translate('Renewed.');
+                $preview['rows'][$index]['member'] = $row['member'];
+                $executedCount++;
+            } catch (RuntimeException $exception) {
+                $preview['rows'][$index]['valid'] = false;
+                $preview['rows'][$index]['message'] = $exception->getMessage();
+            }
+        }
+
+        return [
+            'preview' => $preview,
+            'executedCount' => $executedCount,
+        ];
     }
 
     /**
@@ -1068,6 +1289,11 @@ class Member
         $form->setMembership($member->getLastMembership());
 
         return $form;
+    }
+
+    public function getBulkMemberRenewalForm(): BulkMemberRenewalForm
+    {
+        return $this->bulkMemberRenewalForm;
     }
 
     /**

--- a/module/Database/src/Service/Member.php
+++ b/module/Database/src/Service/Member.php
@@ -63,6 +63,8 @@ use function array_diff;
 use function array_intersect;
 use function array_key_exists;
 use function array_merge;
+use function array_unique;
+use function array_values;
 use function assert;
 use function bin2hex;
 use function count;
@@ -1150,9 +1152,9 @@ class Member
      */
     public function getFrontpageData(): array
     {
-        $totalInclExpired = $this->getMemberMapper()->countMembers(true, true, true);
-        $totalExclExpired = $this->getMemberMapper()->countMembers(true, true, false);
-        $nongraduatesExclExpired = $this->getMemberMapper()->countMembers(false, true, false);
+        $totalInclExpired = $this->getMemberMapper()->countMembers(true, false, true);
+        $totalExclExpired = $this->getMemberMapper()->countMembers(true, false, false);
+        $nongraduatesExclExpired = $this->getMemberMapper()->countMembers(false, false, false);
 
         return [
             'members' => $nongraduatesExclExpired,
@@ -1434,12 +1436,20 @@ class Member
      *     days: int,
      *     members: MemberModel[],
      *     reasons: array<int, AttentionReasons[]>,
+     *     bulkRenewalShortcuts: array{
+     *         expiringActive: int[],
+     *         expiringNonActive: int[],
+     *     },
      * }
      */
     public function getMembersRequiringAttention(int $days = 30): array
     {
         $members = [];
         $reasons = [];
+        $bulkRenewalShortcuts = [
+            'expiringActive' => [],
+            'expiringNonActive' => [],
+        ];
 
         /** @var array<value-of<AttentionReasons>, MemberModel[]> $combined */
         $combined = [];
@@ -1482,6 +1492,18 @@ class Member
         );
 
         foreach (AttentionReasons::cases() as $reason) {
+            if ($reason->includeBulkActiveMemberRenewal()) {
+                foreach ($combined[$reason->value] ?? [] as $member) {
+                    $bulkRenewalShortcuts['expiringActive'][] = $member->getLidnr();
+                }
+            }
+
+            if ($reason->includeBulkGraduateConversion()) {
+                foreach ($combined[$reason->value] ?? [] as $member) {
+                    $bulkRenewalShortcuts['expiringNonActive'][] = $member->getLidnr();
+                }
+            }
+
             foreach ($combined[$reason->value] ?? [] as $member) {
                 if (!array_key_exists($member->getLidnr(), $reasons)) {
                     $members[] = $member;
@@ -1497,7 +1519,19 @@ class Member
                 + ($a->getFirstName() <=> $b->getFirstName());
         });
 
-        return ['days' => $days, 'members' => $members, 'reasons' => $reasons];
+        $bulkRenewalShortcuts['expiringActive'] = array_values(
+            array_unique($bulkRenewalShortcuts['expiringActive']),
+        );
+        $bulkRenewalShortcuts['expiringNonActive'] = array_values(
+            array_unique($bulkRenewalShortcuts['expiringNonActive']),
+        );
+
+        return [
+            'days' => $days,
+            'members' => $members,
+            'reasons' => $reasons,
+            'bulkRenewalShortcuts' => $bulkRenewalShortcuts,
+        ];
     }
 
     /**

--- a/module/Database/view/database/member/attention-needed.phtml
+++ b/module/Database/view/database/member/attention-needed.phtml
@@ -12,6 +12,7 @@ use Laminas\Translator\TranslatorInterface;
  * @var PhpRenderer|HelperTrait $this
  * @var MemberModel[] $members
  * @var array<int, AttentionReasons[]> $reasons
+ * @var array{expiringActive: int[], expiringNonActive: int[]} $bulkRenewalShortcuts
  * @var int $days
  * @var TranslatorInterface $translator
  */
@@ -20,6 +21,29 @@ $translator = $this->plugin('translate')->getTranslator();
 
 <h2><?= $this->translate('Members requiring attention') ?></h2>
 <p><?= sprintf($this->translate('The following members require attention because their membership will expire within the next %d days or they are missing required information.'), $days) ?></p>
+
+<p><?= $this->translate('Bulk renewal is available for expiring active members and bulk conversion to graduate available for expiring non-active members. Do this <strong>after</strong> studying members have been renewed.') ?></p>
+<div style="margin-bottom: 15px;">
+    <form method="post" action="<?= $this->url('member/bulk-renewal') ?>" style="display: inline;">
+        <input type="hidden" name="memberIds" value="<?= $this->escapeHtmlAttr(implode(' ', $bulkRenewalShortcuts['expiringActive'])) ?>">
+        <input type="hidden" name="membershipType" value="external">
+        <input type="hidden" name="intent" value="preview">
+        <button type="submit" class="btn btn-primary"<?= [] === $bulkRenewalShortcuts['expiringActive'] ? ' disabled="disabled"' : '' ?>>
+            <span class="glyphicon glyphicon-repeat"></span>
+            <?= $this->translate('Renew expiring active members') ?>
+        </button>
+    </form>
+    <form method="post" action="<?= $this->url('member/bulk-renewal') ?>" style="display: inline;">
+        <input type="hidden" name="memberIds" value="<?= $this->escapeHtmlAttr(implode(' ', $bulkRenewalShortcuts['expiringNonActive'])) ?>">
+        <input type="hidden" name="membershipType" value="graduate">
+
+        <input type="hidden" name="intent" value="preview">
+        <button type="submit" class="btn btn-primary"<?= [] === $bulkRenewalShortcuts['expiringNonActive'] ? ' disabled="disabled"' : '' ?>>
+            <span class="glyphicon glyphicon-transfer"></span>
+            <?= $this->translate('Convert expiring non-active members to graduate') ?>
+        </button>
+    </form>
+</div>
 <table class="table table-hover">
     <thead>
         <tr>

--- a/module/Database/view/database/member/bulk-renewal.phtml
+++ b/module/Database/view/database/member/bulk-renewal.phtml
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use Application\View\HelperTrait;
+use Database\Form\BulkMemberRenewal as BulkMemberRenewalForm;
+use Database\Model\Enums\MembershipTypes;
+use Database\Model\Member as MemberModel;
+use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\View\Renderer\PhpRenderer;
+
+/**
+ * @var PhpRenderer|HelperTrait $this
+ * @var BulkMemberRenewalForm $form
+ * @var array{memberIds: string, membershipType: string} $formData
+ * @var array{
+ *     memberIds: string,
+ *     membershipType: MembershipTypes,
+ *     rows: array<int, array{
+ *         memberId: int,
+ *         member: ?MemberModel,
+ *         currentExpiration: ?string,
+ *         newExpiration: ?string,
+ *         valid: bool,
+ *         message: string,
+ *         executed: bool,
+ *     }>,
+ *     validCount: int,
+ *     invalidCount: int,
+ * } $preview
+ * @var array|null $result
+ * @var TranslatorInterface $translator
+ */
+
+$translator = $this->plugin('translate')->getTranslator();
+?>
+<h1><?= $this->translate('Bulk renew memberships') ?></h1>
+<p><?= $this->translate('Enter one or more GEWIS membership numbers, choose the target membership type, and <strong>review the preview</strong> before confirming the renewal.') ?></p>
+<p><?= $this->translate('Use cases:') ?></p>
+<ul>
+    <li><?= $this->translate('Annual renewal of studying members. New type is ordinary.') ?></li>
+    <li><?= $this->translate('Annual renewal of active non-studying ordinary/external members. New type is external.') ?></li>
+    <li><?= $this->translate('Annual bulk conversion of non-active non-studying ordinary/external members. New type is graduate.') ?></li>
+</ul>
+<p><?= $this->translate('Tip: perform these changes in this order before July 1st of each association year. This form will prevent you from renewing the membership twice.') ?></p>
+<p><?= $this->translate('Note: all changes will take effect at the end of the current membership of a member. Do you want to make changes now or in the past? Go to the individual member profile.') ?></p>
+
+<?php
+$form->prepare();
+$form->setAttribute('action', $this->url('member/bulk-renewal'));
+$form->setAttribute('method', 'post');
+$form->setAttribute('role', 'form');
+?>
+<?= $this->form()->openTag($form) ?>
+    <?php 
+    $element = $form->get('memberIds');
+    $element->setAttribute('class', 'form-control');
+    $element->setAttribute('rows', '8');
+    $element->setAttribute('placeholder', $this->translate('One membership number per line, or separated by spaces or commas'));
+    ?>
+    <div class="form-group">
+        <label for="memberIds"><?= $element->getLabel() ?></label>
+        <?= $this->formTextarea($element) ?>
+        <?= $this->formElementErrors($element) ?>
+    </div>
+
+    <?php
+    $element = $form->get('membershipType');
+    $element->setAttribute('placeholder', $element->getLabel());
+    ?>
+    <div class="form-group<?= $this->bootstrapElementError($element) ?>">
+        <label for="<?= $element->getName() ?>" class="control-label col-sm-2"><?= $element->getLabel() ?></label>
+        <div class="col-sm-10">
+            <?php foreach ($element->getValueOptions() as $option => $text): ?>
+                <div class="radio">
+                    <label>
+                    <input type="radio" name="<?= $element->getName() ?>" id="<?= $element->getName() ?>" value="<?= $option ?>" <?= $element->getValue() == $option ? 'checked' : '' ?>>
+                        <?= $text ?>
+                    </label>
+                </div>
+            <?php endforeach ?>
+        <?= $this->formElementErrors($element) ?>
+        </div>
+    </div>
+
+    <?php
+    $submit = $form->get('submit');
+    $submit->setLabel($submit->getValue());
+    $submit->setAttribute('class', 'btn btn-primary');
+    ?>
+    <?= $this->formButton($submit) ?>
+    <a href="<?= $this->url('member') ?>" class="btn btn-default"><?= $this->translate('Cancel') ?></a>
+<?= $this->form()->closeTag() ?>
+
+<?php if (null !== $preview): ?>
+    <hr>
+
+    <?php if (null !== $result): ?>
+        <div class="alert alert-success"><?= sprintf($this->translate('Confirmed %d membership renewal(s).'), $result['executedCount']) ?></div>
+    <?php endif; ?>
+
+    <?php if ([] !== $preview['rows']): ?>
+        <p><?= sprintf($this->translate('Previewing %1$d valid change(s) and %2$d issue(s).'), $preview['validCount'], $preview['invalidCount']) ?></p>
+
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th><?= $this->translate('Membership number') ?></th>
+                    <th><?= $this->translate('Name') ?></th>
+                    <th><?= $this->translate('Last type') ?></th>
+                    <th><?= $this->translate('New type') ?></th>
+                    <th><?= $this->translate('Current expiration') ?></th>
+                    <th><?= $this->translate('New expiration') ?></th>
+                    <th><?= $this->translate('Status') ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($preview['rows'] as $row): ?>
+                    <tr class="<?= $row['executed'] ? 'success' : ($row['valid'] ? '' : 'danger') ?>">
+                        <td><?= null === $row['memberId'] ? $this->translate('n/a') : $this->escapeHtml((string) $row['memberId']) ?></td>
+                        <td><?= $this->escapeHtml($row['member']?->getFullName() ?? $this->translate('n/a')) ?></td>
+                        <td><?= $this->escapeHtml($row['member']?->getLastMembership()?->getType()->getName($translator) ?? $this->translate('n/a')) ?></td>
+                        <td><?= $this->escapeHtml(
+                            null !== $preview['membershipType'] &&
+                            null !== $row['member'] ?
+                            $preview['membershipType']->getName($translator) :
+                            $this->translate('n/a'),
+                            ) ?>
+                        </td>
+                        <td><?= $this->escapeHtml($row['currentExpiration'] ?? $this->translate('n/a')) ?></td>
+                        <td><?= $this->escapeHtml($row['newExpiration'] ?? $this->translate('n/a')) ?></td>
+                        <td><?= $this->escapeHtml($row['message']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+
+        <?php if (null === $result && 0 < $preview['validCount']): ?>
+            <form method="post" action="<?= $this->url('member/bulk-renewal') ?>" role="form">
+                <input type="hidden" name="memberIds" value="<?= $this->escapeHtmlAttr(implode(' ', $preview['memberIds'])) ?>">
+                <input type="hidden" name="membershipType" value="<?= $this->escapeHtmlAttr($preview['membershipType']->value) ?>">
+                <input type="hidden" name="intent" value="confirm">
+                <button type="submit" class="btn btn-success">
+                    <?= $this->translate('Confirm renewal') ?>
+                </button>
+            </form>
+        <?php endif; ?>
+    <?php endif; ?>
+<?php endif; ?>

--- a/module/Database/view/database/member/index.phtml
+++ b/module/Database/view/database/member/index.phtml
@@ -90,3 +90,6 @@ $(document).ready(function () {
 <a href="<?= $this->url('member/attention-needed') ?>" class="btn btn-warning">
     <span class="glyphicon glyphicon-exclamation-sign"></span> <?= $this->translate('View members needing attention') ?>
 </a>
+<a href="<?= $this->url('member/bulk-renewal') ?>" class="btn btn-info">
+    <span class="glyphicon glyphicon-repeat"></span> <?= $this->translate('Bulk renew memberships') ?>
+</a>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -365,6 +365,11 @@ input[type="checkbox"] {
     transition: background 200ms,box-shadow 200ms,border 200ms;
 }
 
+.btn-primary[disabled] {
+    background-color: #9b394b;
+    border-color: #9b394b;
+}
+
 .btn-primary:focus,
 .btn-primary.focus,
 .btn-primary:hover {


### PR DESCRIPTION
# Description
Introduces a bulk renewal form for the secretary to renew members. 

It can be used in 3 situations:
1. Annual renewal of studying members based on TU/e data. New type is ordinary.
2. Annual renewal of active non-studying ordinary/external members. New type is external.
3. Annual bulk conversion of non-active non-studying ordinary/external members. New type is graduate.

The secretary should run through each of these flows once before July 1st, in this order. That ensures that active studying members are renewed to ordinary before they are renewed as external. 

<img width="1285" height="960" alt="image" src="https://github.com/user-attachments/assets/470b4a23-e683-4305-8db6-7fca42cd92c7" />

<img width="1285" height="960" alt="image" src="https://github.com/user-attachments/assets/9ad844b2-de0c-4f96-b2d4-a2f4b4d1aa29" />

<img width="1285" height="960" alt="image" src="https://github.com/user-attachments/assets/3afff9a4-8e78-4fe6-89b0-74513e55efbd" />


## Related issues/external references
Resolves a part of GEWIS/radix#65

Depends partially on GEWIS/gewisdb#545

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement _(no changes to code)_
- [ ] Other _(please specify)_
