### PR TITLE
fix: move routing from CBC nginx to application nginx

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -26,8 +26,9 @@ NGINX_REQUIRE_AUTH=off
 
 # Proxy configuration to allow getting actual IP address from remote
 # Note that PROXY_IPS must be a comma-delimited string
+# 127.0.0.1 must be trusted because the join/member vhosts re-proxy via loopback
 PROXY_ENABLED=false
-PROXY_IPS=
+PROXY_IPS=127.0.0.1
 PROXY_HEADER=X-Real-IP
 
 # Stripe settings to enable auto-magic payment flow in enrolment form

--- a/.env.dist
+++ b/.env.dist
@@ -25,11 +25,12 @@ APP_URL=https://member.gewis.nl
 NGINX_REQUIRE_AUTH=off
 
 # Proxy configuration to allow getting actual IP address from remote
-# Note that PROXY_IPS must be a comma-delimited string
-# 127.0.0.1 must be trusted because the join/member vhosts re-proxy via loopback
+# The client IP is the right-most PROXY_HEADER entry not in PROXY_IPS (comma-
+# delimited, CIDR allowed), so list every hop: 127.0.0.1 (join/member vhosts
+# re-proxy via loopback), the edge chain, and the proxy reaching this container.
 PROXY_ENABLED=false
 PROXY_IPS=127.0.0.1
-PROXY_HEADER=X-Real-IP
+PROXY_HEADER=X-Forwarded-For
 
 # Stripe settings to enable auto-magic payment flow in enrolment form
 # The STRIPE_SECRET_KEY should at all times be a restricted key with the following permissions:

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -30,13 +30,9 @@ http {
     gzip_types          text/plain application/x-javascript text/css image/png image/jpeg image/gif image/x-icon image/svg+xml;
     gzip_vary           on;
 
-    # Main application host. Also listens on the loopback interface so it can
-    # double as the internal backend for the join.gewis.nl / member.gewis.nl
-    # vhosts below: it is the only (=default) server on 127.0.0.1:9726, so it
-    # answers those proxy hops regardless of the Host they preserve. The hop
-    # exists purely so proxy_cookie_domain can rewrite the session cookie domain,
-    # which the application hard-codes to database.gewis.nl (session.cookie_domain
-    # in docker/web/production/php.ini) with no FastCGI equivalent to change it.
+    # Main application host. Also listens on loopback as the backend for the
+    # join.gewis.nl/member.gewis.nl vhosts: that extra hop lets proxy_cookie_domain
+    # rewrite the session cookie domain that php.ini hard-codes to database.gewis.nl.
     server {
         listen                  9725 default_server;
         listen                  [::]:9725 default_server;
@@ -91,10 +87,6 @@ http {
         }
     }
 
-    # join.gewis.nl only exposes the public membership subscription flow. The
-    # upstream proxy used to filter the allowed paths, rewrite the pretty URLs
-    # onto the /member/subscribe routes and rewrite the session cookie domain;
-    # with the move to Traefik that host-specific routing now lives here.
     server {
         listen                  9725;
         listen                  [::]:9725;
@@ -106,8 +98,6 @@ http {
 
         include /etc/nginx/snippets/securitytxt.conf;
 
-        # Only the subscription flow is reachable; everything else falls through
-        # to the `location /` below and returns 404.
         location ~ ^(/$|/member/subscribe$|/member/subscribe/checkout/error$|/checkout/cancelled$|/checkout/completed$|/checkout/error$|/checkout/restart/|/checkout/webhook$|/js/|/css/|/img/|/robots.txt$|/fonts/|/lang/en$|/lang/nl$) {
             rewrite ^/$ /member/subscribe break;
             rewrite ^/checkout/(cancelled|completed|error|restart/.+|webhook)$ /member/subscribe/checkout/$1 break;
@@ -121,9 +111,6 @@ http {
         }
     }
 
-    # member.gewis.nl only exposes the public membership renewal flow, rewriting
-    # /renew/... onto the /member/renew/... routes. As with join.gewis.nl this
-    # used to be handled by the upstream proxy.
     server {
         listen                  9725;
         listen                  [::]:9725;
@@ -135,8 +122,6 @@ http {
 
         include /etc/nginx/snippets/securitytxt.conf;
 
-        # Only the renewal flow is reachable; everything else falls through to
-        # the `location /` below and returns 404.
         location ~ ^(/renew/|/js/|/css/|/img/|/robots.txt$|/fonts/|/lang/en$|/lang/nl$) {
             rewrite ^/renew/(.+)$ /member/renew/$1 break;
 

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -30,22 +30,6 @@ http {
     gzip_types          text/plain application/x-javascript text/css image/png image/jpeg image/gif image/x-icon image/svg+xml;
     gzip_vary           on;
 
-    map $host $x_css_protection {
-        default "1; mode=block";
-    }
-    map $host $x_content_type_options {
-        default "nosniff";
-    }
-    map $host $content_security_policy {
-        default "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'";
-    }
-    map $host $referrer_policy {
-        default "strict-origin-when-cross-origin";
-    }
-    map $host $permissions_policy {
-        default 'accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(self ), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-write=(self), interest-cohort=()';
-    }
-
     # Main application host. Also listens on the loopback interface so it can
     # double as the internal backend for the join.gewis.nl / member.gewis.nl
     # vhosts below: it is the only (=default) server on 127.0.0.1:9726, so it

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -75,12 +75,7 @@ http {
         #     rewrite ^(.*)$ /errors/maintenance.html break;
         # }
 
-        # security.txt is served centrally from gewis.nl.
-        location /.well-known/security.txt {
-            proxy_set_header  Host  gewis.nl;
-            proxy_pass        https://gewis.nl/.well-known/security.txt;
-        }
-
+        include /etc/nginx/snippets/securitytxt.conf;
 
         location ~ ^/data/(images|img|javascript|js|css|fonts|flash|media|static|jpe?g|gif|ico|png|xml|otf|ttf|eot|woff|woff2|svg)/  {
             gzip_static                 on;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -46,9 +46,17 @@ http {
         default 'accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(self ), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-write=(self), interest-cohort=()';
     }
 
+    # Main application host. Also listens on the loopback interface so it can
+    # double as the internal backend for the join.gewis.nl / member.gewis.nl
+    # vhosts below: it is the only (=default) server on 127.0.0.1:9726, so it
+    # answers those proxy hops regardless of the Host they preserve. The hop
+    # exists purely so proxy_cookie_domain can rewrite the session cookie domain,
+    # which the application hard-codes to database.gewis.nl (session.cookie_domain
+    # in docker/web/production/php.ini) with no FastCGI equivalent to change it.
     server {
-        listen                  9725;
-        listen                  [::]:9725;
+        listen                  9725 default_server;
+        listen                  [::]:9725 default_server;
+        listen                  127.0.0.1:9726;
         server_name             database.gewis.nl;
         charset                 utf-8;
         server_tokens           off;
@@ -67,31 +75,25 @@ http {
         #     rewrite ^(.*)$ /errors/maintenance.html break;
         # }
 
+        # security.txt is served centrally from gewis.nl.
+        location /.well-known/security.txt {
+            proxy_set_header  Host  gewis.nl;
+            proxy_pass        https://gewis.nl/.well-known/security.txt;
+        }
+
+
         location ~ ^/data/(images|img|javascript|js|css|fonts|flash|media|static|jpe?g|gif|ico|png|xml|otf|ttf|eot|woff|woff2|svg)/  {
             gzip_static                 on;
             etag                        on;
             add_header                  Cache-Control                       "private, max-age=2592000";
-            add_header                  X-XSS-Protection                    $x_css_protection;
-            add_header                  X-Content-Type-Options              $x_content_type_options;
-            add_header                  Content-Security-Policy             $content_security_policy;
-            add_header                  Referrer-Policy                     $referrer_policy;
-            add_header                  Permissions-Policy                  $permissions_policy;
-        }
-
-        location /.well-known/security.txt  {
-            proxy_set_header        Host              gewis.nl;
-            proxy_pass https://gewis.nl/.well-known/security.txt;
+            include /etc/nginx/snippets/security-headers.conf;
         }
 
         location ~ ^/(images|img|javascript|js|css|fonts|flash|media|static|jpe?g|gif|ico|png|xml|otf|ttf|eot|woff|woff2|svg)/  {
             gzip_static                 on;
             etag                        on;
             add_header                  Cache-Control                       "public, max-age=86400";
-            add_header                  X-XSS-Protection                    $x_css_protection;
-            add_header                  X-Content-Type-Options              $x_content_type_options;
-            add_header                  Content-Security-Policy             $content_security_policy;
-            add_header                  Referrer-Policy                     $referrer_policy;
-            add_header                  Permissions-Policy                  $permissions_policy;
+            include /etc/nginx/snippets/security-headers.conf;
         }
 
         location / {
@@ -106,11 +108,65 @@ http {
             fastcgi_hide_header         Cache-Control;
             fastcgi_keep_conn           on;
             add_header                  Cache-Control                       "private, no-cache";
-            add_header                  X-XSS-Protection                    $x_css_protection;
-            add_header                  X-Content-Type-Options              $x_content_type_options;
-            add_header                  Content-Security-Policy             $content_security_policy;
-            add_header                  Referrer-Policy                     $referrer_policy;
-            add_header                  Permissions-Policy                  $permissions_policy;
+            include /etc/nginx/snippets/security-headers.conf;
+        }
+    }
+
+    # join.gewis.nl only exposes the public membership subscription flow. The
+    # upstream proxy used to filter the allowed paths, rewrite the pretty URLs
+    # onto the /member/subscribe routes and rewrite the session cookie domain;
+    # with the move to Traefik that host-specific routing now lives here.
+    server {
+        listen                  9725;
+        listen                  [::]:9725;
+        server_name             join.gewis.nl;
+        charset                 utf-8;
+        server_tokens           off;
+        auth_basic              ${NGINX_REQUIRE_AUTH};
+        auth_basic_user_file    /etc/nginx/.htpasswd;
+
+        include /etc/nginx/snippets/securitytxt.conf;
+
+        # Only the subscription flow is reachable; everything else falls through
+        # to the `location /` below and returns 404.
+        location ~ ^(/$|/member/subscribe$|/member/subscribe/checkout/error$|/checkout/cancelled$|/checkout/completed$|/checkout/error$|/checkout/restart/|/checkout/webhook$|/js/|/css/|/img/|/robots.txt$|/fonts/|/lang/en$|/lang/nl$) {
+            rewrite ^/$ /member/subscribe break;
+            rewrite ^/checkout/(cancelled|completed|error|restart/.+|webhook)$ /member/subscribe/checkout/$1 break;
+
+            proxy_cookie_domain     database.gewis.nl     join.gewis.nl;
+            include /etc/nginx/snippets/proxy-to-backend.conf;
+        }
+
+        location / {
+            return 404;
+        }
+    }
+
+    # member.gewis.nl only exposes the public membership renewal flow, rewriting
+    # /renew/... onto the /member/renew/... routes. As with join.gewis.nl this
+    # used to be handled by the upstream proxy.
+    server {
+        listen                  9725;
+        listen                  [::]:9725;
+        server_name             member.gewis.nl;
+        charset                 utf-8;
+        server_tokens           off;
+        auth_basic              ${NGINX_REQUIRE_AUTH};
+        auth_basic_user_file    /etc/nginx/.htpasswd;
+
+        include /etc/nginx/snippets/securitytxt.conf;
+
+        # Only the renewal flow is reachable; everything else falls through to
+        # the `location /` below and returns 404.
+        location ~ ^(/renew/|/js/|/css/|/img/|/robots.txt$|/fonts/|/lang/en$|/lang/nl$) {
+            rewrite ^/renew/(.+)$ /member/renew/$1 break;
+
+            proxy_cookie_domain     database.gewis.nl     member.gewis.nl;
+            include /etc/nginx/snippets/proxy-to-backend.conf;
+        }
+
+        location / {
+            return 404;
         }
     }
 }

--- a/docker/nginx/proxy.conf
+++ b/docker/nginx/proxy.conf
@@ -1,8 +1,4 @@
 proxy_redirect          off;
-proxy_set_header        Host              $host;
-proxy_set_header        X-Real-IP         $remote_addr;
-proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
-proxy_set_header        X-Forwarded-Proto $scheme;
 client_max_body_size    64m;
 client_body_buffer_size 128k;
 proxy_connect_timeout   90;

--- a/docker/nginx/snippets/proxy-to-backend.conf
+++ b/docker/nginx/snippets/proxy-to-backend.conf
@@ -1,0 +1,13 @@
+# Forward to the loopback application backend, which is the database.gewis.nl
+# server block (it also listens on 127.0.0.1:9726 and is the only/default server
+# there, so it answers regardless of the Host sent here). Host is preserved so
+# the application keeps generating URLs for the requested vhost (serverUrl());
+# the caller adds a matching proxy_cookie_domain to rewrite the hard-coded
+# database.gewis.nl session cookie domain. X-Forwarded-Proto/Port are taken from
+# what Traefik set, so the extra hop does not downgrade them to plain http.
+proxy_set_header  Host               $host;
+proxy_set_header  X-Real-IP          $remote_addr;
+proxy_set_header  X-Forwarded-For    $proxy_add_x_forwarded_for;
+proxy_set_header  X-Forwarded-Proto  $http_x_forwarded_proto;
+proxy_set_header  X-Forwarded-Port   $http_x_forwarded_port;
+proxy_pass        http://127.0.0.1:9726;

--- a/docker/nginx/snippets/proxy-to-backend.conf
+++ b/docker/nginx/snippets/proxy-to-backend.conf
@@ -1,8 +1,5 @@
-# The edge proxy's headers are passed through: $remote_addr and $scheme here
-# would describe the internal loopback hop rather than the client connection.
-proxy_set_header  Host               $host;
-proxy_set_header  X-Real-IP          $remote_addr;
-proxy_set_header  X-Forwarded-For    $proxy_add_x_forwarded_for;
-proxy_set_header  X-Forwarded-Proto  $http_x_forwarded_proto;
-proxy_set_header  X-Forwarded-Port   $http_x_forwarded_port;
+# Anything not set here is passed through unchanged; do not rebuild forwarded
+# headers from $remote_addr or $scheme, those describe the loopback hop.
+proxy_set_header  Host             $host;
+proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;
 proxy_pass        http://127.0.0.1:9726;

--- a/docker/nginx/snippets/proxy-to-backend.conf
+++ b/docker/nginx/snippets/proxy-to-backend.conf
@@ -1,10 +1,5 @@
-# Forward to the loopback application backend, which is the database.gewis.nl
-# server block (it also listens on 127.0.0.1:9726 and is the only/default server
-# there, so it answers regardless of the Host sent here). Host is preserved so
-# the application keeps generating URLs for the requested vhost (serverUrl());
-# the caller adds a matching proxy_cookie_domain to rewrite the hard-coded
-# database.gewis.nl session cookie domain. X-Forwarded-Proto/Port are taken from
-# what Traefik set, so the extra hop does not downgrade them to plain http.
+# The edge proxy's headers are passed through: $remote_addr and $scheme here
+# would describe the internal loopback hop rather than the client connection.
 proxy_set_header  Host               $host;
 proxy_set_header  X-Real-IP          $remote_addr;
 proxy_set_header  X-Forwarded-For    $proxy_add_x_forwarded_for;

--- a/docker/nginx/snippets/security-headers.conf
+++ b/docker/nginx/snippets/security-headers.conf
@@ -1,9 +1,7 @@
-# Common security response headers. Included per-location because add_header is
-# not inherited by a location that sets any add_header of its own (e.g. the
-# Cache-Control ones), so it has to be repeated where those live. The values
-# come from the $host maps in nginx.conf.
-add_header  X-XSS-Protection         $x_css_protection;
-add_header  X-Content-Type-Options   $x_content_type_options;
-add_header  Content-Security-Policy  $content_security_policy;
-add_header  Referrer-Policy          $referrer_policy;
-add_header  Permissions-Policy       $permissions_policy;
+# add_header directives are only inherited by locations that set none of their
+# own, so include this wherever another add_header (e.g. Cache-Control) is set.
+add_header  X-XSS-Protection         "1; mode=block";
+add_header  X-Content-Type-Options   "nosniff";
+add_header  Content-Security-Policy  "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'";
+add_header  Referrer-Policy          "strict-origin-when-cross-origin";
+add_header  Permissions-Policy       'accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(self ), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-write=(self), interest-cohort=()';

--- a/docker/nginx/snippets/security-headers.conf
+++ b/docker/nginx/snippets/security-headers.conf
@@ -1,0 +1,9 @@
+# Common security response headers. Included per-location because add_header is
+# not inherited by a location that sets any add_header of its own (e.g. the
+# Cache-Control ones), so it has to be repeated where those live. The values
+# come from the $host maps in nginx.conf.
+add_header  X-XSS-Protection         $x_css_protection;
+add_header  X-Content-Type-Options   $x_content_type_options;
+add_header  Content-Security-Policy  $content_security_policy;
+add_header  Referrer-Policy          $referrer_policy;
+add_header  Permissions-Policy       $permissions_policy;

--- a/docker/nginx/snippets/securitytxt.conf
+++ b/docker/nginx/snippets/securitytxt.conf
@@ -1,5 +1,7 @@
 # security.txt is served centrally from gewis.nl.
-location /.well-known/security.txt {
-    proxy_set_header  Host  gewis.nl;
-    proxy_pass        https://gewis.nl/.well-known/security.txt;
+location = /.well-known/security.txt {
+    proxy_ssl_server_name  on;
+    proxy_ssl_name         gewis.nl;
+    proxy_set_header       Host gewis.nl;
+    proxy_pass             https://gewis.nl/.well-known/security.txt;
 }

--- a/docker/nginx/snippets/securitytxt.conf
+++ b/docker/nginx/snippets/securitytxt.conf
@@ -1,0 +1,5 @@
+# security.txt is served centrally from gewis.nl.
+location /.well-known/security.txt {
+    proxy_set_header  Host  gewis.nl;
+    proxy_pass        https://gewis.nl/.well-known/security.txt;
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The CBC is trying to move to Traefik proxying instead of nginx. Traefik does not support proxying the cookie domain (without plugins), but from the CBC we also rather have that the ABC projects manage this complex routing themselves. I helped out a bit, this should work. Do you want me see if I can test this locally? Or is possible to quickly test this in production? Reverting back should be able without any hassle.

## Related issues/external references
<!--
Format issues on GitHub as `GH-NNN`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-NNN`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
